### PR TITLE
Modified Multiple Stripper Configs

### DIFF
--- a/stripper/ze_Pidaras_va2.cfg
+++ b/stripper/ze_Pidaras_va2.cfg
@@ -1,3 +1,35 @@
+;Prevent the bahamut miniboss from being instant killed before it can scale up its hp for players. You can still shoot it from outside without scaling it up yourself, but at least 1 person has to scale it up before you can start killing it.
+modify:
+{
+	match:
+	{
+		"classname" "math_counter"
+		"targetname" "npc_bahamut_counter"
+	}
+	replace:
+	{
+		"startvalue" "100000"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "trig_bahamut_vie"
+	}
+	delete:
+	{
+		"OnStartTouch" "fix_hp_boss_*FireUser10-1"
+	}
+	insert:
+	{
+		"OnStartTouch" "fix_hp_boss_*FireUser10.1-1"
+		"OnStartTouch" "npc_bahamut_counter,setvalue,20,0,-1"
+	}
+}
+
 ;increase boss speed
 modify:
 {

--- a/stripper/ze_dark_souls_ptd_v0_4_csgo7.cfg
+++ b/stripper/ze_dark_souls_ptd_v0_4_csgo7.cfg
@@ -1,3 +1,45 @@
+;Stop zombies from respawning in PvP mode by adding a spawn killer after PvP cages open
+add:
+{
+	"classname" "trigger_hurt"
+	"damage" "999999"
+	"damagecap" "999999"
+	"origin" "-12032 -384 2111.5"
+	"spawnflags" "1"
+	"StartDisabled" "1"
+	"targetname" "pvp_respawn_killer"
+	"model" "*420"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "PVP_Arena_Start_Relay"
+	}
+	insert:
+	{
+		"OnTrigger" "pvp_respawn_killer,Enable,,17,-1"
+	}
+}
+
+;Make it so that PvP triggers only have a 25% chance to spawn so every other round isn't a PvP round
+add:
+{
+	"classname" "logic_case"
+	"Case01" "1"
+	"Case02" "2"
+	"Case03" "3"
+	"Case04" "4"
+	"origin" "-3352 -4624 -56"
+	"targetname" "pvp_chance"
+	"OnCase01" "BEO_TempFireUser10-1"
+	"OnCase02" "!selfFireUser10-1"
+	"OnCase03" "!selfFireUser20-1"
+	"OnCase04" "!selfFireUser30-1"
+}
+
 ;Fix delay spot (left path trigger inside Sen's Fortress).
 add:
 {
@@ -25,11 +67,16 @@ modify:
 	{
 		"classname" "logic_auto"
 	}
+	delete:
+	{
+		"OnMapSpawn" "BEO_TempFireUser15-1"
+	}
 	insert:
 	{
 		"OnMapSpawn" "the_sagi_incident_tp,AddOutput,solid 2,0.5,1"
 		"OnMapSpawn" "the_sagi_incident_tp,AddOutput,mins -354 -672 -200.1,1,1"
 		"OnMapSpawn" "the_sagi_incident_tp,AddOutput,maxs 354 672 200.1,1,1"
+		"OnMapSpawn" "pvp_chance,PickRandom,,5,-1"
 	}
 }
 
@@ -173,31 +220,6 @@ modify:
 	replace:
 	{
 		"vscripts" "dark/item_c_patched.nut"
-	}
-}
-
-;pvp mode is still broken...
-filter:
-{
-	"targetname" "BEO_Temp"
-}
-filter:
-{
-	"targetname" "BEO_Sprite"
-}
-filter:
-{
-	"targetname" "BEO_Button"
-}
-modify:
-{
-	match:
-	{
-		"classname" "logic_auto"
-	}
-	delete:
-	{
-		"OnMapSpawn" "BEO_TempFireUser15-1"
 	}
 }
 

--- a/stripper/ze_rabanastre_royal_t4.cfg
+++ b/stripper/ze_rabanastre_royal_t4.cfg
@@ -44,6 +44,6 @@ modify:
 	}
 	insert:
 	{
-		"item_assasultsuit" "1"
+		"item_assaultsuit" "1"
 	}
 }

--- a/stripper/ze_surf_dark_fantasy_v2go2.cfg
+++ b/stripper/ze_surf_dark_fantasy_v2go2.cfg
@@ -1,0 +1,84 @@
+; What it does:
+;	- Prevent zombies from getting on top of the sewer elevator until it reaches the bottom, so that they cannot knife through the top of the elevator if a human jumps in it
+;	- Make glow on levers in castle easier to see
+
+; Prevent zombies from getting on top of the sewer elevator until it reaches the bottom, so that they cannot knife through the top of the elevator if a human jumps in it
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "crick_bitching_stopper,AddOutput,solid 2,0.5,-1"
+		"OnMapSpawn" "crick_bitching_stopper,AddOutput,mins -100 -8 -70,1,-1"
+		"OnMapSpawn" "crick_bitching_stopper,AddOutput,maxs 100 8 70,1,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "lvls_sewage_trig_lift"
+	}
+	insert:
+	{
+		"OnStartTouch" "crick_bitching_stopper,Enable,,20.1,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_movelinear"
+		"targetname" "lvls_sewage_lift"
+	}
+	insert:
+	{
+		"OnFullyOpen" "crick_bitching_stopper,Disable,,0,-1"
+	}
+}
+
+add:
+{
+	"classname" "trigger_push"
+	"origin" "-474 -1607 7145"
+	"pushdir" "0 90 0"
+	"spawnflags" "4097"
+	"speed" "300"
+	"StartDisabled" "1"
+	"targetname" "crick_bitching_stopper"
+}
+
+; Make glow on levers in castle easier to see
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic_glow"
+		"targetname" "lvls_castle_level_throne"
+	}
+	replace:
+	{
+		"glowdist" "20000"
+		"glowcolor" "0 255 0"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic_glow"
+		"targetname" "lvls_castle_level_tower_mid"
+	}
+	replace:
+	{
+		"glowdist" "20000"
+		"glowcolor" "0 255 0"
+	}
+}

--- a/stripper/ze_surf_gypt_v1_3_1f.cfg
+++ b/stripper/ze_surf_gypt_v1_3_1f.cfg
@@ -1,3 +1,16 @@
+;Hopefully prevent zombies from knifing through the bottom of the elevator when it goes up
+{
+	"targetname" "woodladderblocks"
+	"classname" "func_breakable"
+	"origin" "6128 5920 -908"
+	"parentname" "pullelevator"
+	"angles" "0 0 0"
+	"model" "*47"
+	"rendermode" "10"
+	"spawnflags" "1"
+	"material" "1"
+}
+
 ;fix tp avoidance spots in upper elevator room
 modify:
 {


### PR DESCRIPTION
Rabanastre Royal:
- Fixed kevlar addition on round spawn

Surf dark fantasy:
- Prevent zombies knifing humans through top of sewer elevator by not letting them into elevator shaft until the elevator has stopped moving
- Change lever glow color and max glow distance so that players can see them easier

Pidaras:
- Prevent players from insta-killing bahamut miniboss before it can scale up to any players

Surf Gypt:
- Hopefully prevent zombies from knifing cts through the bottom of the elevator by extending the already existing blocker (that was probably attempting to fix this problem, but failed) down a bit further

Dark Souls:
- Reenable PvP round, but only with a 25% chance for triggers to spawn in for it, so it isn't spammed every other round
- Add a spawn killer in PvP arena, so zombies don't just respawn forever, making it unwinnable for humans.