### PR TITLE
Cyberderp Configs

### DIFF
--- a/bosshud/ze_CYBERDERP_p3_KIA.txt
+++ b/bosshud/ze_CYBERDERP_p3_KIA.txt
@@ -1,0 +1,28 @@
+"math_counter"
+{
+	"0"
+	{
+		"HP_counter"		"bosshp100"
+		"CustomText"		"Cyber (5/5)"
+	}
+	"1"
+	{
+		"HP_counter"		"bosshp75"
+		"CustomText"		"Cyber (4/5)"
+	}
+	"2"
+	{
+		"HP_counter"		"bosshp50"
+		"CustomText"		"Cyber (3/5)"
+	}
+	"3"
+	{
+		"HP_counter"		"bosshp25"
+		"CustomText"		"Cyber (2/5)"
+	}
+	"4"
+	{
+		"HP_counter"		"bosshp"
+		"CustomText"		"Cyber (1/5)"
+	}
+}

--- a/stripper/ze_CYBERDERP_p3_KIA.cfg
+++ b/stripper/ze_CYBERDERP_p3_KIA.cfg
@@ -295,6 +295,7 @@ modify:
 	{
 		"OnSpawn" "ConsoleCommandmp_freezetime 20-1"
 		"OnSpawn" "cyber_spawn_breakableBreak25-1"
+		"OnSpawn" "weapon_managerAddOutputweaponname weapon_*5-1"
 	}
 	insert:
 	{
@@ -458,4 +459,11 @@ modify:
 		"disableshadows" "1"
 		"disablereceiveshadows" "1"
 	}
+}
+
+;Remove a weaponcleaner which can cause issue with the item making it impossible to recover
+filter:
+{
+	"targetname" "weapon_manager"
+	"hammerid" "962219"
 }


### PR DESCRIPTION
- Add Bosshud
- Remove a weaponcleaner that can screw over the items when the player dies with it, which makes picking up the items impossible.