### PR TITLE
Modified Multiple Configs

### DIFF
--- a/stripper/ze_dangerous_waters_v2_Final.cfg
+++ b/stripper/ze_dangerous_waters_v2_Final.cfg
@@ -1,3 +1,45 @@
+;Make the laser secret not useless, since damage value on env_beam and env_laser is damage per second, not per damage tick.
+modify:
+{
+	match:
+	{
+		"classname" "env_laser"
+		"targetname" "Lazer"
+	}
+	replace:
+	{
+		"damage" "40000"
+	}
+}
+
+;Make it so watermelon gun does not stop CTs mid-jump to prevent trolling teammates
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "L_Melon_trig"
+	"origin" "-8923 -5704 -1830"
+	"wait" "0"
+	"StartDisabled" "0"
+	"spawnflags" "1"
+	"filtername" "Human Filter"
+	"parentname" "L_Melon"
+	"model" "*155"
+	"OnStartTouch" "L_Melon,RunScriptCode,activator.SetOwner(self),0,-1"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "temp"
+	}
+	insert:
+	{
+		"Template02" "L_Melon_trig"
+	}
+}
+
 ;Pity fixes on env_fires.
 modify:
 {

--- a/stripper/ze_ffxii_ridorana_cataract_t5_3_w6.cfg
+++ b/stripper/ze_ffxii_ridorana_cataract_t5_3_w6.cfg
@@ -102,8 +102,6 @@ modify:
 	insert:
 	{
 		"OnStartTouch" "speedModifySpeed18-1"
-		"OnStartTouch" "!activator,RunScriptCode,activator.SetVelocity(Vector(0,0,0));,7.95,-1"
-		"OnEndTouch" "!activator,RunScriptCode,activator.SetVelocity(Vector(0,0,0));,0,-1"
 	}
 }
 
@@ -120,9 +118,38 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "speedModifySpeed15.5-1"
-		"OnStartTouch" "!activator,RunScriptCode,activator.SetVelocity(Vector(0,0,0));,5.45,-1"
-		"OnEndTouch" "!activator,RunScriptCode,activator.SetVelocity(Vector(0,0,0));,0,-1"
+		"OnEndTouch" "speed,ModifySpeed,1,0.05,-1"
+		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(0,0,0));0.05-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_case"
+		"targetname" "Item_Darkaga_Level_Case"
+	}
+	delete:
+	{
+		"OnCase01" "Item_Relay_DarkagaAddOutputOnTrigger Item_Darkaga_Trigger:Kill::5:-10-1"
+		"OnCase02" "Item_Relay_DarkagaAddOutputOnTrigger Item_Darkaga_Trigger:Kill::6.50:-10-1"
+		"OnCase03" "Item_Relay_DarkagaAddOutputOnTrigger Item_Darkaga_Trigger:Kill::8:-10-1"
+		"OnCase04" "Item_Relay_DarkagaAddOutputOnTrigger Item_Darkaga_Trigger:Kill::8:-10-1"
+		"OnCase05" "Item_Relay_DarkagaAddOutputOnTrigger Item_Darkaga_Trigger:Kill::8:-10-1"
+	}
+	insert:
+	{
+		"OnCase01" "Item_Relay_DarkagaAddOutputOnTrigger Item_Darkaga_Trigger:Disable::5:-10-1"
+		"OnCase02" "Item_Relay_DarkagaAddOutputOnTrigger Item_Darkaga_Trigger:Disable::6.50:-10-1"
+		"OnCase03" "Item_Relay_DarkagaAddOutputOnTrigger Item_Darkaga_Trigger:Disable::8:-10-1"
+		"OnCase04" "Item_Relay_DarkagaAddOutputOnTrigger Item_Darkaga_Trigger:Disable::8:-10-1"
+		"OnCase05" "Item_Relay_DarkagaAddOutputOnTrigger Item_Darkaga_Trigger:Disable::8:-10-1"
+		"OnCase01" "Item_Relay_DarkagaAddOutputOnTrigger Item_Darkaga_Trigger:Kill::5.1:-10-1"
+		"OnCase02" "Item_Relay_DarkagaAddOutputOnTrigger Item_Darkaga_Trigger:Kill::6.6:-10-1"
+		"OnCase03" "Item_Relay_DarkagaAddOutputOnTrigger Item_Darkaga_Trigger:Kill::8.1:-10-1"
+		"OnCase04" "Item_Relay_DarkagaAddOutputOnTrigger Item_Darkaga_Trigger:Kill::8.1:-10-1"
+		"OnCase05" "Item_Relay_DarkagaAddOutputOnTrigger Item_Darkaga_Trigger:Kill::8.1:-10-1"
 	}
 }
 

--- a/stripper/ze_grau_a03_4ff.cfg
+++ b/stripper/ze_grau_a03_4ff.cfg
@@ -1,3 +1,43 @@
+;half the zm item volume, since it is excessively loud when directly on top of a player
+modify:
+{
+	match:
+	{
+		"classname" "ambient_generic"
+		"targetname" "item1_gr_se"
+	}
+	replace:
+	{
+		"health" "5"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "ambient_generic"
+		"targetname" "item2_gr_se"
+	}
+	replace:
+	{
+		"health" "5"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "ambient_generic"
+		"targetname" "item3_gr_se"
+	}
+	replace:
+	{
+		"health" "5"
+	}
+}
+
 ;fix zombies spawning in the rtv level boss arena
 modify:
 {

--- a/stripper/ze_tesv_skyrim_v5_6.cfg
+++ b/stripper/ze_tesv_skyrim_v5_6.cfg
@@ -23,7 +23,7 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "!activator,RunScriptCode,self.SetVelocity(Vector(0,0,0));,2.3,-1"
+		"OnStartTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(0,0,0));2.3-1"
 	}
 }
 
@@ -36,7 +36,7 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "!activator,RunScriptCode,self.SetVelocity(Vector(0,0,0));,2,-1"
+		"OnStartTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(0,0,0));2-1"
 	}
 }
 
@@ -49,7 +49,7 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "!activator,RunScriptCode,self.SetVelocity(Vector(0,0,0));,1.5,-1"
+		"OnStartTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(0,0,0));1.5-1"
 	}
 }
 

--- a/stripper/ze_tesv_skyrim_v5_6.cfg
+++ b/stripper/ze_tesv_skyrim_v5_6.cfg
@@ -953,19 +953,6 @@ modify:
 	}
 }
 
-;so OnUser4 from previous fix doesn't carry between rounds on permanent player entities
-modify:
-{
-	match:
-	{
-		"classname" "logic_auto"
-	}
-	insert:
-	{
-		"OnMapSpawn" "player,FireUser4,,0,-1"
-	}
-}
-
 ;Keep default server freezetime so people have a bit more time to buy guns
 modify:
 {

--- a/stripper/ze_tesv_skyrim_v5_6.cfg
+++ b/stripper/ze_tesv_skyrim_v5_6.cfg
@@ -23,7 +23,7 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "!activator,RunScriptCode,activator.SetVelocity(Vector(0,0,0));,2.3,-1"
+		"OnStartTouch" "!activator,RunScriptCode,self.SetVelocity(Vector(0,0,0));,2.3,-1"
 	}
 }
 
@@ -36,7 +36,7 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "!activator,RunScriptCode,activator.SetVelocity(Vector(0,0,0));,2,-1"
+		"OnStartTouch" "!activator,RunScriptCode,self.SetVelocity(Vector(0,0,0));,2,-1"
 	}
 }
 
@@ -49,7 +49,7 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "!activator,RunScriptCode,activator.SetVelocity(Vector(0,0,0));,1.5,-1"
+		"OnStartTouch" "!activator,RunScriptCode,self.SetVelocity(Vector(0,0,0));,1.5,-1"
 	}
 }
 

--- a/stripper/ze_tesv_skyrim_v5_6.cfg
+++ b/stripper/ze_tesv_skyrim_v5_6.cfg
@@ -1,4 +1,19 @@
-;Reset werewolf and giant velocity after their right click freezes themselves, so they don't get launched across the map with stacked kb while frozen and sometimes able to boost off ramps
+;Disable heals after level 2 boss to prevent heal trimming at bridges
+modify:
+{
+	match:
+	{
+		"classname" "math_counter"
+		"targetname" "BossHpIterations3"
+	}
+	insert:
+	{
+		"OnHitMin" "heal_button,Kill,,0,-1"
+		"OnHitMin" "mg_kaitse,Kill,,0,-1"
+	}
+}
+
+;Reset ZM item velocity after their right click freezes themselves, so they don't get launched across the map with stacked kb while frozen and sometimes able to boost off ramps
 modify:
 {
 	match:
@@ -9,6 +24,19 @@ modify:
 	insert:
 	{
 		"OnStartTouch" "!activator,RunScriptCode,activator.SetVelocity(Vector(0,0,0));,2.3,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "troll_stop"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activator,RunScriptCode,activator.SetVelocity(Vector(0,0,0));,2,-1"
 	}
 }
 

--- a/stripper/ze_tesv_skyrim_v5_6.cfg
+++ b/stripper/ze_tesv_skyrim_v5_6.cfg
@@ -921,12 +921,17 @@ modify:
 {
 	match:
 	{
-		"classname" "trigger_multiple"
-		"targetname" "dr_nuke2"
+		"classname" "logic_relay"
+		"targetname" "dragon_nuke"
+	}
+	delete:
+	{
+		"OnTrigger" "dr_nuke2Kill51"
 	}
 	insert:
 	{
-		"OnStartTouch" "!activatorAddOutputOnUser4 speedmod,ModifySpeed,1,0,10-1"
+		"OnTrigger" "dr_nuke2,Disable,,5,1"
+		"OnTrigger" "dr_nuke2,Kill,,5.1,1"
 	}
 }
 
@@ -937,9 +942,14 @@ modify:
 		"classname" "func_physbox_multiplayer"
 		"targetname" "dr_phbox"
 	}
+	delete:
+	{
+		"OnBreak" "dr_nuke2Kill1-1"
+	}
 	insert:
 	{
-		"OnBreak" "player,FireUser4,,1,-1"
+		"OnBreak" "dr_nuke2,Disable,,1,-1"
+		"OnBreak" "dr_nuke2,Kill,,1.1,-1"
 	}
 }
 


### PR DESCRIPTION
Grau:
- Lower ZM item volume

Skyrim:
- Prevent level 2 heal trimming after boss at bridges
- Reset all ZM items' velocity after right click

Dangerous Waters:
- Make it so CTs cant troll teammates with melon gun
- Make the laser secret not useless and actually kill zombies

Ridorana Cataract:
- Actually fix CT dark item boosting this time