### PR TITLE
Fixup Tenkinoko Welkin Configs

### DIFF
--- a/entwatch/ze_tenkinoko_welkin_v1_4.cfg
+++ b/entwatch/ze_tenkinoko_welkin_v1_4.cfg
@@ -102,7 +102,7 @@
 	"5"
 	{
 		"name"              "Sunny Doll"
-		"shortname"         "Heal"
+		"shortname"         "Doll"
 		"color"             "{default}"
 		"buttonclass"       "func_button"
 		"filtername"        "Player_SunnyDoll_user"

--- a/stripper/ze_tenkinoko_welkin_v1_4.cfg
+++ b/stripper/ze_tenkinoko_welkin_v1_4.cfg
@@ -1,15 +1,15 @@
 ;fix Frozentomb
 modify:
 {
-    match:
-    {
-        "targetname" "item_FrozenTomb_onhit_temp"
-        "classname" "point_template"
-    }
-    replace:
-    {
-        "spawnflags" "2"
-    }
+	match:
+	{
+		"targetname" "item_FrozenTomb_onhit_temp"
+		"classname" "point_template"
+	}
+	replace:
+	{
+		"spawnflags" "2"
+	}
 }
 
 ;Make item buttons less frustrating to press
@@ -28,26 +28,26 @@ modify:
 ;OnUser inputs are not affected by a relay being enabled or not, so thunderbolt could kill boss before it spawns. Instead add the OnUser interaction when the trigger is enabled
 modify:
 {
-    match:
-    {
-        "targetname" "item_boss_heal_relay"
-        "classname" "logic_relay"
-    }
-    delete:
-    {
-        "OnUser1" "boss_healthSubtract15000-1"
-    }
+	match:
+	{
+		"targetname" "item_boss_heal_relay"
+		"classname" "logic_relay"
+	}
+	delete:
+	{
+		"OnUser1" "boss_healthSubtract15000-1"
+	}
 }
 
 modify:
 {
-    match:
-    {
-        "targetname" "cloud_fall_mu"
-        "classname" "trigger_multiple"
-    }
-    insert:
-    {
-        "OnStartTouch" "item_boss_heal_relayAddOutputOnUser1 boss_health,Subtract,1500,0,-101"
-    }
+	match:
+	{
+		"targetname" "cloud_fall_mu"
+		"classname" "trigger_multiple"
+	}
+	insert:
+	{
+		"OnStartTouch" "item_boss_heal_relayAddOutputOnUser1 boss_health,Subtract,1500,0,-101"
+	}
 }

--- a/stripper/ze_tenkinoko_welkin_v1_4.cfg
+++ b/stripper/ze_tenkinoko_welkin_v1_4.cfg
@@ -1,0 +1,53 @@
+;fix Frozentomb
+modify:
+{
+    match:
+    {
+        "targetname" "item_FrozenTomb_onhit_temp"
+        "classname" "point_template"
+    }
+    replace:
+    {
+        "spawnflags" "2"
+    }
+}
+
+;Make item buttons less frustrating to press
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+	}
+	replace:
+	{
+		"min_use_angle" "0.2"
+	}
+}
+
+;OnUser inputs are not affected by a relay being enabled or not, so thunderbolt could kill boss before it spawns. Instead add the OnUser interaction when the trigger is enabled
+modify:
+{
+    match:
+    {
+        "targetname" "item_boss_heal_relay"
+        "classname" "logic_relay"
+    }
+    delete:
+    {
+        "OnUser1" "boss_healthSubtract15000-1"
+    }
+}
+
+modify:
+{
+    match:
+    {
+        "targetname" "cloud_fall_mu"
+        "classname" "trigger_multiple"
+    }
+    insert:
+    {
+        "OnStartTouch" "item_boss_heal_relayAddOutputOnUser1 boss_health,Subtract,1500,0,-101"
+    }
+}


### PR DESCRIPTION
Entwatch:
- Change Sunny Doll shortname from "Heal" to "Doll", since it is also a push and item recharge in addition to the heal.

Stripper:
- Add frozen tomb fix from 93x's stripper provided by mapper.
- Increase useable angle of buttons to make item buttons less finicky to use
- Prevent Thunderbolt from instant killing the boss before it scales up because mapper didn't realize enabling/disabling a logic_relay doesn't affect OnUser inputs.