### PR TITLE
Modified Feywood Configs

### DIFF
--- a/entwatch/ze_ffxii_feywood_b6_3k_override.cfg
+++ b/entwatch/ze_ffxii_feywood_b6_3k_override.cfg
@@ -128,9 +128,9 @@
 		"chat"			"true"
 		"hud"			"true"
 		"hammerid"		"5388540"
-		"mode"			"1"
+		"mode"			"2"
 		"maxuses"		"0"
-		"cooldown"		"0"
+		"cooldown"		"60"
 		"maxamount"		"1"
 	}
 	"7"

--- a/stripper/ze_ffxii_feywood_b6_3k.cfg
+++ b/stripper/ze_ffxii_feywood_b6_3k.cfg
@@ -118,9 +118,9 @@ modify:
 	}
 	insert:
 	{
-		"OnPlayerPickup" "Item_Berserk_UI,Activate,,0.05,-1"
+		"OnPlayerPickup" "Item_Berserk_UI,Activate,,0.1,-1"
 		"OnPlayerPickup" "player,FireUser2,,0,-1"
-		"OnPlayerPickup" "!activatorAddOutputOnUser2 Item_Berserk_UI:Deactivate::0:10-1"
+		"OnPlayerPickup" "!activatorAddOutputOnUser2 Item_Berserk_UI:Deactivate::0:10.05-1"
 	}
 }
 

--- a/stripper/ze_ffxii_feywood_b6_3k.cfg
+++ b/stripper/ze_ffxii_feywood_b6_3k.cfg
@@ -1,3 +1,316 @@
+;Make players do parkour for berserk rather than e-picking to skip map obstacle
+add:
+{
+	"classname" "func_physbox_multiplayer"
+	"origin" "9096 12305 5523.5"
+	"model" "*411"
+	"shadowdepthnocache" "0"
+	"damagetoenablemotion" "0"
+	"Damagetype" "0"
+	"ExploitableByPlayer" "0"
+	"disableflashlight" "0"
+	"disableshadowdepth" "0"
+	"disablereceiveshadows" "0"
+	"fademaxdist" "0"
+	"disableshadows" "0"
+	"drawinfastreflection" "0"
+	"ExplodeDamage" "0"
+	"explodemagnitude" "0"
+	"ExplodeRadius" "0"
+	"explosion" "0"
+	"fademindist" "-1"
+	"fadescale" "1"
+	"spawnobject" "0"
+	"forcetoenablemotion" "0"
+	"spawnflags" "34817"
+	"gibdir" "0 0 0"
+	"health" "0"
+	"rendermode" "10"
+	"massScale" "0"
+	"material" "0"
+	"renderfx" "0"
+	"nodamageforces" "0"
+	"rendercolor" "255 255 255"
+	"notsolid" "0"
+	"renderamt" "255"
+	"propdata" "0"
+	"PerformanceMode" "0"
+	"pressuredelay" "0"
+	"preferredcarryangles" "0 0 0"
+}
+
+;Move cactus free level to button instead of a trigger, as you can press the button and someone else steals the level (or multiple get free level cause all touching trigger_once)
+filter:
+{
+	"classname" "trigger_once"
+	"targetname" "Cactus_Trigger"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "Cactus_Button"
+	}
+	delete:
+	{
+		"OnPressed" "Cactus_TriggerEnable0-1"
+	}
+	insert:
+	{
+		"OnPressed" "!activatorAddOutputOnUser4 Map_Level_Check:Add:1:0.00:-10-1"
+		"OnPressed" "cmdCommandsay **Cactus found. The player who did it got 1 level**0-1"
+		"OnPressed" "Map_Score_AddApplyScore0-1"
+		"OnPressed" "Cactus_ButtonKill0-1"
+		"OnPressed" "Map_Local_GametextAddOutputmessage YOU FOUND THE CACTUS. YOU GOT 100 EXP AND LEVELED UP0-1"
+		"OnPressed" "Map_Local_GametextDisplay0.5-1"
+		"OnPressed" "Map_Local_GametextAddOutputcolor 49 255 130-1"
+		"OnPressed" "Map_Local_GametextAddOutputcolor 234 255 2302-1"
+		"OnPressed" "Cactus*Kill0.5-1"
+		"OnPressed" "Sidequest_CactusKill0.25-1"
+		"OnPressed" "Sidequest_Cactus_CaseKill0.25-1"
+	}
+}
+
+;Change the func_button for berserk mode toggling to a game_ui with right click (like other feywood ports/versions), so that entwatch doesnt track it
+filter:
+{
+	"classname" "func_button"
+	"targetname" "Item_Berserk_Change"
+}
+
+filter:
+{
+	"classname" "filter_activator_name"
+	"targetname" "Item_Berserk_Filter_2"
+}
+
+add:
+{
+	"classname" "game_ui"
+	"targetname" "Item_Berserk_UI"
+	"origin" "-1904 -6688 -4610"
+	"spawnflags" "0"
+	"FieldOfView" "-1.0"
+	"PressedAttack2" "Item_Berserk_Relay_gameui,Trigger,,0,-1"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "game_text"
+		"targetname" "Item_Berserk_Gametext"
+	}
+	replace:
+	{
+		"message" "You picked up Berserk Magick. Right click (+attack2) to switch modes (ammo/speed)"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_elite"
+		"targetname" "Weapon_Berserk"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "Item_Berserk_UI,Activate,,0.05,-1"
+		"OnPlayerPickup" "player,FireUser2,,0,-1"
+		"OnPlayerPickup" "!activatorAddOutputOnUser2 Item_Berserk_UI:Deactivate::0:10-1"
+	}
+}
+
+;Change this output to be OnUser2 (since it is either this or the other OnUser2 output anyways, never both) to free up OnUser3 for berserk game_ui
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "lvl5_Solo_Win"
+	}
+	delete:
+	{
+		"OnTrigger" "!activatorAddOutputOnUser3 !self:setdamagefilter:Zombies_Ignore:5:101"
+		"OnTrigger" "!activatorAddOutputOnUser3 !self:addoutput:targetname solo_winner:5:101"
+		"OnTrigger" "!activatorAddOutputOnUser3 ZMround_Relay:CancelPending::0:101"
+		"OnTrigger" "!activatorAddOutputOnUser3 ZMround_Solo_Relay:Trigger::0:101"
+		"OnTrigger" "!activatorAddOutputOnUser3 ZMround_Relay:Kill::0.5:101"
+	}
+	insert:
+	{
+		"OnTrigger" "!activatorAddOutputOnUser2 !self:setdamagefilter:Zombies_Ignore:5:101"
+		"OnTrigger" "!activatorAddOutputOnUser2 !self:addoutput:targetname solo_winner:5:101"
+		"OnTrigger" "!activatorAddOutputOnUser2 ZMround_Relay:CancelPending::0:101"
+		"OnTrigger" "!activatorAddOutputOnUser2 ZMround_Solo_Relay:Trigger::0:101"
+		"OnTrigger" "!activatorAddOutputOnUser2 ZMround_Relay:Kill::0.5:101"
+	}
+}
+
+;use logic_relay since a game_ui cant be locked
+add:
+{
+	"classname" "logic_relay"
+	"targetname" "Item_Berserk_Relay_gameui"
+	"origin" "-1918 -6664 -4715"
+	"spawnflags" "0"
+	"OnTrigger" "Item_Berserk_Counter,Add,1,0,-1"
+	"OnTrigger" "!self,Disable,,0,-1"
+	"OnTrigger" "!self,Enable,,0.1,-1"
+}
+
+;Make berserk mode change entwatch cooldown, since the modes are different. Comment which of the next 2 blocks the current server's entwatch's sm_setcooldown mode doesnt work as
+;For if sm_setcooldown affects future cooldowns of items but not current
+modify:
+{
+	match:
+	{
+		"classname" "logic_case"
+		"targetname" "Item_Berserk_Case"
+	}
+	insert:
+	{
+		"OnCase01" "cmd,Command,sm_setcooldown 5388540 60,0,-1"
+		"OnCase02" "cmd,Command,sm_setcooldown 5388540 50,0,-1"
+	}
+}
+
+;For if sm_setcooldown affects current cooldown of an item already on cooldown
+;modify:
+;{
+;	match:
+;	{
+;		"classname" "logic_case"
+;		"targetname" "Item_Berserk_Use_Case"
+;	}
+;	insert:
+;	{
+;		"OnCase01" "cmd,Command,sm_setcooldown 5388540 60,0,-1"
+;		"OnCase02" "cmd,Command,sm_setcooldown 5388540 50,0,-1"
+;	}
+;}
+
+;Force Berserk to ammo in certain spots that it can be used to troll with speed
+;level 2 broken floor
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "lvl2_Action_2"
+	}
+	insert:
+	{
+		"OnTrigger" "Item_Berserk_Relay_gameui,Disable,,15,1"
+		"OnTrigger" "Item_Berserk_Counter,SetValue,1,15,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "math_counter"
+		"targetname" "lvl2_Doors_Counter"
+	}
+	insert:
+	{
+		"OnHitMax" "Item_Berserk_Relay_gameui,Enable,,20,1"
+	}
+}
+
+;level 2 end
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "lvl2_Action_4"
+	}
+	insert:
+	{
+		"OnTrigger" "Item_Berserk_Relay_gameui,Disable,,15,-1"
+		"OnTrigger" "Item_Berserk_Counter,SetValue,1,15,-1"
+	}
+}
+
+;level 4 tp near a pit, reenable after pit
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Level_4_Start"
+	}
+	insert:
+	{
+		"OnTrigger" "lvl3_Action_1AddOutputOnTrigger Item_Berserk_Relay_gameui:Disable::37:10-1"
+		"OnTrigger" "lvl3_Action_1AddOutputOnTrigger Item_Berserk_Counter:SetValue:1:37:10-1"
+		"OnTrigger" "Tomb_02_Door_TriggerAddOutputOnStartTouch Item_Berserk_Relay_gameui:Enable::15:10-1"
+	}
+}
+
+;level 4 broken ground near swinging axe, before boss fight (not after cause cts fall back staggered due to overdef, so allow for early trig and just eban if they troll)
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "lvl4_Action_1"
+	}
+	insert:
+	{
+		"OnTrigger" "Item_Berserk_Relay_gameui,Disable,,20,1"
+		"OnTrigger" "Item_Berserk_Counter,SetValue,1,20,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "lvl4_Action_2"
+	}
+	insert:
+	{
+		"OnStartTouch" "Item_Berserk_Relay_gameui,Enable,,20,1"
+	}
+}
+
+;level 4 end lasers
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "lvl4_End_Relay"
+	}
+	insert:
+	{
+		"OnTrigger" "Item_Berserk_Relay_gameui,Disable,,20,-1"
+		"OnTrigger" "Item_Berserk_Counter,SetValue,1,20,-1"
+	}
+}
+
+;level 5 end
+modify:
+{
+	match:
+	{
+		"classname" "trigger_teleport"
+		"targetname" "lvl5_End_TP"
+	}
+	insert:
+	{
+		"OnStartTouch" "Item_Berserk_Relay_gameui,Disable,,0,1"
+		"OnStartTouch" "Item_Berserk_Counter,SetValue,1,0,1"
+	}
+}
+
 ;Use default freezetime so players have a comfortable amount of time to buy guns
 modify:
 {


### PR DESCRIPTION
-  Change berserk mode toggle func_button to right click game_ui so it wont trigger entwatch cooldown
-  EW: Change berserk mode to 2
-  Make entwatch correctly track Berserk cooldown depending on which mode is used
-  Make players do the parkour/kz jumps to get berserk rather than skipping the map obstacle with e-pick
-  Make cactus button level up triggers to be on button instead of a trigger_once, so multiple people or people that didnt press the button cant get the level
-  Block berserk speed (by forcing ammo mode) in certain parts of the map that it is used to troll and kill teammates (ie. lasers, jumps, etc.)

tl;dr Berserk QoL stuff

Tested everything except for dropping berserk item to another CT (either manually dropped or client disconnected) and making sure the game_ui still works correctly.

Thank god for git reflog. I fucking overwrote these changes and reflog saved my life.