### PR TITLE
Edits to Helms Deep and Mount Doom strippers and entwatches

### DIFF
--- a/entwatch/ze_LOTR_Helms_Deep_v5_p6.cfg
+++ b/entwatch/ze_LOTR_Helms_Deep_v5_p6.cfg
@@ -19,4 +19,23 @@
 		"cooldown"          "0"
 		"maxamount"         "1"
 	}
+	"1"
+	{
+		"name"              "Radio"
+		"shortname"         "Radio"
+		"color"             "{default}"
+		"buttonclass"       "func_button"
+		"filtername"        ""
+		"hasfiltername"     "false"
+		"blockpickup"       "false"
+		"allowtransfer"     "false"
+		"forcedrop"         "false"
+		"chat"              "true"
+		"hud"               "false"
+		"hammerid"          "1087"
+		"mode"              "0"
+		"maxuses"           "0"
+		"cooldown"          "0"
+		"maxamount"         "1"
+	}
 }

--- a/entwatch/ze_LOTR_Mount_Doom_p3.cfg
+++ b/entwatch/ze_LOTR_Mount_Doom_p3.cfg
@@ -57,4 +57,23 @@
 		"cooldown"          "0"
 		"maxamount"         "1"
 	}
+	"3"
+	{
+		"name"              "Radio"
+		"shortname"         "Radio"
+		"color"             "{default}"
+		"buttonclass"       "func_button"
+		"filtername"        ""
+		"hasfiltername"     "false"
+		"blockpickup"       "false"
+		"allowtransfer"     "false"
+		"forcedrop"         "false"
+		"chat"              "true"
+		"hud"               "false"
+		"hammerid"          "2305"
+		"mode"              "0"
+		"maxuses"           "0"
+		"cooldown"          "0"
+		"maxamount"         "1"
+	}
 }

--- a/entwatch/ze_LOTR_Mount_Doom_p3.cfg
+++ b/entwatch/ze_LOTR_Mount_Doom_p3.cfg
@@ -12,7 +12,7 @@
 		"allowtransfer"     "false"
 		"forcedrop"         "false"
 		"chat"              "true"
-		"hud"               "false"
+		"hud"               "true"
 		"hammerid"          "1385"
 		"mode"              "0"
 		"maxuses"           "0"

--- a/stripper/ze_LOTR_Helms_Deep_v5_p6.cfg
+++ b/stripper/ze_LOTR_Helms_Deep_v5_p6.cfg
@@ -1,3 +1,23 @@
+;Make it so that only the player holding the radio can stop/start the music. Requires csgo/scripts/vscripts/itemfilter.nut
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"hammerid" "1791"
+	}
+	insert:
+	{
+		"vscripts" "itemfilter.nut"
+		"OnPressed" "!self,RunScriptCode,filterHolderNoIn();,0,-1"
+		"OnUser1" "apagarencender,PickRandom,,0,-1"
+	}
+	delete:
+	{
+		"OnPressed" "apagarencenderPickRandom0-1"
+	}
+}
+
 ;Fix gate glitch
 modify:
 {

--- a/stripper/ze_LOTR_Mount_Doom_p3.cfg
+++ b/stripper/ze_LOTR_Mount_Doom_p3.cfg
@@ -1,0 +1,19 @@
+;Make it so that only the player holding the radio can stop/start the music. Requires csgo/scripts/vscripts/itemfilter.nut
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"hammerid" "1995"
+	}
+	insert:
+	{
+		"vscripts" "itemfilter.nut"
+		"OnPressed" "!self,RunScriptCode,filterHolderNoIn();,0,-1"
+		"OnUser1" "apagarencender,PickRandom,,0,-1"
+	}
+	delete:
+	{
+		"OnPressed" "apagarencenderPickRandom0-1"
+	}
+}

--- a/vscripts/itemfilter.nut
+++ b/vscripts/itemfilter.nut
@@ -1,0 +1,12 @@
+;Install as csgo/scripts/vscripts/itemfilter.nut
+;Script taken from ze_ffxii_westersand_v8zeta1_b5k
+
+;Used by the following strippers:
+;	- ze_LOTR_Helms_Deep_v5_p6
+;	- ze_LOTR_Mount_Doom_p3
+
+function filterHolderNoIn() 
+{
+	if (self.GetMoveParent().GetOwner() == activator)
+		EntFireByHandle(self, "FireUser1", "", 0.0, activator, activator)
+}


### PR DESCRIPTION
- Change mosquito on Mount Doom EW to show on hud, mirroring behavior of most zombie items.
- Add Radios to entwatches (chat only, no hud)
- Make the radios only able to be turned on/off by the holder using westersand v8's filter vscript. This change is untested on both maps (since it is late and I am tired). If could be double checked before added in case I am stupid, and it breaks the radios, that would be great.