### PR TITLE
Modified Multiple Files

### DIFF
--- a/entwatch/ze_diddle_v3.cfg
+++ b/entwatch/ze_diddle_v3.cfg
@@ -35,7 +35,7 @@
 		"hammerid"				"1010403" 
 		"mode"					"2"
 		"maxuses"				"0"
-		"cooldown"				"85"
+		"cooldown"				"130"
 		"maxamount"				"4"
 	}
 	"2"

--- a/entwatch/ze_paper_escaper_p7.cfg
+++ b/entwatch/ze_paper_escaper_p7.cfg
@@ -197,7 +197,7 @@
 		"shortname"         "CoolR"
 		"color"             "{default}"
 		"buttonclass"       "func_button"
-		"filtername"        "coolr"
+		"filtername"        "coolrguy"
 		"hasfiltername"     "true"
 		"blockpickup"       "false"
 		"allowtransfer"     "true"
@@ -205,12 +205,11 @@
 		"chat"              "true"
 		"hud"               "true"
 		"hammerid"          "695670"
-		"mode"              "1"
+		"mode"              "2"
 		"maxuses"           "0"
 		"cooldown"          "75"
 		"maxamount"         "1"
 	}
-	
 	"11"
 	{
 		"name"              "Speed Weapon"

--- a/stripper/ze_ffxii_feywood_b6_3k.cfg
+++ b/stripper/ze_ffxii_feywood_b6_3k.cfg
@@ -1,0 +1,211 @@
+;logic_auto changes
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+		"hammerid" "1153"
+	}
+	insert:
+	{
+		"OnNewGame" "weapon_meleeKill20-1"
+		"OnNewGame" "weapon_taggrenadeKill21-1"
+		"OnNewGame" "lvl3_finalpushAddOutputsolid 20.5-1"
+		"OnNewGame" "lvl3_finalpushAddOutputmins -200 -8 -2561-1"
+		"OnNewGame" "lvl3_finalpushAddOutputmaxs 200 8 2561-1"
+		"OnNewGame" "lvl3_Boss_Push1AddOutputsolid 20.5-1"
+		"OnNewGame" "lvl3_Boss_Push1AddOutputmins -16 -840 -1281-1"
+		"OnNewGame" "lvl3_Boss_Push1AddOutputmaxs 16 840 1281-1"
+		"OnNewGame" "lvl3_Boss_HP_Add_BxzlAddOutputsolid 20.5-1"
+		"OnNewGame" "lvl3_Boss_HP_Add_BxzlAddOutputmins -8 -840 -1281-1"
+		"OnNewGame" "lvl3_Boss_HP_Add_BxzlAddOutputmaxs 8 840 1281-1"
+		"OnNewGame" "lv4_BossCage_Teleport1AddOutputsolid 20.5-1"
+		"OnNewGame" "lv4_BossCage_Teleport1AddOutputmins -77 -77 -681-1"
+		"OnNewGame" "lv4_BossCage_Teleport1AddOutputmaxs 77 77 681-1"
+		"OnNewGame" "lv4_BossCage_Teleport2AddOutputsolid 20.5-1"
+		"OnNewGame" "lv4_BossCage_Teleport2AddOutputmins -77 -77 -681-1"
+		"OnNewGame" "lv4_BossCage_Teleport2AddOutputmaxs 77 77 681-1"
+		"OnNewGame" "lv4_RotatingAxe_Teleport1AddOutputsolid 20.5-1"
+		"OnNewGame" "lv4_RotatingAxe_Teleport1AddOutputmins -200 -8 -2561-1"
+		"OnNewGame" "lv4_RotatingAxe_Teleport1AddOutputmaxs 200 8 2561-1"
+		"OnNewGame" "lv4_RotatingAxe_Teleport2AddOutputsolid 20.5-1"
+		"OnNewGame" "lv4_RotatingAxe_Teleport2AddOutputmins -200 -8 -2561-1"
+		"OnNewGame" "lv4_RotatingAxe_Teleport2AddOutputmaxs 200 8 2561-1"
+	}
+}
+
+;add lvl3 dragon hp detect
+filter:
+{
+		"targetname" "lvl3_Boss_HP_Add"
+		"classname" "trigger_multiple"
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "lvl3_Boss_Push"
+		"classname" "trigger_push"
+	}
+	delete:
+	{
+		"OnStartTouch" "lvl3_Boss_HP_AddFireUser201"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "lvl3_Boss_Killed"
+		"classname" "logic_relay"
+	}
+	insert:
+	{
+		"OnTrigger" "lvl3_Boss_HP_Add_BxzlFireUser10-1"
+		"OnTrigger" "lvl3_Boss_PushFireUser10-1"
+	}
+}
+
+add:
+{
+	"targetname" "lvl3_Boss_Push1"
+	"StartDisabled" "0"
+	"speed" "350"
+	"spawnflags" "1"
+	"pushdir" "0 0 0"
+	"origin" "2800 5176 3344"
+	"filtername" "Humans_Filter"
+	"alternateticksfix" "0"
+	"classname" "trigger_push"
+	connections
+	{
+		"OnStartTouch" "lvl3_Boss_HP_AddEnable01"
+		"OnStartTouch" "Boss_HPbar_CounterEnable01"
+		"OnStartTouch" "Boss_HP_2Enable01"
+		"OnStartTouch" "Boss_HPEnable01"
+	}
+}
+
+add:
+{
+	"targetname" "lvl3_Boss_HP_Add_Bxzl"
+	"StartDisabled" "0"
+	"spawnflags" "1"
+	"origin" "2804 5176 3344"
+	"nodmgforce" "0"
+	"filtername" "Humans_Filter"
+	"damagetype" "0"
+	"damagemodel" "0"
+	"damagecap" "20"
+	"damage" "-2"
+	"classname" "trigger_hurt"
+	connections
+	{
+		"OnStartTouch" "Boss_HPAdd220-1"
+		"OnUser1" "!selfDisable0-1"
+	}
+}
+
+;ADD Another push at the end boss in level 3
+add:
+{
+	"targetname" "lvl3_finalpush"
+	"StartDisabled" "1"
+	"speed" "350"
+	"spawnflags" "1"
+	"pushdir" "0 270 0"
+	"origin" "10641 6390 2673"
+	"filtername" "Humans_Filter"
+	"FallingSpeedThreshold" "-150"
+	"alternateticksfix" "0"
+	"classname" "trigger_push"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "lvl3_Boss_Killed"
+	}
+	insert:
+	{
+		"OnTrigger" "lvl3_finalpushEnable0-1"
+	}
+}
+
+;fix teleport bug at stage 4
+add:
+{
+	"UseLandmarkAngles" "1"
+	"targetname" "lv4_BossCage_Teleport1"
+	"target" "lvl4_Cage"
+	"StartDisabled" "1"
+	"spawnflags" "1"
+	"origin" "6581 -52 3949"
+	"classname" "trigger_teleport"
+}
+
+add:
+{
+	"UseLandmarkAngles" "1"
+	"targetname" "lv4_BossCage_Teleport2"
+	"target" "lvl4_Cage"
+	"StartDisabled" "1"
+	"spawnflags" "1"
+	"origin" "6581 832 3949"
+	"classname" "trigger_teleport"
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "Chuchulainn_Start_Relay"
+		"classname" "logic_relay"
+	}
+	insert:
+	{
+		"OnTrigger" "lv4_BossCage_Teleport*Enable13-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "Chuchulainn_Killed_Relay"
+		"classname" "logic_relay"
+	}
+	insert:
+	{
+		"OnTrigger" "lv4_BossCage_Teleport*Disable0-1"
+	}
+}
+
+;add roating axe teleport for bugged zombie
+add:
+{
+	"UseLandmarkAngles" "1"
+	"targetname" "lv4_RotatingAxe_Teleport1"
+	"target" "Map_Tp_2"
+	"StartDisabled" "0"
+	"spawnflags" "1"
+	"origin" "10045 1420 3450.78"
+	"filtername" "Zombies_Filter"
+	"classname" "trigger_teleport"
+}
+
+add:
+{
+	"UseLandmarkAngles" "1"
+	"targetname" "lv4_RotatingAxe_Teleport2"
+	"target" "Map_Tp_2"
+	"StartDisabled" "0"
+	"spawnflags" "1"
+	"origin" "9382 1420 3450.78"
+	"filtername" "Zombies_Filter"
+	"classname" "trigger_teleport"
+}

--- a/stripper/ze_ffxii_feywood_b6_3k.cfg
+++ b/stripper/ze_ffxii_feywood_b6_3k.cfg
@@ -8,8 +8,6 @@ modify:
 	}
 	insert:
 	{
-		"OnNewGame" "weapon_meleeKill20-1"
-		"OnNewGame" "weapon_taggrenadeKill21-1"
 		"OnNewGame" "lvl3_finalpushAddOutputsolid 20.5-1"
 		"OnNewGame" "lvl3_finalpushAddOutputmins -200 -8 -2561-1"
 		"OnNewGame" "lvl3_finalpushAddOutputmaxs 200 8 2561-1"

--- a/stripper/ze_ffxii_feywood_b6_3k.cfg
+++ b/stripper/ze_ffxii_feywood_b6_3k.cfg
@@ -79,13 +79,10 @@ add:
 	"filtername" "Humans_Filter"
 	"alternateticksfix" "0"
 	"classname" "trigger_push"
-	connections
-	{
-		"OnStartTouch" "lvl3_Boss_HP_AddEnable01"
-		"OnStartTouch" "Boss_HPbar_CounterEnable01"
-		"OnStartTouch" "Boss_HP_2Enable01"
-		"OnStartTouch" "Boss_HPEnable01"
-	}
+	"OnStartTouch" "lvl3_Boss_HP_AddEnable01"
+	"OnStartTouch" "Boss_HPbar_CounterEnable01"
+	"OnStartTouch" "Boss_HP_2Enable01"
+	"OnStartTouch" "Boss_HPEnable01"
 }
 
 add:
@@ -101,11 +98,8 @@ add:
 	"damagecap" "20"
 	"damage" "-2"
 	"classname" "trigger_hurt"
-	connections
-	{
-		"OnStartTouch" "Boss_HPAdd220-1"
-		"OnUser1" "!selfDisable0-1"
-	}
+	"OnStartTouch" "Boss_HPAdd220-1"
+	"OnUser1" "!selfDisable0-1"
 }
 
 ;ADD Another push at the end boss in level 3

--- a/stripper/ze_paper_escaper_p7.cfg
+++ b/stripper/ze_paper_escaper_p7.cfg
@@ -1,0 +1,13 @@
+;Parent the button directly to the item's pistols so entwatch can track it correctly
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "CoolrButt"
+	}
+	replace:
+	{
+		"parentname" "CoolrGun"
+	}
+}

--- a/stripper/ze_touhou_gensokyo_o4.cfg
+++ b/stripper/ze_touhou_gensokyo_o4.cfg
@@ -156,6 +156,59 @@ filter:
 	"targetname" "logic_eventlistener_player_connect"
 }
 
+;Fix tp avoidance in grass area after 1st tp. (I KNOW THIS FIX IS SCUFFED PUTTING 4 TRIGGERS ON TOP OF EACH OTHER, BUT THE TRIGGER WONT FUCKING RESIZE)
+modify:
+{
+	match:
+	{
+		"classname" "trigger_teleport"
+		"targetname" "hmgtel"
+	}
+	replace:
+	{
+		"origin" "-8571.52 -1653.5 -541.22"
+	}
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"CheckDestIfClearForPlayer" "0"
+	"origin" "-8571.52 -1520.5 -541.22"
+	"model" "*199"
+	"spawnflags" "4097"
+	"StartDisabled" "1"
+	"target" "hmgdes2"
+	"targetname" "hmgtel"
+	"UseLandmarkAngles" "1"
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"CheckDestIfClearForPlayer" "0"
+	"origin" "-8371.52 -1520.5 -541.22"
+	"model" "*199"
+	"spawnflags" "4097"
+	"StartDisabled" "1"
+	"target" "hmgdes2"
+	"targetname" "hmgtel"
+	"UseLandmarkAngles" "1"
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"CheckDestIfClearForPlayer" "0"
+	"origin" "-8371.52 -1653.5 -541.22"
+	"model" "*199"
+	"spawnflags" "4097"
+	"StartDisabled" "1"
+	"target" "hmgdes2"
+	"targetname" "hmgtel"
+	"UseLandmarkAngles" "1"
+}
+
 ;Remove zm skins due to their small size and similarity to the human ones
 modify:
 {


### PR DESCRIPTION
Diddle:
	- EW: Fix Push cd timing to line up with the stripper change

Touhou Gensokyo:
	- Block a tp avoidance spot after 1st tp.

Paper Escaper:
	- Change CoolR button parenting to be directly to the item's pistols so entwatch can track it
	- EW: Add cooldown support to CoolR item and fix an incorrect filter's name on the item

Feywood:
	- Make the level 3 dragon detect hp correctly
	- Adds a push at the end of the level 3 dragon fight
	- Fixes a teleport bug at level 4
	- Adds a rotating axe teleport for bugged zombie on level 4

The feywood stripper is taken from 93x's strippers, so I am assuming it works (can't test hp scaling really in singleplayer to confirm the big bug on the map). Just in case, it should get another map test on level 3 in specific to make sure the fix for the boss actually works before adding it.