### PR TITLE
Modified Multiple Files

### DIFF
--- a/entwatch/ze_solgryn_v1_5.cfg
+++ b/entwatch/ze_solgryn_v1_5.cfg
@@ -95,4 +95,24 @@
 		"cooldown"          "4"
 		"maxamount"         "1"
 	}
+	"5"
+	{
+		"name"              "ZM Jumper"
+		"shortname"         "ZM Jumper"
+		"color"             "{orange}"
+		"buttonclass"       "func_button"
+		"filtername"        "jumperuser"
+		"hasfiltername"     "true"
+		"blockpickup"       "false"
+		"allowtransfer"     "false"
+		"forcedrop"         "false"
+		"chat"              "true"
+		"hud"               "true"
+		"hammerid"          "4609601"
+		"mode"              "2"
+		"maxuses"           "0"
+		"cooldown"          "20"
+		"maxamount"         "1"
+		"trigger"           "4644764"
+	}
 }

--- a/stripper/ze_genso_of_last_v3_4_t1.cfg
+++ b/stripper/ze_genso_of_last_v3_4_t1.cfg
@@ -1,4 +1,4 @@
-;What it does:
+;Changes:
 ;	- Prevent delaying in secret
 ;	- Make doors that cannot be broken via shooting not make breakable sounds
 ;	- Prevent blocking the final door on lvl 1/2
@@ -17,6 +17,25 @@
 ;	- More easy (optional). Change teleport location, add limited use 2 times for ZM heal item.
 ;	- Remove 1 Box
 ;	- Make Stage 4 boss attack name accurate
+;	- Delay secret tele by 3 seconds so person that triggered it has time to use it themselves
+
+;Delay secret tele by 3 seconds so person that triggered it has time to use it themselves
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "secret_bt"
+	}
+	delete:
+	{
+		"OnPressed" "secretEnable01"
+	}
+	insert:
+	{
+		"OnPressed" "secret,Enable,,3,1"
+	}
+}
 
 ;Prevent delaying in secret
 add:

--- a/stripper/ze_shroomforest2_p6.cfg
+++ b/stripper/ze_shroomforest2_p6.cfg
@@ -1,3 +1,18 @@
+;Force 1st heaven door open without killing people only stuck for a split second
+modify:
+{
+	match:
+	{
+		"classname" "func_door_rotating"
+		"targetname" "Lvl3_H_Gate"
+	}
+	replace:
+	{
+		"forceclosed" "1"
+		"dmg" "1"
+	}
+}
+
 ;Remove safe spot on Extreme 2 boss by making closes web hit the wall
 modify:
 {

--- a/stripper/ze_surf_vortex_v2_6.cfg
+++ b/stripper/ze_surf_vortex_v2_6.cfg
@@ -1,3 +1,84 @@
+;Make melon secret start moving a bit later so that the person that pressed the last button has time to get on it if someone tries to steal it. Speed up melon to compensate time loss.
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"hammerid" "7809"
+	}
+	delete:
+	{
+		"OnStartTouch" "lemon2StartForward2-1"
+	}
+	insert:
+	{
+		"OnStartTouch" "lemon2,StartForward,,10,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_tanktrain"
+		"targetname" "lemon2"
+	}
+	replace:
+	{
+		"startspeed" "3000"
+	}
+}
+
+;Make final door unable to be blocked so people cant edge and troll
+modify:
+{
+	match:
+	{
+		"classname" "func_door"
+		"targetname" "finaldoor"
+	}
+	replace:
+	{
+		"forceclosed" "1"
+		"dmg" "9999999"
+	}
+}
+
+;Make melon secret only print chat message on first press
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "melonbt1"
+	}
+	delete:
+	{
+		"OnPressed" "cmd1Commandsay ***shorcut open***0-1"
+	}
+	insert:
+	{
+		"OnPressed" "cmd1,Command,say ***shorcut open***,0,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "melonbt2"
+	}
+	delete:
+	{
+		"OnPressed" "cmd1Commandsay ***Watermelon***0-1"
+	}
+	insert:
+	{
+		"OnPressed" "cmd1,Command,say ***Watermelon***,0,1"
+	}
+}
+
 ;remove bloom, it does NOT work well on a map that's almost all white textures
 modify:
 {

--- a/stripper/ze_traak_b2.cfg
+++ b/stripper/ze_traak_b2.cfg
@@ -1,0 +1,30 @@
+;Fix nuke avoidance spot
+add:
+{
+	"classname" "trigger_hurt"
+	"targetname" "resizeme"
+	"StartDisabled" "1"
+	"spawnflags" "1"
+	"origin" "-5392 1760 416"
+	"nodmgforce" "0"
+	"damagetype" "0"
+	"damagemodel" "0"
+	"damagecap" "20"
+	"damage" "9999999"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+		"hammerid" "31649"
+	}
+	insert:
+	{
+		"OnMapSpawn" "resizeme,AddOutput,solid 2,0.5,1"
+		"OnMapSpawn" "resizeme,AddOutput,mins -144 -1376 -608,1,1"
+		"OnMapSpawn" "resizeme,AddOutput,maxs 144 1376 608,1,1"
+		"OnMapSpawn" "resizeme,AddOutput,targetname nuke_hurt,2,1"
+	}
+}


### PR DESCRIPTION
- Solgyrn EW: Add jumper item
- Genso: Delay secret tele by 3 seconds so person that triggered it has time to use it themselves
- Shroomforest2: Force 1st heaven door open without killing people only stuck for a split second
- Surf Vortex: Make melon secret start moving a bit later so that the person that pressed the last button has time to get on it if someone tries to steal it. Speed up melon to compensate time loss.
- Surf Vortex: Make final door unable to be blocked so people cant edge and troll
- Surf Vortex: Make melon secret only print chat message on first press
- Traak: Fix nuke avoidance spot