### PR TITLE
Modified Multiple Configs

### DIFF
--- a/entwatch/ze_cyberpunk_x_a07.cfg
+++ b/entwatch/ze_cyberpunk_x_a07.cfg
@@ -55,7 +55,7 @@
         "mode"              "0"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "1"
+        "maxamount"         "4"
     }
     "3"
     {

--- a/entwatch/ze_naiads_v4a_5f.cfg
+++ b/entwatch/ze_naiads_v4a_5f.cfg
@@ -42,8 +42,8 @@
 	}
 	"2"
 	{
-		"name"				"Gravity"
-		"shortname"			"Gravity"
+		"name"				"Zombie Gravity"
+		"shortname"			"ZM Gravity"
 		"color"				"{purple}"
 		"buttonclass"			""
 		"filtername"			"neikosplayer"

--- a/entwatch/ze_naiads_v4a_6f.cfg
+++ b/entwatch/ze_naiads_v4a_6f.cfg
@@ -42,8 +42,8 @@
 	}
 	"2"
 	{
-		"name"				"Gravity"
-		"shortname"			"Gravity"
+		"name"				"Zombie Gravity"
+		"shortname"			"ZM Gravity"
 		"color"				"{purple}"
 		"buttonclass"			""
 		"filtername"			"neikosplayer"

--- a/entwatch/ze_roof_adventure_v8f_override.cfg
+++ b/entwatch/ze_roof_adventure_v8f_override.cfg
@@ -74,7 +74,7 @@
 		"mode"			"2"
 		"maxuses"		"0"
 		"cooldown"		"35"
-		"maxamount"		"1"
+		"maxamount"		"2"
 		"trigger"		"41731"
 	}
 	"4"
@@ -91,9 +91,9 @@
 		"chat"			"true"
 		"hud"			"true"
 		"hammerid"		"71551"
-		"mode"			"3"
+		"mode"			"4"
 		"maxuses"		"1"
-		"cooldown"		"0"
+		"cooldown"		"14"
 		"maxamount"		"1"
 	}
 	"5"
@@ -157,7 +157,7 @@
 	"8"
 	{
 		"name"			"Mini Ultimate"
-		"shortname"		"MUltimate"
+		"shortname"		"M.Ultimate"
 		"color"			"{lightgreen}"
 		"buttonclass"		"func_button"
 		"filtername"		"ultimate_zm_user"
@@ -168,9 +168,9 @@
 		"chat"			"true"
 		"hud"			"true"
 		"hammerid"		"514832"
-		"mode"			"3"
+		"mode"			"4"
 		"maxuses"		"1"
-		"cooldown"		"0"
+		"cooldown"		"14"
 		"maxamount"		"1"
 	}
 	"9"

--- a/stripper/ze_dark_souls_ptd_csgo2.cfg
+++ b/stripper/ze_dark_souls_ptd_csgo2.cfg
@@ -1,3 +1,70 @@
+;Make picking up knife items kill off their strip triggers
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Weapon_PM"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "Item_PM_Strip,Kill,,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Weapon_PW"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "Item_PW_Strip,Kill,,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Weapon_BF"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "Item_BF_Strip,Kill,,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Weapon_ZMPoison"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "Item_ZMPoison_Strip,Kill,,0,-1"
+	}
+}
+
+;force first spawn door to open outwards so as to not block team
+modify:
+{
+	match:
+	{
+		"classname" "func_door_rotating"
+		"targetname" "Spawn_Door_1"
+	}
+	replace:
+	{
+		"spawnflags" "272"
+	}
+}
+
 ;Kill CTs that use the afk tp out of Sen's Fortress
 ;This mimics old port behaviour and HaRyDe clarified that the intended behavior is: "Force all players to go through the traps in Sen's Fortress"
 modify:

--- a/stripper/ze_escape_stroggos_p2.cfg
+++ b/stripper/ze_escape_stroggos_p2.cfg
@@ -1,0 +1,52 @@
+;lock item buttons until they are picked up, since they arent filtered (and entwatch can filter once picked up)
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "antizombie_bttn"
+	}
+	replace:
+	{
+		"spawnflags" "19457"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_p250"
+		"targetname" "antizombie_dg"
+	}
+	add:
+	{
+		"OnPlayerPickup" "antizombie_bttn,Unlock,,0,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "laser_bttn"
+	}
+	replace:
+	{
+		"spawnflags" "19457"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_p250"
+		"targetname" "laser_dg"
+	}
+	add:
+	{
+		"OnPlayerPickup" "laser_bttn,Unlock,,0,1"
+	}
+}

--- a/stripper/ze_naiads_v4a_5f.cfg
+++ b/stripper/ze_naiads_v4a_5f.cfg
@@ -485,3 +485,17 @@ modify:
 		"OnTrigger" "trueendbrush3Disable0-1"
 	}
 }
+
+;Make a door that open based on a trigger_once not make a breakable sound when shot
+modify:
+{
+	match:
+	{
+		"classname" "func_breakable"
+		"targetname" "b7"
+	}
+	replace:
+	{
+		"spawnflags" "1"
+	}
+} 

--- a/stripper/ze_naiads_v4a_6f.cfg
+++ b/stripper/ze_naiads_v4a_6f.cfg
@@ -485,3 +485,17 @@ modify:
 		"OnTrigger" "trueendbrush3Disable0-1"
 	}
 }
+
+;Make a door that open based on a trigger_once not make a breakable sound when shot
+modify:
+{
+	match:
+	{
+		"classname" "func_breakable"
+		"targetname" "b7"
+	}
+	replace:
+	{
+		"spawnflags" "1"
+	}
+} 

--- a/stripper/ze_rollermine_factory_2010_p.cfg
+++ b/stripper/ze_rollermine_factory_2010_p.cfg
@@ -1,0 +1,7 @@
+;remove a vending machine at last defense that could be used to get on top of end room. This lead to a delay spot after nuke where whichever team on top of end room could just sit there and wait out round time.
+filter:
+{
+	"classname" "prop_physics_override"
+	"origin" "116 10536 524"
+	"model" "models/props/cs_office/vending_machine.mdl"
+}

--- a/stripper/ze_rollermine_factory_2010_p.cfg
+++ b/stripper/ze_rollermine_factory_2010_p.cfg
@@ -1,7 +1,12 @@
-;remove a vending machine at last defense that could be used to get on top of end room. This lead to a delay spot after nuke where whichever team on top of end room could just sit there and wait out round time.
-filter:
+;Block top of final room. Players could get up here and just sit there and wait out round time if the other team was inside the end room.
+add:
 {
-	"classname" "prop_physics_override"
-	"origin" "116 10536 524"
-	"model" "models/props/cs_office/vending_machine.mdl"
+	"classname" "func_breakable"
+	"origin" "454 11006 735.46"
+	"parentname" "fly"
+	"angles" "0 0 0"
+	"model" "*51"
+	"rendermode" "10"
+	"spawnflags" "1"
+	"health" "0"
 }


### PR DESCRIPTION
*ze_cyberpunk_x_a07
- EW: Change fuel can max to 4

*ze_naiads_v4a_5f
- EW: Gravity is a ZM item
- Make a door that open based on a trigger_once not make a breakable sound when shot

*ze_naiads_v4a_6f
- EW: Gravity is a ZM item
- Make a door that open based on a trigger_once not make a breakable sound when shot

*ze_roof_adventure_v8f
- EW: Fix ZM Speed maxamount
- EW: Make ultima chargeup times count down show on hud/scoreboard

*ze_dark_souls_ptd_csgo2
- Force first spawn door to open outwards so as to not block team if opened from other spawn room
- Make picking up knife items kill off their strip triggers

*ze_escape_stroggos_p2
- lock item buttons until they are picked up, since they arent filtered (and entwatch can filter once picked up)

*ze_rollermine_factory_2010_p
- Block top of final room. Players could get up here and just sit there and wait out round time if the other team was inside the end room.