### PR TITLE
Updated santa stripper & entwatch

### DIFF
--- a/entwatch/ze_santassination_v3.cfg
+++ b/entwatch/ze_santassination_v3.cfg
@@ -33,8 +33,8 @@
         "chat"              		"true"
         "hud"               		"true"
         "hammerid"          	"1983722"
-        "mode"              	"1"
-        "maxuses"           	"0"
+        "mode"              	"3"
+        "maxuses"           	"1"
         "cooldown"          	"0"
         "maxamount"         	"8"
     }

--- a/stripper/ze_santassination_v3.cfg
+++ b/stripper/ze_santassination_v3.cfg
@@ -1,0 +1,35 @@
+;=====================================================================================>
+;	REPLACE ITEM TARGETNAME FILTER WITH SCRIPT FILTERING
+;	Edit: Fixed the button parenting for the Shitbox Heal so entWatch can track the item properly.
+;------------------------------------------------------------------------------------->
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "item_button_5"
+	}
+	delete:
+	{
+		"OnPressed" "item_filter_5TestActivator0-1"
+	}
+	insert:
+	{
+		"spawnflags" "17409"
+		"OnPressed" "santa_v3_fixes,RunScriptCode,CheckItemFilter(),0,-1"
+		"OnUser2" "santa_v3_fixes,RunScriptCode,SetItemFilter(),0,-1"
+		"OnUser1" "item_hurt_5,Enable,,0,-1"
+		"OnUser1" "item_particle_5,Stop,,0,-1"
+		"OnUser1" "item_s_5,FireUser1,,0,-1"
+		"OnUser1" "item_particle_5,Start,,0.02,-1"
+		"OnUser1" "item_s_5,FireUser4,,5.00,1"
+		"OnUser1" "item_visual_5,FireUser3,,4.95,1"
+		"OnUser1" "item_visual_5,FireUser4,,5.00,1"
+		"OnUser1" "item_filter_5,Kill,,5.00,1"
+	}
+	replace:
+	{
+		"parentname" "item_holder_5"
+	}
+}


### PR DESCRIPTION
Stripper:

- Fixed parenting of the "Shitbox Heal's" button so entWatch can properly track the item, though, only for this item for now
  unless there is a demand to add proper cooldown display to the other items as well.
- I highly recommend merging this stripper with the existing config from the server.

Entwatch:

- Changing 'Shitbox Heal' mode from 1 (= Spam protection only) to 3 (= Limited uses only) so players can see which heal item 
  has already been used and who used it (chat notification).

