### PR TITLE
Update ze_gris_v1_13.cfg

### DIFF
--- a/entwatch/ze_gris_v1_13.cfg
+++ b/entwatch/ze_gris_v1_13.cfg
@@ -16,7 +16,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "1"
+        "maxamount"         "3"
     }
     "1"
     {


### PR DESCRIPTION
Correctly account for additional 2 outlines added on later levels of the map.