### PR TITLE
tweak some bhuds, update entwatch and stripper

### DIFF
--- a/bosshud/ze_S_A_M_v1_7.txt
+++ b/bosshud/ze_S_A_M_v1_7.txt
@@ -9,7 +9,7 @@
 		"HPbar_max"		"9"
 		"HPbar_default"		"9"
 		"HPbar_mode"		"2"
-		"CustomText"		"Barlog"
+		"CustomText"		"Balrog"
 	}
 	"1"
 	{

--- a/bosshud/ze_infected_sewers_csgo
+++ b/bosshud/ze_infected_sewers_csgo
@@ -1,0 +1,18 @@
+"math_counter"
+{
+	"config"
+	{
+		"HitMarkerOnly"		"1"
+	}
+	
+	"0"
+	{
+		"Type"			"breakable"
+		"BreakableName"		"boss_spiderhp"
+	}
+	"1"
+	{
+		"Type"			"breakable"
+		"BreakableName"		"Noctali_Boss_Break"
+	}
+}

--- a/bosshud/ze_negative_legacy_va2.txt
+++ b/bosshud/ze_negative_legacy_va2.txt
@@ -55,4 +55,9 @@
 		"HP_counter"		"heavy_b_20"
 		"CustomText"		"Boss B 1/5"
 	}
+	"10"
+	{
+		"HP_counter"		"agony_counter_a"
+		"CustomText"		"Agony"
+	}
 }

--- a/bosshud/ze_sky_athletic_adv_v9_12.txt
+++ b/bosshud/ze_sky_athletic_adv_v9_12.txt
@@ -60,4 +60,9 @@
 		"HPbar_mode"		"1"
 		"CustomText"		"True Crasher"
 	}
+	"10"
+	{
+		"HP_counter"		"ex2_boss_angry_hp"
+		"CustomText"		"Angry Father Cloud"
+	}
 }

--- a/bosshud/ze_sky_athletic_adv_v9_12.txt
+++ b/bosshud/ze_sky_athletic_adv_v9_12.txt
@@ -33,17 +33,17 @@
 	"5"
 	{
 		"HP_counter"		"ex2_boss_real_hp"
-		"CustomText"		"Father Cloud"
+		"CustomText"		"Father Cloud (Rage)"
 	}
 	"6"
 	{
 		"HP_counter"		"final_boss_ittanstop_counter"
-		"CustomText"		"Crasher Phase 2"
+		"CustomText"		"Crasher Phase 1"
 	}
 	"7"
 	{
 		"HP_counter"		"final_boss_truehp_counter"
-		"CustomText"		"Crasher Phase 1"
+		"CustomText"		"Crasher Phase 2"
 	}
 	"8"
 	{
@@ -63,6 +63,6 @@
 	"10"
 	{
 		"HP_counter"		"ex2_boss_angry_hp"
-		"CustomText"		"Angry Father Cloud"
+		"CustomText"		"Father Cloud"
 	}
 }

--- a/entwatch/ze_chaos_v7_4f_override.cfg
+++ b/entwatch/ze_chaos_v7_4f_override.cfg
@@ -3,7 +3,7 @@
 		"0"
 	{
 		"name"			"White Knight"
-		"shortname"		"White Knight"
+		"shortname"		"Knight"
 		"color"			"{default}"
 		"buttonclass"		""
 		"filtername"  		""
@@ -23,7 +23,7 @@
 		"1"
 	{
 		"name"			"Fire Ball"
-		"shortname"		"Fire Ball"
+		"shortname"		"Fire"
 		"color"			"{red}"
 		"buttonclass"		"func_button"
 		"filtername"  		"fire_user"
@@ -61,7 +61,7 @@
 		"3"
 	{
 		"name"			"Snowstorm Ball"
-		"shortname"		"Snowstorm Ball"
+		"shortname"		"Snowstorm"
 		"color"			"{lightblue}"
 		"buttonclass"		"func_button"
 		"filtername"  		"snowstorm_user"
@@ -79,7 +79,7 @@
 	}
 		"4"
 	{
-		"name"			"Health Ball"
+		"name"			"ZM Health Ball"
 		"shortname"		"ZM Health"
 		"color"			"{default}"
 		"buttonclass"		"func_button"
@@ -98,7 +98,7 @@
 	}
 		"5"
 	{
-		"name"			"Blackhole Ball"
+		"name"			"ZM Blackhole Ball"
 		"shortname"		"ZM Gravity"
 		"color"			"{purple}"
 		"buttonclass"		"func_button"
@@ -117,7 +117,7 @@
 	}
 		"6"
 	{
-		"name"			"Alacrity Ball"
+		"name"			"ZM Alacrity Ball"
 		"shortname"		"ZM Alacrity"
 		"color"			"{red}"
 		"buttonclass"		"func_button"
@@ -137,7 +137,7 @@
 		"7"
 	{
 		"name"			"Lightning Ball"
-		"shortname"		"Lightning Ball"
+		"shortname"		"Lightning"
 		"color"			"{lime}"
 		"buttonclass"		"func_button"
 		"filtername"  		"lightning_user"
@@ -174,7 +174,7 @@
 	}
 		"9"
 	{
-		"name"			"Poison Ball"
+		"name"			"ZM Poison Ball"
 		"shortname"		"ZM Poison"
 		"color"			"{green}"
 		"buttonclass"		"func_button"

--- a/entwatch/ze_l0v0l_v1_4_csgo2.cfg
+++ b/entwatch/ze_l0v0l_v1_4_csgo2.cfg
@@ -257,7 +257,7 @@
 		"forcedrop"         "true"
 		"chat"              "true"
 		"hud"               "true"
-		"hammerid"          "1355730"
+		"hammerid"          "1355119"
 		"mode"              "2"
 		"maxuses"           "0"
 		"cooldown"          "75"

--- a/entwatch/ze_tyranny2_v1_csgo2.cfg
+++ b/entwatch/ze_tyranny2_v1_csgo2.cfg
@@ -4,7 +4,7 @@
 	{	
 		"name"              "Meteor"
 		"shortname"         "Meteor"
-		"color"             "{lightgreen}"
+		"color"             "{red}"
 		"buttonclass"       "func_button"
 		"filtername"        "player_meteor"
 		"hasfiltername"     "true"
@@ -42,7 +42,7 @@
 	{		
 		"name"              "Tornado"
 		"shortname"         "Tornado"
-		"color"             "{lightblue}"
+		"color"             "{grey}"
 		"buttonclass"       "func_button"
 		"filtername"        "player_tornado"
 		"hasfiltername"     "true"
@@ -61,7 +61,7 @@
 	{
 		"name"              "Venom"
 		"shortname"         "Venom"
-		"color"             "{lightblue}"
+		"color"             "{lightgreen}"
 		"buttonclass"       "func_button"
 		"filtername"        "player_venom"
 		"hasfiltername"     "true"
@@ -80,7 +80,7 @@
 	{
 		"name"              "Ammo"
 		"shortname"         "Ammo"
-		"color"             "{lightblue}"
+		"color"             "{lime}"
 		"buttonclass"       "func_button"
 		"filtername"        "player_ammo"
 		"hasfiltername"     "true"
@@ -99,7 +99,7 @@
 	{		
 		"name"              "Shade"
 		"shortname"         "Shade"
-		"color"             "{lightblue}"
+		"color"             "{pink}"
 		"buttonclass"       "func_button"
 		"filtername"        "player_shade"
 		"hasfiltername"     "true"
@@ -118,7 +118,7 @@
 	{	
 		"name"              "Sacred"
 		"shortname"         "Sacred"
-		"color"             "{lightblue}"
+		"color"             "{pink}"
 		"buttonclass"       "func_button"
 		"filtername"        "player_sacred"
 		"hasfiltername"     "true"
@@ -137,7 +137,7 @@
 	{		
 		"name"              "Heal"
 		"shortname"         "Heal"
-		"color"             "{lightblue}"
+		"color"             "{default}"
 		"buttonclass"       "func_button"
 		"filtername"        "player_heal"
 		"hasfiltername"     "true"
@@ -156,7 +156,7 @@
 	{	
 		"name"              "Ballista"
 		"shortname"         "Ballista"
-		"color"             "{lightblue}"
+		"color"             "{grey}"
 		"buttonclass"       "func_button"
 		"filtername"        "player_ballista"
 		"hasfiltername"     "true"
@@ -175,7 +175,7 @@
 	{		
 		"name"              "Bible"
 		"shortname"         "Bible"
-		"color"             "{lightblue}"
+		"color"             "{default}"
 		"buttonclass"       "func_button"
 		"filtername"        "player_bible"
 		"hasfiltername"     "true"
@@ -192,9 +192,9 @@
 	}
 	"10"
 	{
-		"name"              "[ZM]Heal"
+		"name"              "ZM Heal"
 		"shortname"         "ZM Heal"
-		"color"             "{lightblue}"
+		"color"             "{red}"
 		"buttonclass"       "func_button"
 		"filtername"        "player_bloodorb"
 		"hasfiltername"     "true"
@@ -211,9 +211,9 @@
 	}
 	"11"
 	{	
-		"name"              "[ZM]Barrel"
+		"name"              "ZM Barrel"
 		"shortname"         "ZM Barrel"
-		"color"             "{lightblue}"
+		"color"             "{red}"
 		"buttonclass"       "func_button"
 		"filtername"        "player_barrel"
 		"hasfiltername"     "true"
@@ -230,7 +230,7 @@
 	}
 	"12"
 	{
-		"name"              "[ZM]Necro"
+		"name"              "ZM Necro"
 		"shortname"         "ZM Necro"
 		"color"             "{lightblue}"
 		"buttonclass"       "func_button"
@@ -249,9 +249,9 @@
 	}
 	"13"
 	{		
-		"name"              "[ZM]Guillotine"
-		"shortname"         "[ZM]Guillotine"
-		"color"             "{lightblue}"
+		"name"              "ZM Guillotine"
+		"shortname"         "ZM Guillotine"
+		"color"             "{grey}"
 		"buttonclass"       "func_button"
 		"filtername"        "player_guillotine"
 		"hasfiltername"     "true"
@@ -268,9 +268,9 @@
 	}
 	"14"
 	{
-		"name"              "[ZM]Abyss"
+		"name"              "ZM Abyss"
 		"shortname"         "ZM Abyss"
-		"color"             "{lightblue}"
+		"color"             "{purple}"
 		"buttonclass"       "func_button"
 		"filtername"        "player_abyss"
 		"hasfiltername"     "true"

--- a/stripper/ze_avalanche_reboot_beta7_p2.cfg
+++ b/stripper/ze_avalanche_reboot_beta7_p2.cfg
@@ -32,7 +32,7 @@ modify:
 	match:
 	{
 		"classname" "game_player_equip"
-		"spawnflags" "0"
+		"origin" "-5915 -10112 -1249"
 	}
 	replace:
 	{

--- a/stripper/ze_avalanche_reboot_beta7_p2.cfg
+++ b/stripper/ze_avalanche_reboot_beta7_p2.cfg
@@ -25,3 +25,21 @@ modify:
 		"damagetype" "0"
 	}
 }
+
+;fix no kevlar on new round
+modify:
+{
+	match:
+	{
+		"classname" "game_player_equip"
+		"spawnflags" "0"
+	}
+	replace:
+	{
+		"spawnflags" "2"
+	}
+	insert:
+	{
+		"item_assaultsuit" "1"
+	}
+}

--- a/stripper/ze_l0v0l_v1_4_csgo2.cfg
+++ b/stripper/ze_l0v0l_v1_4_csgo2.cfg
@@ -44,7 +44,7 @@ modify:
 	insert:
 	{
 		"OnStartTouch" "!activatorAddOutputhealth 99999999990-1"
-		"OnStartTouch" "MapBrush,RunScriptCode,KillAllT();11
+		"OnStartTouch" "MapBrush,RunScriptCode,KillAllT();11"
 	}
 }
 

--- a/stripper/ze_l0v0l_v1_4_csgo2.cfg
+++ b/stripper/ze_l0v0l_v1_4_csgo2.cfg
@@ -39,7 +39,7 @@ modify:
 	}
 	delete:
 	{
-		//"OnStartTouch" "Map_BrushRunScriptCodeKillAll();61"
+		"OnStartTouch" "Map_BrushRunScriptCodeKillAll();61"
 	}
 	insert:
 	{

--- a/stripper/ze_l0v0l_v1_4_csgo2.cfg
+++ b/stripper/ze_l0v0l_v1_4_csgo2.cfg
@@ -44,6 +44,7 @@ modify:
 	insert:
 	{
 		"OnStartTouch" "!activatorAddOutputhealth 99999999990-1"
+		"OnStartTouch" "MapBrush,RunScriptCode,KillAllT();11
 	}
 }
 

--- a/stripper/ze_l0v0l_v1_4_csgo2.cfg
+++ b/stripper/ze_l0v0l_v1_4_csgo2.cfg
@@ -44,7 +44,7 @@ modify:
 	insert:
 	{
 		"OnStartTouch" "!activatorAddOutputhealth 99999999990-1"
-		"OnStartTouch" "MapBrush,RunScriptCode,KillAllT();11-1"
+		"OnStartTouch" "MapBrushRunScriptCodeKillAllT();61"
 	}
 }
 

--- a/stripper/ze_l0v0l_v1_4_csgo2.cfg
+++ b/stripper/ze_l0v0l_v1_4_csgo2.cfg
@@ -29,3 +29,57 @@ modify:
 		"item_assaultsuit" "1"
 	}
 }
+
+;fix level 4 nuke from killing every single player after the Nuke King boss is dead and you get teleported
+modify:
+{
+	match:
+	{
+		"targetname" "lvl4_win"
+	}
+	delete:
+	{
+		//"OnStartTouch" "Map_BrushRunScriptCodeKillAll();61"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activatorAddOutputhealth 99999999990-1"
+	}
+}
+
+	add:
+	{
+		"model" "*505"
+		"targetname" "lvl4_winfix"
+		"StartDisabled" "1"
+		"spawnflags" "1"
+		"origin" "-4487 5370 7350.65"
+		"filtername" "filter_zombie"
+		"classname" "trigger_multiple"
+		"OnStartTouch" "!activatorAddOutputhealth 99999999990-1"
+	}	
+modify:
+	{
+	match:
+	{
+		"targetname" "endrelay4"
+		"classname" "logic_relay"
+	}
+	insert:
+	{
+		"OnTrigger" "lvl4_winfixEnable01"
+	}
+}
+
+;fix kevlar damage not been taking into account
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+	}
+	replace:
+	{
+		"damagetype" "0"
+	}
+}

--- a/stripper/ze_l0v0l_v1_4_csgo2.cfg
+++ b/stripper/ze_l0v0l_v1_4_csgo2.cfg
@@ -44,31 +44,60 @@ modify:
 	insert:
 	{
 		"OnStartTouch" "!activatorAddOutputhealth 99999999990-1"
-		"OnStartTouch" "MapBrush,RunScriptCode,KillAllT();11"
+		"OnStartTouch" "MapBrush,RunScriptCode,KillAllT();11-1"
 	}
 }
 
-	add:
-	{
-		"model" "*505"
-		"targetname" "lvl4_winfix"
-		"StartDisabled" "1"
-		"spawnflags" "1"
-		"origin" "-4487 5370 7350.65"
-		"filtername" "filter_zombie"
-		"classname" "trigger_multiple"
-		"OnStartTouch" "!activatorAddOutputhealth 99999999990-1"
-	}	
+;make electric toilet item slowdown zombies
 modify:
-	{
+{
 	match:
 	{
-		"targetname" "endrelay4"
-		"classname" "logic_relay"
+		"targetname" "elect_hurt"
 	}
 	insert:
 	{
-		"OnTrigger" "lvl4_winfixEnable01"
+		"OnStartTouch" "Map_SpeedModModifySpeed18-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.77.8-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.77.6-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.77.4-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.77.2-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.77-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.76.8-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.76.6-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.76.4-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.76.2-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.76-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.75.8-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.75.6-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.75.4-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.75.2-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.75-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.74.8-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.74.6-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.74.4-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.74.2-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.74-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.73.8-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.73.6-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.73.4-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.73.2-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.73-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.72.8-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.72.6-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.72.4-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.72.2-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.72-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.71.8-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.71.6-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.71.4-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.71.2-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.71-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.70.8-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.70.6-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.70.4-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.70.2-1"
+		"OnStartTouch" "Map_SpeedModModifySpeed0.70-1"
 	}
 }
 


### PR DESCRIPTION
what Stripper of l0v0l does: fixes a glitch with the nuke on level 4 that can occur without warning. Make bosses take Kevlar since on some bosses ex: Priest level 1 if you take damage without crouching or jumping and you take 140 damage by going to the position of the crouch or tilex laser, another ex: Queen level 4, if you have Beam and Laser attack active and you don't jump or crouch you take about 170-200 damage by standing up and not crouching.
Chaos entwatch: remove ball in the name and confusing zombie item names.
Updated negative legacy bhud for the Agony attack.
Tyranny2 entwatch: remove [] from zm entwatch and give color to both human and zm item
Sky Athletic: tweak/update names for bosses.
Avalanche Stripper: Add Kevlar on new round, Note: we do not have the map on GFL due to some bugs, if we either play the map on event or if the porter did not fix this on a new version.
S_A_M bhud: fix a typo on the stage 4 boss, it was named "Barlog" instead of "Balrog"
L0v0l fix again, entwatch: fix Fire Toilet having wrong Hammerid. 