### PR TITLE
Updated demon god stripper/bosshud, updated onahole bosshud

### DIFF
--- a/bosshud/ze_onahole_v3_3_3.txt
+++ b/bosshud/ze_onahole_v3_3_3.txt
@@ -4,7 +4,7 @@
 	"0"
 	{
 		"Type"		"breakable"
-		"HP_counter"	"Onabox"
+		"BreakableName"	"Onabox"
 		"CustomText"	"Onahole Box"
 	}
 	

--- a/bosshud/ze_onahole_v3_3_3.txt
+++ b/bosshud/ze_onahole_v3_3_3.txt
@@ -3,43 +3,50 @@
 	
 	"0"
 	{
+		"Type"		"breakable"
 		"HP_counter"	"Onabox"
 		"CustomText"	"Onahole Box"
 	}
 	
 	"1"
 	{
-		"HP_counter"	"boss_health2"
+		"Type"		"breakable"
+		"BreakableName"	"boss_health2"
 		"CustomText"	"Pingas"
 	}
 	
 	"2"
 	{
-		"HP_counter"	"Hank_hitbox"
+		"Type"		"breakable"
+		"BreakableName"	"Hank_hitbox"
 		"CustomText"	"Cosmo Hank Hill"
 	}
 
 	"3"
 	{
-		"HP_counter"	"ex2_boss2_health"
+		"Type"		"breakable"
+		"BreakableName"	"ex2_boss2_health"
 		"CustomText"	"Gris Kazoo"
 	}
 	
 	"4"
 	{
-		"HP_counter"	"boss_health2_ex"
+		"Type"		"breakable"
+		"BreakableName"	"boss_health2_ex"
 		"CustomText"	"Kazoo Pingas"
 	}
 
 	"5"
 	{
-		"HP_counter"	"boss3_hitbox_health"
+		"Type"		"breakable"
+		"BreakableName"	"boss3_hitbox_health"
 		"CustomText"	"Vagene"
 	}
 
 	"6"
 	{
-		"HP_counter"	"hank_bahamut_hp"
+		"Type"		"breakable"
+		"BreakableName"	"hank_bahamut_hp"
 		"CustomText"	"Bahamut Hank"
 	}
 

--- a/bosshud/ze_temple_of_the_demon_god_v1_2.txt
+++ b/bosshud/ze_temple_of_the_demon_god_v1_2.txt
@@ -105,4 +105,10 @@
 		"BreakableName"		"nrk3_soulscollecter_break"
 		"CustomText"		"Soul Collector"
 	}
+	"10"
+	{
+		"Type"			"breakable"
+		"BreakableName"		"nrk3_hellguardian_break"
+		"CustomText"		"Hell Guardian"
+	}
 }

--- a/bosshud/ze_temple_of_the_demon_god_v1_2.txt
+++ b/bosshud/ze_temple_of_the_demon_god_v1_2.txt
@@ -111,4 +111,11 @@
 		"BreakableName"		"nrk3_hellguardian_break"
 		"CustomText"		"Hell Guardian"
 	}
+	"11"
+	{
+		"Type"			"breakable"
+		"BreakableName"		"nrk3_crystal_breakable"
+		"CustomText"		"Crystal"
+		
+	}
 }

--- a/bosshud/ze_temple_of_the_demon_god_v1_2.txt
+++ b/bosshud/ze_temple_of_the_demon_god_v1_2.txt
@@ -103,7 +103,7 @@
 	{
 		"Type"			"breakable"
 		"BreakableName"		"nrk3_soulscollecter_break"
-		"CustomText"		"Soul Collector"
+		"CustomText"		"Souls Collector"
 	}
 	"10"
 	{

--- a/stripper/ze_temple_of_the_demon_god_v1_2.cfg
+++ b/stripper/ze_temple_of_the_demon_god_v1_2.cfg
@@ -1,3 +1,38 @@
+;fix stage 2/stage 3 final boss not taking damage from items i.e holy light
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox_multiplayer"
+		"targetname" "nrk2_hellseeker_break" 
+	}
+	delete:
+	{
+		"OnUser2" "!selfSubtract100001"
+	}
+	insert:
+	{
+		"OnUser2" "!selfRemoveHealth100001"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox_multiplayer"
+		"targetname" "nrk3_soulscollecter_break" 
+	}
+	delete:
+	{
+		"OnUser2" "!selfSubtract350001"
+	}
+	insert:
+	{
+		"OnUser2" "!selfRemoveHealth350001"
+	}
+}
+
 ;fix bad tp/hurt placement on a patch of lava that allowed you to swim above them
 modify:
 {

--- a/stripper/ze_temple_of_the_demon_god_v1_3.cfg
+++ b/stripper/ze_temple_of_the_demon_god_v1_3.cfg
@@ -1,3 +1,38 @@
+;fix stage 2/stage 3 final boss not taking damage from items i.e holy light
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox_multiplayer"
+		"targetname" "nrk2_hellseeker_break" 
+	}
+	delete:
+	{
+		"OnUser2" "!selfSubtract100001"
+	}
+	insert:
+	{
+		"OnUser2" "!selfRemoveHealth100001"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox_multiplayer"
+		"targetname" "nrk3_soulscollecter_break" 
+	}
+	delete:
+	{
+		"OnUser2" "!selfSubtract350001"
+	}
+	insert:
+	{
+		"OnUser2" "!selfRemoveHealth350001"
+	}
+}
+
 ;increase StartFire time to prevent invisible env_fires
 modify:
 {


### PR DESCRIPTION
I gave loan the updated onahole bosshud two weeks ago and it worked. Today it broke again.
My guess is that Snowy overrode the updated bosshud with the old one on the GFL repository and loan probably forgot to tell him about.
I guess I just make it official here to keep the consistency.