### PR TITLE
Update mist bosshud

### DIFF
--- a/bosshud/ze_mist_q3.txt
+++ b/bosshud/ze_mist_q3.txt
@@ -11,16 +11,9 @@
 		"CustomText"		"Revived Dragon"
 	}
 	
-	"1"
-	{
-		"Type"			"breakable"
-		"BreakableName"		"pbox_dragon"
-		"CustomText"		"Dragon"
-	}
-	
 	"2"
 	{
 		"HP_counter"		"counter_dragon"
-		"CustomText"		"Segments"
+		"CustomText"		"Dragon - HP Segments"
 	}
 }

--- a/bosshud/ze_mist_q3.txt
+++ b/bosshud/ze_mist_q3.txt
@@ -1,11 +1,6 @@
 "math_counter"
 {
-	"config"
-	{
-		"MultBoss"	"1"
-	}
-
-	"0" //math_counter
+	"0"
 	{
 		"HP_counter"		"counter_eschp"
 		"CustomText"		"Revived Dragon"


### PR DESCRIPTION
- Removed Dragon bosshud, because of the way the HP is set which might confuse some players.
- Renamed "Segments" to "Dragon - HP Segments" to show the players it still belongs to the dragon.