### PR TITLE
Update ze_tesv_skyrim_v5_6.cfg

### DIFF
--- a/entwatch/ze_tesv_skyrim_v5_6.cfg
+++ b/entwatch/ze_tesv_skyrim_v5_6.cfg
@@ -216,7 +216,7 @@
 	"11"
 	{
 		"name"              "Werewolf"
-		"shortname"         ""
+		"shortname"         "ZM Werewolf"
 		"color"             "{default}"
 		"buttonclass"       ""
 		"filtername"        ""
@@ -235,7 +235,7 @@
 	"12"
 	{
 		"name"              "Troll"
-		"shortname"         ""
+		"shortname"         "ZM Troll"
 		"color"             "{default}"
 		"buttonclass"       ""
 		"filtername"        ""
@@ -254,7 +254,7 @@
 	"13"
 	{
 		"name"              "Giant"
-		"shortname"         ""
+		"shortname"         "ZM Giant"
 		"color"             "{default}"
 		"buttonclass"       ""
 		"filtername"        ""
@@ -273,7 +273,7 @@
 	"14"
 	{
 		"name"              "Dragonpriest"
-		"shortname"         ""
+		"shortname"         "ZM Dragonpriest"
 		"color"             "{default}"
 		"buttonclass"       ""
 		"filtername"        ""


### PR DESCRIPTION
Added shortnames to zombie items. Now that they show on !hud and scoreboard, they showed with blank names and above CT items on !hud, so this fixes the blank name and moves them below CT items due to alphabetical sorting.