### PR TITLE
Modify Otakuroom stripper and add Surf Danger stripper

### DIFF
--- a/stripper/ze_otakuroom_v5_6f3.cfg
+++ b/stripper/ze_otakuroom_v5_6f3.cfg
@@ -2,6 +2,7 @@
 add:
 {
 	"classname" "func_brush"
+	"targetname" "adminroom_blocker"
 	"origin" "2638 3806 -1360"
 	"angles" "90 0 0"
 	"model" "*160"
@@ -10,6 +11,7 @@ add:
 add:
 {
 	"classname" "func_brush"
+	"targetname" "adminroom_blocker"
 	"origin" "3198 3806 -1360"
 	"angles" "90 0 0"
 	"model" "*160"
@@ -18,6 +20,7 @@ add:
 add:
 {
 	"classname" "func_brush"
+	"targetname" "adminroom_blocker"
 	"origin" "2794 3650 -1360"
 	"angles" "0 0 90"
 	"model" "*160"
@@ -26,8 +29,154 @@ add:
 add:
 {
 	"classname" "func_brush"
+	"targetname" "adminroom_blocker"
 	"origin" "3050 3650 -1360"
 	"angles" "0 0 90"
 	"model" "*160"
 	"rendermode" "10"
+}
+
+;Makes it so that players cannot hurt the ending laser boss until after the ladder to it has opened up (you could kill it from spawn before)
+modify:
+{
+	match:
+	{
+		"classname" "func_breakable"
+		"targetname" "lv3_ts_hitbox"
+	}
+	delete:
+	{
+		"OnHealthChanged" "lv3_ts_hpSubtract10-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "trigger_lv3"
+		"origin" "2440 3894.5 -654"
+	}
+	insert:
+	{
+		"OnStartTouch" "lv3_ts_hitboxAddOutputOnHealthChanged lv3_ts_hp,Subtract,1,0,-110-1"
+	}
+}
+
+;Allows players to go to the admin room during ZM level (level 4) as they used to be able to with the low grav originally, so they can change the level when they beat the map
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+		"hammerid" "4685"
+	}
+	insert:
+	{
+		"OnMapSpawn" "adminroom_blocker,Enable,,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "map_relay_lvl4"
+	}
+	insert:
+	{
+		"OnTrigger" "adminroom_blocker,Disable,,1,-1""
+		"OnTrigger" "cmd,Command,sv_gravity 80,0,-1"
+		"OnTrigger" "cmd,Command,sv_gravity 800,208,-1"
+	}
+}
+
+;Hopefully fix some lag common on level 4. Originally used a trigger_hurt spamming inputs on players, since gravity changed with AddOutput is reset when a player climbs a ladder. Removes this spammy trigger and instead uses sv_gravity for level 4.
+filter:
+{
+	"classname" "trigger_hurt"
+	"hammerid" "52162"
+}
+
+;repurposes this entity to set speed on level 4, since no fall damage is on GFL by default, and it no longer needs to set client gravity each round, but an entity that isn't spammy is now needed to set speed.
+modify:
+{
+	match:
+	{
+		"hammerid" "10482"
+	}
+	replace:
+	{
+		"targetname" "zm_gravity"
+	}
+	insert:
+	{
+		"OnStartTouch" "Map_SpeedModModifySpeed3.00-1"
+	}
+	delete:
+	{
+		"OnStartTouch" "!activatorSetDamageFilternfg0-1"
+		"OnEndTouch" "!activatorSetDamageFilternfg0-1"
+		"OnStartTouch" "!activatorAddOutputgravity 10-1"
+		"OnEndTouch" "!activatorAddOutputgravity 10-1"
+	}
+}
+
+;Remove gravity spam from level 4 nuke since it is no longer needed
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "zm_nuke"
+		"hammerid" "52111"
+	}
+	delete:
+	{
+		"OnHurtPlayer" "!activatorAddOutputgravity 10-1"
+		"OnStartTouch" "!activatorAddOutputgravity 10-1"
+		"OnEndTouch" "!activatorAddOutputgravity 10-1"
+	}
+}
+
+;Have levels 1-3 starts set default gravity, since level 4 uses sv_gravity now
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "map_relay_lvl1"
+	}
+	insert:
+	{
+		"OnTrigger" "cmd,Command,sv_gravity 800,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "map_relay_lvl2"
+	}
+	insert:
+	{
+		"OnTrigger" "cmd,Command,sv_gravity 800,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "map_relay_lvl3"
+	}
+	insert:
+	{
+		"OnTrigger" "cmd,Command,sv_gravity 800,0,-1"
+	}
 }

--- a/stripper/ze_surf_danger_p2.cfg
+++ b/stripper/ze_surf_danger_p2.cfg
@@ -1,0 +1,13 @@
+;Make the door to the ending helicopter trigger stay open, so CTs cannot delay in the room without triggering, even after all the CTs outside have died. Also means a player doesn't have to suicide for the trigger now.
+modify:
+{
+	match:
+	{
+		"classname" "func_door"
+		"targetname" "controlroomdoor"
+	}
+	replace:
+	{
+		"wait" "-1"
+	}
+}


### PR DESCRIPTION
Otakuroom changes:
- Prevent level 3 laser boss from being shot and killed from the spawn of the map
- Allow access to admin room for normal players during the low grav of level 4, as players could do originally in the map
- Hopefully prevent lag on level 4, by removing spammy triggers (that were to fix gravity after a player grabs a ladder) and use sv_gravity (since it isn't undone when a ladder is grabbed) for level 4 instead of AddOutput gravity

Note that if a server other than GFL uses this otakuroom stripper, they would need a no fall damage plugin or to recreate the no_fall entity for the map, since it was repurposed for level 4 speed settings instead of its original setting of disabling fall damage and setting default gravity per client, since it was no longer needed assuming the server has a no_fall damage plugin.

Surf Danger change:
- Make it so players cannot delay at end of map in trigger room for heli by keeping the door open