### PR TITLE
Modified Multiple Strippers

### DIFF
--- a/stripper/ze_ffxii_ridorana_cataract_t5_3_w6.cfg
+++ b/stripper/ze_ffxii_ridorana_cataract_t5_3_w6.cfg
@@ -1,0 +1,181 @@
+;What it does:
+;	- Fix cactus spawn locations (and last cactus not spawning at all)
+;	- Make dark item kill ZM velocity when it ends so ZMs arent boosted
+;	- Let ZMs actually see the level 3 boss fight
+;	- Disable unbalanced level 3 ZM items to mimic older port (since it had far better balance)
+;	- Fix TP avoidance spot
+
+;Fix cactus spawn locations (and last cactus not spawning at all)
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "Sidequest_Cactus_Spawner"
+	}
+	replace:
+	{
+		"origin" "-5092 -772 172"
+	}
+}
+
+;Make dark item kill ZM velocity when it ends so ZMs arent boosted
+modify:
+{
+	match:
+	{
+		"targetname" "Item_Darkaga_Trigger"
+		"classname" "trigger_push"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activator,RunScriptCode,activator.SetVelocity(Vector(0,0,0));,7.95,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "Item_Darkaga_Trigger"
+		"classname" "trigger_multiple"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activator,RunScriptCode,activator.SetVelocity(Vector(0,0,0));,5.45,-1"
+	}
+}
+
+;Let ZMs actually see the level 3 boss fight
+modify:
+{
+	match:
+	{
+		"targetname" "Hashmel_ZM_Cage"
+		"classname" "func_breakable"
+	}
+	replace:
+	{
+		"rendermode" "10"
+	}
+}
+
+;Remove max level of ZM items since they are incredibly unbalanced (old PS port flat out removed all level 3 ZM items and was far more balanced than current)
+;ZM Heal - Remove KB and nade invulerability (Keeps the level 3 Heal amount, so don't replace pickup message to level 2)
+modify:
+{
+	match:
+	{
+		"targetname" "Item_Z_Heal_Level_Case"
+		"classname" "logic_case"
+	}
+	delete:
+	{
+		"OnCase04" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter::5:-10-1"
+		"OnCase04" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter:Filter_CT_Ignore:0:-10-1"
+		"OnCase03" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter::5:-10-1"
+		"OnCase03" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter:Nade_Ignore:0:-10-1"
+		"OnCase02" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter:Nade_Ignore:0:-10-1"
+		"OnCase02" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter::5:-10-1"
+	}
+}
+
+;ZM Fire Level 3 -> Level 2
+modify:
+{
+	match:
+	{
+		"targetname" "Item_Z_Fire_Level_Case"
+		"classname" "logic_case"
+	}
+	delete:
+	{
+		"OnCase04" "Map_ScriptRunScriptCodeItemTextZFire(3);0-1"
+		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(23);0-1"
+		"OnCase04" "Item_Z_Fire_Effect_lvl3AddOutputtargetname Item_Z_Fire_Effect0-1"
+		"OnCase04" "Item_Relay_Z_FireAddOutputOnTrigger Item_Z_Fire_Effect:Stop::4:-10-1"
+		"OnCase04" "Item_Relay_Z_FireAddOutputOnTrigger Item_Z_Fire_Trigger:Disable::4:-10-1"
+		"OnCase04" "Item_Z_Fire_Trigger_lvl3AddOutputtargetname Item_Z_Fire_Trigger0-1"
+	}
+	insert:
+	{
+		"OnCase04" "Map_ScriptRunScriptCodeItemTextZFire(2);0-1"
+		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(22);0-1"
+		"OnCase04" "Item_Z_Fire_Effect_lvl2AddOutputtargetname Item_Z_Fire_Effect0-1"
+		"OnCase04" "Item_Relay_Z_FireAddOutputOnTrigger Item_Z_Fire_Effect:Stop::3:-10-1"
+		"OnCase04" "Item_Relay_Z_FireAddOutputOnTrigger Item_Z_Fire_Trigger:Disable::3:-10-1"
+		"OnCase04" "Item_Z_Fire_Trigger_lvl2AddOutputtargetname Item_Z_Fire_Trigger0-1"
+	}
+}
+
+;ZM Darkaga Level 3 -> Level 2
+modify:
+{
+	match:
+	{
+		"targetname" "Item_Z_Darkaga_Level_Case"
+		"classname" "logic_case"
+	}
+	delete:
+	{
+		"OnCase04" "Map_ScriptRunScriptCodeItemTextZGravity(3);0-1"
+		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(26);0-1"
+		"OnCase04" "Item_Relay_Z_DarkagaAddOutputOnTrigger Item_Z_Darkaga_Push:Disable::3:-10-1"
+		"OnCase04" "Item_Relay_Z_DarkagaAddOutputOnTrigger Item_Z_Darkaga_Effect:Stop::3.5:-10-1"
+	}
+	insert:
+	{
+		"OnCase04" "Map_ScriptRunScriptCodeItemTextZGravity(2);0-1"
+		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(25);0-1"
+		"OnCase04" "Item_Relay_Z_DarkagaAddOutputOnTrigger Item_Z_Darkaga_Push:Disable::2:-10-1"
+		"OnCase04" "Item_Relay_Z_DarkagaAddOutputOnTrigger Item_Z_Darkaga_Effect:Stop::2.5:-10-1"
+	}
+}
+
+;ZM Warp Level 3 -> Level 2
+modify:
+{
+	match:
+	{
+		"targetname" "Item_Z_Warp_Level_Case"
+		"classname" "logic_case"
+	}
+	delete:
+	{
+		"OnCase04" "Map_ScriptRunScriptCodeItemTextZWarp(3);0-1"
+		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(29);0-1"
+		"OnCase04" "Item_Z_Warp_SpawnerAddOutputEntityTemplate Item_Z_Warp_Temp_lvl30-1"
+	}
+	insert:
+	{
+		"OnCase04" "Map_ScriptRunScriptCodeItemTextZWarp(2);0-1"
+		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(28);0-1"
+		"OnCase04" "Item_Z_Warp_SpawnerAddOutputEntityTemplate Item_Z_Warp_Temp_lvl20-1"
+	}
+}
+
+;Fix TP avoidance spot
+modify:
+{
+	match:
+	{
+		"targetname" "Stage_24_TP_7"
+		"classname" "trigger_teleport"
+	}
+	replace:
+	{
+		"origin" "-5912 8560 3516"
+	}
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"model" "*258"
+	"origin" "-5320 8560 3516"
+	"spawnflags" "1"
+	"StartDisabled" "1"
+	"target" "Stage_24_TD_7"
+	"targetname" "Stage_24_TP_7"
+	"UseLandmarkAngles" "1"
+}

--- a/stripper/ze_m0w0m_csgo1.cfg
+++ b/stripper/ze_m0w0m_csgo1.cfg
@@ -1,3 +1,18 @@
+;Fix TP Avoidance Spot
+add:
+{
+	"origin" "-3018 1222 -8506.5"
+	"angles" "0 0 0"
+	"model" "*239"
+	"UseLandmarkAngles" "1"
+	"target" "tele7_1"
+	"targetname" "afktele21"
+	"StartDisabled" "1"
+	"spawnflags" "1"
+	"CheckDestIfClearForPlayer" "0"
+	"classname" "trigger_teleport"
+}
+
 ;A missing TP Angle fix
 modify:
 {

--- a/stripper/ze_touhou_gensokyo_o4.cfg
+++ b/stripper/ze_touhou_gensokyo_o4.cfg
@@ -1,3 +1,31 @@
+;Prevent a strafe jump around an invis wall in boss arena
+add:
+{
+	"origin" "-11891 -5881.5 4622"
+	"angles" "0 0 0"
+	"model" "*4"
+	"UseLandmarkAngles" "1"
+	"target" "bosstar"
+	"StartDisabled" "0"
+	"spawnflags" "4097"
+	"CheckDestIfClearForPlayer" "0"
+	"classname" "trigger_teleport"
+}
+
+;Make ZMs in Boss arena at end get TPed with other ZMs rather than avoiding all TPs
+entity
+{
+	"UseLandmarkAngles" "1"
+	"targetname" "bossteloutall"
+	"target" "bolibackdes2"
+	"StartDisabled" "1"
+	"spawnflags" "4097"
+	"origin" "-11841.5 -6435.5 4689"
+	"model" "*125"
+	"CheckDestIfClearForPlayer" "0"
+	"classname" "trigger_teleport"
+}
+
 ;Make getting a custom CT model reset player color (doesnt apply to mapper's custom models)
 modify:
 {

--- a/stripper/ze_touhou_gensokyo_o4.cfg
+++ b/stripper/ze_touhou_gensokyo_o4.cfg
@@ -13,7 +13,7 @@ add:
 }
 
 ;Make ZMs in Boss arena at end get TPed with other ZMs rather than avoiding all TPs
-entity
+add:
 {
 	"UseLandmarkAngles" "1"
 	"targetname" "bossteloutall"
@@ -23,6 +23,7 @@ entity
 	"origin" "-11841.5 -6435.5 4689"
 	"model" "*125"
 	"CheckDestIfClearForPlayer" "0"
+	"filtername" "zombie"
 	"classname" "trigger_teleport"
 }
 


### PR DESCRIPTION
Touhou Gensokyo:
- Prevent a strafe jump around an invis wall in boss arena
- Make ZMs in Boss arena at end get TPed with other ZMs rather than avoiding all TPs

M0W0M:
- Fix TP Avoidance Spot

Ridorana Cataract:
- Fix cactus spawn locations (point_template was offset, so last cactus location spawned inside a wall and couldn't be gotten)
- Make darkaga human item kill ZM velocity when it ends so ZMs aren't boosted when it ends
- Let ZMs actually see the level 3 boss fight
- Make ZM item levels mimic older port (since it had far better balance)
- Fix TP avoidance spot in level 2/4 boss cages