### PR TITLE
Multiple Bhud fixes

### DIFF
--- a/bosshud/ze_evernight_a3_4.txt
+++ b/bosshud/ze_evernight_a3_4.txt
@@ -9,7 +9,7 @@
 		"HPbar_max"		"10"
 		"HPbar_default"		"10"
 		"HPbar_mode"		"1"
-		"CustomText"		"Boss"
+		"CustomText"		"Basil"
 	}
 	"1"
 	{
@@ -31,7 +31,7 @@
 		"HPbar_max"		"10"
 		"HPbar_default"		"10"
 		"HPbar_mode"		"1"
-		"CustomText"		"Basil"
+		"CustomText"		"Gradyrat"
 	}
 	"3"
 	{

--- a/bosshud/ze_ffxii_feywood_b6_1k.txt
+++ b/bosshud/ze_ffxii_feywood_b6_1k.txt
@@ -22,5 +22,16 @@
 		"HPbar_default"		""
 		"HPbar_mode"		"2"//1=OnHitMin 2=OnHitMax
 	}
+	"2"
+	{
+		"Type"			"breakable"
+		"BreakableName"		"Glass_Ball_Break"
+		"CustomText"		"Ball"
+	}
+	"3"
+	{
+		"Type"			"breakable"
+		"BreakableName"		"Boss_Cactus_Break"
+		"CustomText"		"Cactuar"
+	}
 }
-

--- a/bosshud/ze_ffxii_feywood_b6_1k.txt
+++ b/bosshud/ze_ffxii_feywood_b6_1k.txt
@@ -1,32 +1,32 @@
 "math_counter"
 {
-	"0" //math_counter
+	"0"
 	{
 		"HP_counter"		"Boss_HP_2"
 		"HPbar_counter"		"Boss_HPbar_Counter"
 		"HPinit_counter"	"Boss_HP"
-		"CustomText"		""//def: BOSS HP
-		"HPbar_min"			"1"
-		"HPbar_max"			"7"
+		"HPbar_min"		"1"
+		"HPbar_max"		"7"
 		"HPbar_default"		""
 		"HPbar_mode"		"2"//1=OnHitMin 2=OnHitMax
+		"CustomText"		"BOSS HP"
 	}
-	"1" //math_counter
+	"1"
 	{
 		"HP_counter"		"lvl5_Boss_HP_2"
 		"HPbar_counter"		"lvl5_Boss_HPbar_Counter"
 		"HPinit_counter"	"lvl5_Boss_HP"
-		"CustomText"		""//def: BOSS HP
-		"HPbar_min"			""
-		"HPbar_max"			""
+		"HPbar_min"		"1"
+		"HPbar_max"		"7"
 		"HPbar_default"		""
 		"HPbar_mode"		"2"//1=OnHitMin 2=OnHitMax
+		"CustomText"		"Zodiark"
 	}
 	"2"
 	{
 		"Type"			"breakable"
 		"BreakableName"		"Glass_Ball_Break"
-		"CustomText"		"Ball"
+		"CustomText"		"Electric Ball"
 	}
 	"3"
 	{

--- a/bosshud/ze_ffxii_ridorana_cataract_t5_3_w6.txt
+++ b/bosshud/ze_ffxii_ridorana_cataract_t5_3_w6.txt
@@ -28,21 +28,21 @@
 	"4"
 	{
 		"HP_counter"		"Fat_Nigger_Counter"
-		"CustomText"		"Cuchulainn"
+		"CustomText"		"Zalera"
 	}
 	"5"
 	{
 		"HP_counter"		"Stage_4_End_Guard_Counter"
-		"CustomText"		"Guardian"
+		"CustomText"		"Gabranth"
 	}
 	"6"
 	{
 		"HP_counter"		"Famfrit_Holy_Summon_Counter"
-		"CustomText"		"Guardian(Holy)"
+		"CustomText"		"Zargabaath"
 	}
 	"7"
 	{
 		"HP_counter"		"Famfrit_Fire_Summon_Counter"
-		"CustomText"		"Guardian(Fire)"
+		"CustomText"		"Bergan"
 	}
 }

--- a/bosshud/ze_stalkermonolit_v7gofix.txt
+++ b/bosshud/ze_stalkermonolit_v7gofix.txt
@@ -3,68 +3,57 @@
 	"config" 
 	{
 		"MultBoss"			"1"
-		"BossBeatenShowTopDamage"	"0"
 	}
 
 	"0"
 	{
-		"HP_counter"		"stage_1_gigant1" 
-		"HPbar_mode"		"1" 
+		"HP_counter"		"stage_1_gigant1"
 		"CustomText"		"Pseudogiant"
 
 	}
 	"1"
 	{
-		"HP_counter"		"stage_1_countermonolit1" 
-		"HPbar_mode"		"1" 
+		"HP_counter"		"stage_1_countermonolit1"
 		"CustomText"		"Helicopter"
 	}
 	"2"
 	{
-		"HP_counter"		"stage_1_block1" 
-		"HPbar_mode"		"1" 
+		"HP_counter"		"stage_1_block1"
 		"CustomText"		"Generator 1"
 	}
 	"3"
 	{
-		"HP_counter"		"stage_1_block2" 
-		"HPbar_mode"		"1" 
+		"HP_counter"		"stage_1_block2"
 		"CustomText"		"Generator 2"
 	}
 	"4"
 	{
-		"HP_counter"		"stage_1_block3" 
-		"HPbar_mode"		"1" 
+		"HP_counter"		"stage_1_block3"
 		"CustomText"		"Generator 3"
 	}
 	"5"
 	{
-		"HP_counter"		"stage_1_block4" 
-		"HPbar_mode"		"1" 
+		"HP_counter"		"stage_1_block4"
 		"CustomText"		"Generator 4"
 	}
 	"6"
 	{
-		"HP_counter"		"stage_1_block5" 
-		"HPbar_mode"		"1" 
+		"HP_counter"		"stage_1_block5"
 		"CustomText"		"Controller"
 	}	
 	"7"
 	{
-		"HP_counter"		"stage_2_burrercounter" 
-		"HPbar_mode"		"1" 
+		"HP_counter"		"stage_2_burrercounter"
 		"CustomText"		"Burer"
 	}	
 	"8"
 	{
-		"HP_counter"		"stage_2_burrercounter2" 
-		"HPbar_mode"		"1" 
+		"HP_counter"		"stage_2_burrercounter2"
 		"CustomText"		"Burer"
 	}
 	"9"
 	{
-		"HP_counter"		"stage_3_countercontroler1" 
-		"HPbar_mode"		"1" 
+		"HP_counter"		"stage_3_countercontroler1"
 		"CustomText"		"Controller"
 	}
 	"10"
@@ -81,13 +70,21 @@
 	"11"
 	{
 		"HP_counter"		"psevdocounter1"
-		"HPbar_mode"		"1"
 		"CustomText"		"Pseudogiant"
 	}
 	"12"
 	{
+		"HP_counter"		"counterlaser1"
+		"CustomText"		"Monolith"
+	}
+	"13"
+	{
+		"HP_counter"		"counterlaser2"
+		"CustomText"		"Monolith"
+	}
+	"14"
+	{
 		"HP_counter"		"counterlaser3"
-		"HPbar_mode"		"1"
 		"CustomText"		"Monolith"
 	}
 }


### PR DESCRIPTION
Evernight: Name changes for Level 1 and 3 bosses.

Ridorana: Name changes for Stage 4 laser boss and change some mini bosses names. Fact: In old ridorana the stage 4 miniboss before Famfirt boss was cuchulainn, in new ridorana it uses Esper Zalera.

Feywood: add Stage 3 mini boss and Cactuar to the bhud and adjust Zodiark laser boss into the bhud,

Stalkermonolit: delete a lot hpbar_min for being on the bhud, might've caused the bhud to glitch and not show any HP on the npcs or bosses and add 2 more entity that were missing in the old config made by gibbon for stage 4 laser boss.