### PR TITLE
Modified ze_bioshock_v6_2_csgo7.cfg

### DIFF
--- a/stripper/ze_bioshock_v6_2_csgo7.cfg
+++ b/stripper/ze_bioshock_v6_2_csgo7.cfg
@@ -1,9 +1,10 @@
 ; ze_bioshock_v6_2_csgo7 Stripper
-; What it does:
+;Changes:
 ;	- Fix nuke avoidance spot
 ;	- Nerfs Songbird HP
 ;	- Make it so players hopefully dont die in level 4 elevator if doorhugging
 ;	- Make items easier to press (dont have to look right at button to use it)
+;	- Increase blocking damage on 1st elevator in 1999 level
 
 ;add notice about stripper changes (requested by mapper)
 modify:
@@ -16,6 +17,22 @@ modify:
 	insert:
 	{
 		"OnTrigger" "consoleCommandsay Custom stripper changes are active on this map not done by the original mapper21"
+	}
+}
+
+; ----------------------------------------------------------
+; | Increase blocking damage on 1st elevator in 1999 level |
+; ----------------------------------------------------------
+modify:
+{
+	match:
+	{
+		"classname" "func_movelinear"
+		"targetname" "welcome_alt_elevator"
+	}
+	replace:
+	{
+		"blockdamage" "99999"
 	}
 }
 


### PR DESCRIPTION
- Add blockingdamage to first elevator of 1999 level so people cant infinitely delay it