### PR TITLE
Modified Multiple Files

### DIFF
--- a/entwatch/ze_farmhouse_v9f2.cfg
+++ b/entwatch/ze_farmhouse_v9f2.cfg
@@ -95,4 +95,39 @@
 		"cooldown"          "0"
 		"maxamount"         "1"
 	}
+	"5" 
+	{
+		"name"              "SUIT EBAN BLOCKER"
+		"hammerid"          "-1"
+		"maxamount"         "1"
+		"trigger"           "2665544"
+	}
+	"6" 
+	{
+		"name"              "SUIT EBAN BLOCKER"
+		"hammerid"          "-1"
+		"maxamount"         "1"
+		"trigger"           "2665547"
+	}
+	"7" 
+	{
+		"name"              "SUIT EBAN BLOCKER"
+		"hammerid"          "-1"
+		"maxamount"         "1"
+		"trigger"           "2665550"
+	}
+	"8" 
+	{
+		"name"              "SUIT EBAN BLOCKER"
+		"hammerid"          "-1"
+		"maxamount"         "1"
+		"trigger"           "2665553"
+	}
+	"9" 
+	{
+		"name"              "SUIT EBAN BLOCKER"
+		"hammerid"          "-1"
+		"maxamount"         "1"
+		"trigger"           "2665556"
+	}
 }

--- a/stripper/ze_Pidaras_va2.cfg
+++ b/stripper/ze_Pidaras_va2.cfg
@@ -1,3 +1,31 @@
+;Fix tp avoidance spot
+add:
+{
+	"classname" "trigger_teleport"
+	"origin" "3712 -2624 -1216"
+	"spawnflags" "1"
+	"CheckDestIfClearForPlayer" "0"
+	"StartDisabled" "1"
+	"UseLandmarkAngles" "1"
+	"target" "teleport_rainbowT"
+	"targetname" "resizeme"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "resizeme,Addoutput,targetname teleport_stage1_3,2,1"
+		"OnMapSpawn" "resizeme,Addoutput,solid 2,0.5,1"
+		"OnMapSpawn" "resizeme,Addoutput,mins -448 -384 -192,1,1"
+		"OnMapSpawn" "resizeme,Addoutput,maxs 448 384 192,1,1"
+	}
+}
+
 ;Prevent the bahamut miniboss from being instant killed before it can scale up its hp for players. You can still shoot it from outside without scaling it up yourself, but at least 1 person has to scale it up before you can start killing it.
 modify:
 {

--- a/stripper/ze_mojos_minigames_v1_4_1.cfg
+++ b/stripper/ze_mojos_minigames_v1_4_1.cfg
@@ -106,41 +106,41 @@ add:
 	"targetname" "lava_afk_teleport"
 }
 
-;Fix no kevlar on new round & Inconsistent HP setting of players. Kind of a dirty solution might be a better one out there, this is it for now
-;Fix by Ice (github: FrozenH2O)
+;Make it so only humans are given 140 hp on round start
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "main_fairplay"
+	}
+	insert:
+	{
+		"filtername" "HUMANS"
+	}
+}
+
+;Fix no kevlar on new round & Inconsistent HP setting of players. APPARENTLY, you can't buy kevlar nor be given it when a player is too high in the air (why, just why valve?). As such, give players kevlar after they fall from spawn, rather than the typical flag 2 for game_player_equip
 add:
 {
-    "classname" "game_player_equip"
-    "targetname" "gimmekev"
-    "spawnflags" "3"
-    "item_assaultsuit" "1"
-    "weapon_knife" "1"
+	"classname" "game_player_equip"
+	"targetname" "gimmekev"
+	"spawnflags" "1"
+	"item_assaultsuit" "1"
 	"origin" "-6560 -11708 -2883"
 }
 
 add:
 {
-    "classname" "trigger_multiple"
-    "origin" "-5120 -11264 -2712"
-    "spawnflags" "4097"
-    "StartDisabled" "1"
-    "targetname" "gibkev"
-    "filtername" "HUMANS"
-    "wait" "0"
-    "model" "*150"
-    "OnStartTouch" "gimmekev,Use,,0,-1"
-    "OnStartTouch" "!activator,SetHealth,140,0,-1"
-}
-
-modify:
-{
-    match:
-    {
-        "classname" "logic_auto"
-    }
-    insert:
-    {
-        "OnMapSpawn" "gibkev,Enable,,1,-1"
-        "OnMapSpawn" "gibkev,Disable,,2,-1"
-    }
+	"classname" "trigger_multiple"
+	"origin" "-5120 -11264 -3288"
+	"spawnflags" "4097"
+	"StartDisabled" "0"
+	"targetname" "gibkev"
+	"filtername" "HUMANS"
+	"wait" "0"
+	"model" "*150"
+	"OnStartTouch" "gimmekev,Use,,0,-1"
+	"OnStartTouch" "!activator,SetHealth,140,0,-1"
+	"OnStartTouch" "!self,Kill,,30,-1"
 }

--- a/stripper/ze_omochix_v3_2fix.cfg
+++ b/stripper/ze_omochix_v3_2fix.cfg
@@ -24,3 +24,18 @@ modify:
 		"OnMapSpawn" "map_command,Command,mp_buy_anywhere 0,20,-1"
 	}
 }
+
+;Fix afk tp not working
+modify:
+{
+	match:
+	{
+		"classname" "trigger_teleport"
+		"targetname" "afk1"
+		"origin" "896 -2560 128"
+	}
+	replace:
+	{
+		"spawnflags" "1"
+	}
+}


### PR DESCRIPTION
Mojos Minigames:
- Fixed players spawning with no kevlar when joining late by moving the kevlar trigger closer to ground and making game_player_equip only give kevlar and not strip weapons (in case players touch it again due to it being just above the water). Can't use normal game_player_equip on spawn cause Volvo won't let us give kevlar to people too high in the air (just why).

Omochix:
- Fix broken afk tp.

Pidaras:
- Block tp avoidance spot.

Farmhouse:
- Add entwatch trigger support for secret suit items.