### PR TITLE
surprise!

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ Find entity classnames that start with "weapon_" as a starting point for creatin
 ## SaveLevel
 
 The SaveLevel plugin is unlike the other configs in this repository in that it uses datamaps. A full list of datamaps can be found by using "sm_dump_datamaps datamaps.txt" in your own server with SourceMod installed or you can view [Mapeadores's datamap dump](https://github.com/Mapeadores/CSGO-Dumps/blob/master/datamaps.txt) (This may or may not be up to date depending on when you access their dump).
+
 The datamaps most commonly used for SaveLevel will generally be the following:
 ```
 m_iFrags     - The number of kills a player has
@@ -106,6 +107,7 @@ m_OnUser#    - An OnUser# output attached to a player. Ranges from m_OnUser1 to 
 ```
 
 The general template of a SaveLevel config will be as follows:
+
 ze_map_name.cfg
 ```
 "levels"

--- a/README.md
+++ b/README.md
@@ -17,31 +17,31 @@ Search for **math_counter**, **func_breakable**, **func_physbox** or **func_phys
 ```
 "math_counter"
 {
-    "config" //OPTIONAL
-    {
-        "MultBoss"            "" //Does the map have two breakables/bosses at once? Useful to track 2 bosshp at once. 1 for enable.
-        "HitMarkerOnly"            "" //Only shows HitMarkers + BossDamage Ranking. Useful for maps with built-in BossHud. 1 for enable.
-        "BossBeatenShowTopDamage"    "" //Whether to show the top damagers of boss after it dies. 0 to disable.
-    }
-    "0"
-    {
-        //math_counter example
-        "HP_counter"        "" //targetname of the hp math_counter
-        "HPbar_counter"        "" //targetname of the math_counter that handles a hp bar (if applicable)
-        "HPinit_counter"    "" //targetname of the math_counter that inits the hp math_counter (if applicable)
-        "CustomText"        "" //custom name to show in the hud
-        "HPbar_min"        "" //min value of the math_counter that handles a hp bar (if applicable)
-        "HPbar_max"        "" //max value of the math_counter that handles a hp bar (if applicable)
-        "HPbar_default"        "" //startvalue of the hpbar math_counter (if applicable)
-        "HPbar_mode"        "" //which mode the hpbar math_counter runs on, 1=OnHitMin outputs 2=OnHitMax outputs (if applicable)
-    }
-    "1"
-    {
-        //func_breakable, func_physbox or func_physbox_multiplayer example
-        "Type"            "breakable"
-        "BreakableName"        "" //targetname of the func_breakable, func_physbox or func_physbox_multiplayer
-        "CustomText"        "" //custom name to show in the hud
-    }
+	"config" //OPTIONAL
+	{
+		"MultBoss"			"" //Does the map have two breakables/bosses at once? Useful to track 2 bosshp at once. 1 for enable.
+		"HitMarkerOnly"			"" //Only shows HitMarkers + BossDamage Ranking. Useful for maps with built-in BossHud. 1 for enable.
+		"BossBeatenShowTopDamage"	"" //Whether to show the top damagers of boss after it dies. 0 to disable.
+	}
+	"0"
+	{
+		//math_counter example
+		"HP_counter"		"" //targetname of the hp math_counter
+		"HPbar_counter"		"" //targetname of the math_counter that handles a hp bar (if applicable)
+		"HPinit_counter"	"" //targetname of the math_counter that inits the hp math_counter (if applicable)
+		"CustomText"		"" //custom name to show in the hud
+		"HPbar_min"		"" //min value of the math_counter that handles a hp bar (if applicable)
+		"HPbar_max"		"" //max value of the math_counter that handles a hp bar (if applicable)
+		"HPbar_default"		"" //startvalue of the hpbar math_counter (if applicable)
+		"HPbar_mode"		"" //which mode the hpbar math_counter runs on, 1=OnHitMin outputs 2=OnHitMax outputs (if applicable)
+	}
+	"1"
+	{
+		//func_breakable, func_physbox or func_physbox_multiplayer example
+		"Type"			"breakable"
+		"BreakableName"		"" //targetname of the func_breakable, func_physbox or func_physbox_multiplayer
+		"CustomText"		"" //custom name to show in the hud
+	}
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -103,7 +103,7 @@ The datamaps most commonly used for SaveLevel will generally be the following:
 ```
 m_iFrags     - The number of kills a player has
 m_iName      - The targetname of an entity
-m_OnUser#    - An OnUser# output attached to a player. Ranges from m_OnUser1 to m_OnUser4.
+m_OnUser#    - An OnUser# output attached to an entity. Ranges from m_OnUser1 to m_OnUser4.
 ```
 
 The general template of a SaveLevel config will be as follows:

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ ze_map_name.cfg
 		"name" "" 	//The name of the level to be used with the sm_level command. Typically Level 0, Level 1, Level 2, etc.
 		"match" 	//Block used to detect which level a player is. If this is the default/unset level, this block is unneeded.
 		{
-			//Use only 1 of outputs, math, or props in a match block. Determines which way the match checks.
+			//Use only 1 of outputs, math, or props in a match block. The set one determines which method is used to check entities for the level.
 			"math" 		//Matches an output's number parameter on an add or subtract input.
 			{
 				"" ""	//Datamap to check. Typically used with m_OnUser# (ie. "m_OnUser1" "leveling_counter,Add,1" would check against a 1 there).

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ ze_map_name.cfg
         {
             "AddOutput" ""       //Used to add an output on an entity. Works in roughly the same way AddOutput works in hammer. Have the second parameter in the format of "Output target,input,input parameter,delay,max refires" (input parameter may be blank, but keep its comma if it is)
             "DeleteOutput" ""    //Used to remove an output from an entity. Typically only use for the default/unset level of the map. Have the second parameter in the format of "Output_datamap target,input,input parameter". The target, input, and input parameter may be unset from right to left (ie. if input parameter is set, input must be set as well, but not vice versa) (if they are unset, do not include the comma right before them). If not all of them are set, it will delete ALL outputs that match what is set (ie. "m_OnUser4 score10,ApplyScore" would delete ALL OnUser4 outputs that target score10 with the ApplyScore input) (ie. "m_OnUser1 leveling_counter" would delete ALL OnUser1 outputs that target leveling_counter entity)
-            "" ""                //Datamap to set. First parameter is the datamap, second is the value for it. Do not use this method for output datamaps as they can have multiples under the same datamap.
+            "" ""                //Datamap to set. First parameter is the datamap, second is the value for it (ie. "m_iName" "1" or "m_iFrags" "100"). Do not use this method for output datamaps as they can have multiples under the same datamap.
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -17,31 +17,31 @@ Search for **math_counter**, **func_breakable**, **func_physbox** or **func_phys
 ```
 "math_counter"
 {
-	"config" //OPTIONAL
-	{
-		"MultBoss"			"" //Does the map have two breakables/bosses at once? Useful to track 2 bosshp at once. 1 for enable.
-		"HitMarkerOnly"			"" //Only shows HitMarkers + BossDamage Ranking. Useful for maps with built-in BossHud. 1 for enable.
-		"BossBeatenShowTopDamage"	"" //Whether to show the top damagers of boss after it dies. 0 to disable.
-	}
-	"0"
-	{
-		//math_counter example
-		"HP_counter"		"" //targetname of the hp math_counter
-		"HPbar_counter"		"" //targetname of the math_counter that handles a hp bar (if applicable)
-		"HPinit_counter"	"" //targetname of the math_counter that inits the hp math_counter (if applicable)
-		"CustomText"		"" //custom name to show in the hud
-		"HPbar_min"		"" //min value of the math_counter that handles a hp bar (if applicable)
-		"HPbar_max"		"" //max value of the math_counter that handles a hp bar (if applicable)
-		"HPbar_default"		"" //startvalue of the hpbar math_counter (if applicable)
-		"HPbar_mode"		"" //which mode the hpbar math_counter runs on, 1=OnHitMin outputs 2=OnHitMax outputs (if applicable)
-	}
-	"1"
-	{
-		//func_breakable, func_physbox or func_physbox_multiplayer example
-		"Type"			"breakable"
-		"BreakableName"		"" //targetname of the func_breakable, func_physbox or func_physbox_multiplayer
-		"CustomText"		"" //custom name to show in the hud
-	}
+    "config" //OPTIONAL
+    {
+        "MultBoss"            "" //Does the map have two breakables/bosses at once? Useful to track 2 bosshp at once. 1 for enable.
+        "HitMarkerOnly"            "" //Only shows HitMarkers + BossDamage Ranking. Useful for maps with built-in BossHud. 1 for enable.
+        "BossBeatenShowTopDamage"    "" //Whether to show the top damagers of boss after it dies. 0 to disable.
+    }
+    "0"
+    {
+        //math_counter example
+        "HP_counter"        "" //targetname of the hp math_counter
+        "HPbar_counter"        "" //targetname of the math_counter that handles a hp bar (if applicable)
+        "HPinit_counter"    "" //targetname of the math_counter that inits the hp math_counter (if applicable)
+        "CustomText"        "" //custom name to show in the hud
+        "HPbar_min"        "" //min value of the math_counter that handles a hp bar (if applicable)
+        "HPbar_max"        "" //max value of the math_counter that handles a hp bar (if applicable)
+        "HPbar_default"        "" //startvalue of the hpbar math_counter (if applicable)
+        "HPbar_mode"        "" //which mode the hpbar math_counter runs on, 1=OnHitMin outputs 2=OnHitMax outputs (if applicable)
+    }
+    "1"
+    {
+        //func_breakable, func_physbox or func_physbox_multiplayer example
+        "Type"            "breakable"
+        "BreakableName"        "" //targetname of the func_breakable, func_physbox or func_physbox_multiplayer
+        "CustomText"        "" //custom name to show in the hud
+    }
 }
 ```
 
@@ -100,9 +100,9 @@ Find entity classnames that start with "weapon_" as a starting point for creatin
 The SaveLevel plugin is unlike the other configs in this repository in that it uses datamaps. A full list of datamaps can be found by using "sm_dump_datamaps datamaps.txt" in your own server with SourceMod installed or you can view [Mapeadores's datamap dump](https://github.com/Mapeadores/CSGO-Dumps/blob/master/datamaps.txt) (This may or may not be up to date depending on when you access their dump).
 The datamaps most commonly used for SaveLevel will generally be the following:
 ```
-m_iFrags 	- The number of kills a player has
-m_iName  	- The targetname of an entity
-m_OnUser#	- An OnUser# output attached to a player. Ranges from m_OnUser1 to m_OnUser4.
+m_iFrags     - The number of kills a player has
+m_iName      - The targetname of an entity
+m_OnUser#    - An OnUser# output attached to a player. Ranges from m_OnUser1 to m_OnUser4.
 ```
 
 The general template of a SaveLevel config will be as follows:
@@ -110,32 +110,32 @@ ze_map_name.cfg
 ```
 "levels"
 {
-	"0" //Number of the level, starting at 0 and increasing by 1 per level. In general level 0 should be set to as if it were a newly joined player with no levels.
-	{
-		"name" "" 	//The name of the level to be used with the sm_level command. Typically Level 0, Level 1, Level 2, etc.
-		"match" 	//Block used to detect which level a player is. If this is the default/unset level, this block is unneeded.
-		{
-			//Use only 1 of outputs, math, or props in a match block. The set one determines which method is used to check entities for the level.
-			"math" 		//Matches an output's number parameter on an add or subtract input.
-			{
-				"" ""	//Datamap to check. Typically used with m_OnUser# (ie. "m_OnUser1" "leveling_counter,Add,1" would check against a 1 there).
-			}
-			"props" 	//Matches a networked property of an entity.
-			{
-				"" ""	//Datamap to check. Typically used with m_iName. (ie. "m_iName" "1" checks for a targetname of 1)
-			}
-			"outputs" 	//Matches an output. Typically use math or props instead of outputs if possible.
-			{
-				"" ""	//Datamap to check. May use any output datamap.
-			}
-		}
-		"restore"	//Block used to set datamaps, add outputs, and/or delete outputs upon level restoration (client reconnect or sm_level usage). Only use 1 restore block per level, but you may use multiple output additions, deletions, or datamap changes in the block.
-		{
-			"AddOutput" ""		//Used to add an output on an entity. Works in roughly the same way AddOutput works in hammer. Have the second parameter in the format of "Output target,input,input parameter,delay,max refires" (input parameter may be blank, but keep its comma if it is)
-			"DeleteOutput" ""	//Used to remove an output from an entity. Typically only use for the default/unset level of the map. Have the second parameter in the format of "Output_datamap target,input,input parameter". The target, input, and input parameter may be unset from right to left (ie. if input parameter is set, input must be set as well, but not vice versa) (if they are unset, do not include the comma right before them). If not all of them are set, it will delete ALL outputs that match what is set (ie. "m_OnUser4 score10,ApplyScore" would delete ALL OnUser4 outputs that target score10 with the ApplyScore input) (ie. "m_OnUser1 leveling_counter" would delete ALL OnUser1 outputs that target leveling_counter entity)
-			"" ""			//Datamap to set. First parameter is the datamap, second is the value for it. Do not use this method for output datamaps as they can have multiples under the same datamap.
-		}
-	}
+    "0" //Number of the level, starting at 0 and increasing by 1 per level. In general level 0 should be set to as if it were a newly joined player with no levels.
+    {
+        "name" ""     //The name of the level to be used with the sm_level command. Typically Level 0, Level 1, Level 2, etc.
+        "match"       //Block used to detect which level a player is. If this is the default/unset level, this block is unneeded.
+        {
+            //Use only 1 of outputs, math, or props in a match block. The set one determines which method is used to check entities for the level.
+            "math"       //Matches an output's number parameter on an add or subtract input.
+            {
+                "" ""    //Datamap to check. Typically used with m_OnUser# (ie. "m_OnUser1" "leveling_counter,Add,1" would check against a 1 there).
+            }
+            "props"      //Matches a networked property of an entity.
+            {
+                "" ""    //Datamap to check. Typically used with m_iName. (ie. "m_iName" "1" checks for a targetname of 1)
+            }
+            "outputs"    //Matches an output. Typically use math or props instead of outputs if possible.
+            {
+                "" ""    //Datamap to check. May use any output datamap.
+            }
+        }
+        "restore"     //Block used to set datamaps, add outputs, and/or delete outputs upon level restoration (client reconnect or sm_level usage). Only use 1 restore block per level, but you may use multiple output additions, deletions, or datamap changes in the block.
+        {
+            "AddOutput" ""       //Used to add an output on an entity. Works in roughly the same way AddOutput works in hammer. Have the second parameter in the format of "Output target,input,input parameter,delay,max refires" (input parameter may be blank, but keep its comma if it is)
+            "DeleteOutput" ""    //Used to remove an output from an entity. Typically only use for the default/unset level of the map. Have the second parameter in the format of "Output_datamap target,input,input parameter". The target, input, and input parameter may be unset from right to left (ie. if input parameter is set, input must be set as well, but not vice versa) (if they are unset, do not include the comma right before them). If not all of them are set, it will delete ALL outputs that match what is set (ie. "m_OnUser4 score10,ApplyScore" would delete ALL OnUser4 outputs that target score10 with the ApplyScore input) (ie. "m_OnUser1 leveling_counter" would delete ALL OnUser1 outputs that target leveling_counter entity)
+            "" ""                //Datamap to set. First parameter is the datamap, second is the value for it. Do not use this method for output datamaps as they can have multiples under the same datamap.
+        }
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -97,7 +97,47 @@ Find entity classnames that start with "weapon_" as a starting point for creatin
 
 ## SaveLevel
 
-TODO
+The SaveLevel plugin is unlike the other configs in this repository in that it uses datamaps. A full list of datamaps can be found by using "sm_dump_datamaps datamaps.txt" in your own server with SourceMod installed or you can view [Mapeadores's datamap dump](https://github.com/Mapeadores/CSGO-Dumps/blob/master/datamaps.txt) (This may or may not be up to date depending on when you access their dump).
+The datamaps most commonly used for SaveLevel will generally be the following:
+```
+m_iFrags 	- The number of kills a player has
+m_iName  	- The targetname of an entity
+m_OnUser#	- An OnUser# output attached to a player. Ranges from m_OnUser1 to m_OnUser4.
+```
+
+The general template of a SaveLevel config will be as follows:
+ze_map_name.cfg
+```
+"levels"
+{
+	"0" //Number of the level, starting at 0 and increasing by 1 per level. In general level 0 should be set to as if it were a newly joined player with no levels.
+	{
+		"name" "" 	//The name of the level to be used with the sm_level command. Typically Level 0, Level 1, Level 2, etc.
+		"match" 	//Block used to detect which level a player is. If this is the default/unset level, this block is unneeded.
+		{
+			//Use only 1 of outputs, math, or props in a match block. Determines which way the match checks.
+			"math" 		//Matches an output's number parameter on an add or subtract input.
+			{
+				"" ""	//Datamap to check. Typically used with m_OnUser# (ie. "m_OnUser1" "leveling_counter,Add,1" would check against a 1 there).
+			}
+			"props" 	//Matches a networked property of an entity.
+			{
+				"" ""	//Datamap to check. Typically used with m_iName. (ie. "m_iName" "1" checks for a targetname of 1)
+			}
+			"outputs" 	//Matches an output. Typically use math or props instead of outputs if possible.
+			{
+				"" ""	//Datamap to check. May use any output datamap.
+			}
+		}
+		"restore"	//Block used to set datamaps, add outputs, and/or delete outputs upon level restoration (client reconnect or sm_level usage). Only use 1 restore block per level, but you may use multiple output additions, deletions, or datamap changes in the block.
+		{
+			"AddOutput" ""		//Used to add an output on an entity. Works in roughly the same way AddOutput works in hammer. Have the second parameter in the format of "Output target,input,input parameter,delay,max refires" (input parameter may be blank, but keep its comma if it is)
+			"DeleteOutput" ""	//Used to remove an output from an entity. Typically only use for the default/unset level of the map. Have the second parameter in the format of "Output_datamap target,input,input parameter". The target, input, and input parameter may be unset from right to left (ie. if input parameter is set, input must be set as well, but not vice versa) (if they are unset, do not include the comma right before them). If not all of them are set, it will delete ALL outputs that match what is set (ie. "m_OnUser4 score10,ApplyScore" would delete ALL OnUser4 outputs that target score10 with the ApplyScore input) (ie. "m_OnUser1 leveling_counter" would delete ALL OnUser1 outputs that target leveling_counter entity)
+			"" ""			//Datamap to set. First parameter is the datamap, second is the value for it. Do not use this method for output datamaps as they can have multiples under the same datamap.
+		}
+	}
+}
+```
 
 ## Stripper
 

--- a/entwatch/ze_castle_bridge_v1_3.cfg
+++ b/entwatch/ze_castle_bridge_v1_3.cfg
@@ -37,6 +37,7 @@
 		"maxuses"           "0"
 		"cooldown"          "20"
 		"maxamount"         "1"
+		"trigger"           "150146"
 	}
 	"2"
 	{
@@ -56,5 +57,6 @@
 		"maxuses"           "0"
 		"cooldown"          "50"
 		"maxamount"         "1"
+		"trigger"           "159635"
 	}
 }

--- a/entwatch/ze_castle_bridge_v1_3.cfg
+++ b/entwatch/ze_castle_bridge_v1_3.cfg
@@ -4,7 +4,7 @@
 	{
 		"name"              "Heal Sphere"
 		"shortname"         "Heal"
-		"color"             "{cyan}"
+		"color"             "{lightblue}"
 		"buttonclass"       "func_button"
 		"filtername"        "Human_Heal"
 		"hasfiltername"     "true"


### PR DESCRIPTION
Hopefully this is all correct, since we use savelevel so little that I am not experienced with it. It appears that the match block can also use the ExactMatches, MinMatches, and MaxMatches in conjunction with math, props, or outputs matchs. However, since I haven't seen any SaveLevel config that used this, it doesn't seem necessary to include in the readme.