### PR TITLE
Modified Multiple Files

### DIFF
--- a/entwatch/ze_einstein_v7.cfg
+++ b/entwatch/ze_einstein_v7.cfg
@@ -56,7 +56,7 @@
 		"mode"              "1"
 		"maxuses"           "0"
 		"cooldown"          "0"
-		"maxamount"         "1"
+		"maxamount"         "20"
 	}
 	"3"
 	{
@@ -75,6 +75,6 @@
 		"mode"              "1"
 		"maxuses"           "0"
 		"cooldown"          "0"
-		"maxamount"         "1"
+		"maxamount"         "4"
 	}
 }

--- a/entwatch/ze_paranoid_rezurrection_csgo1.cfg
+++ b/entwatch/ze_paranoid_rezurrection_csgo1.cfg
@@ -17,7 +17,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "1"
     {
@@ -36,7 +36,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
         "trigger"           "1462997"
     }
     "2"
@@ -56,7 +56,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "3"
     {
@@ -75,7 +75,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "4"
     {
@@ -94,7 +94,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "5"
     {
@@ -113,7 +113,7 @@
         "mode"              "2"
         "maxuses"           "0"
         "cooldown"          "40"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "6"
     {
@@ -132,7 +132,7 @@
         "mode"              "3"
         "maxuses"           "1"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "7"
     {
@@ -151,7 +151,7 @@
         "mode"              "2"
         "maxuses"           "0"
         "cooldown"          "50"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "8"
     {
@@ -170,7 +170,7 @@
         "mode"              "3"
         "maxuses"           "1"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "9"
     {
@@ -189,7 +189,7 @@
         "mode"              "2"
         "maxuses"           "0"
         "cooldown"          "22"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "10"
     {
@@ -208,7 +208,7 @@
         "mode"              "3"
         "maxuses"           "1"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "11"
     {
@@ -227,7 +227,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "12"
     {
@@ -246,7 +246,7 @@
         "mode"              "2"
         "maxuses"           "0"
         "cooldown"          "20"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "13"
     {
@@ -265,7 +265,7 @@
         "mode"              "2"
         "maxuses"           "0"
         "cooldown"          "40"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "14"
     {
@@ -284,7 +284,7 @@
         "mode"              "2"
         "maxuses"           "0"
         "cooldown"          "30"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "15"
     {
@@ -303,7 +303,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "16"
     {
@@ -322,7 +322,7 @@
         "mode"              "2"
         "maxuses"           "0"
         "cooldown"          "60"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "17"
     {
@@ -341,7 +341,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "18"
     {
@@ -360,7 +360,7 @@
         "mode"              "2"
         "maxuses"           "0"
         "cooldown"          "40"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "19"
     {
@@ -379,7 +379,7 @@
         "mode"              "2"
         "maxuses"           "0"
         "cooldown"          "40"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "20"
     {
@@ -398,7 +398,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "21"
     {
@@ -417,7 +417,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "22"
     {
@@ -436,7 +436,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "23"
     {
@@ -455,7 +455,7 @@
         "mode"              "4"
         "maxuses"           "3"
         "cooldown"          "16"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "24"
     {
@@ -474,7 +474,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "25"
     {
@@ -493,7 +493,7 @@
         "mode"              "3"
         "maxuses"           "1"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "26"
     {
@@ -512,7 +512,7 @@
         "mode"              "2"
         "maxuses"           "0"
         "cooldown"          "10"
-        "maxamount"         "99"
+        "maxamount"         "10"
         "trigger"           "1464625"
     }
     "27"
@@ -532,7 +532,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
         "trigger"           "1464703"
     }
     "28"
@@ -552,7 +552,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
         "trigger"           "1464804"
     }
     "29"
@@ -572,7 +572,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
         "trigger"           "1466007"
     }
     "30"
@@ -592,7 +592,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
         "trigger"           "1465202"
     }
     "31"
@@ -612,7 +612,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "32"
     {
@@ -631,7 +631,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
     }
     "33"
     {
@@ -650,7 +650,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
         "trigger"           "1465601"
     }
     "34"
@@ -670,7 +670,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
         "trigger"           "1465611"
     }
     "35"
@@ -690,7 +690,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
         "trigger"           "1465663"
     }
     "36"
@@ -710,7 +710,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
         "trigger"           "1465676"
     }
     "37"
@@ -730,7 +730,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
         "trigger"           "1466200"
     }
     "38"
@@ -750,7 +750,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
         "trigger"           "1465773"
     }
     "39"
@@ -770,7 +770,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
         "trigger"           "1465778"
     }
     "40"
@@ -790,7 +790,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
         "trigger"           "1465795"
     }
     "41"
@@ -810,7 +810,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
         "trigger"           "1465901"
     }
     "42"
@@ -831,7 +831,7 @@
         "mode"              "6"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
         "trigger"           "78416"
     }
     "43"
@@ -851,7 +851,7 @@
         "mode"              "1"
         "maxuses"           "0"
         "cooldown"          "0"
-        "maxamount"         "99"
+        "maxamount"         "10"
         "trigger"           "99957"
     }
 }

--- a/stripper/ze_Pirates_Port_Royal_v5_6.cfg
+++ b/stripper/ze_Pirates_Port_Royal_v5_6.cfg
@@ -1,3 +1,44 @@
+;(hopefully) prevent zombies from getting locked in a TP loop as badly by lowering info_teleport_destination (to try and lower in air kb) and making trigger_teleport reset velocity (probably only need 1 of these changes, not both)
+modify:
+{
+	match:
+	{
+		"classname" "info_teleport_destination"
+		"targetname" "teleport_lvl5_2_voda"
+		"origin" "9098 14698 -930"
+	}
+	replace:
+	{
+		"origin" "9098 14698 -935"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_teleport"
+		"targetname" "teleport_lvl5_cestaukrakena"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(0,0,0));0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_teleport"
+		"origin" "6578 14653 -1184"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(0,0,0));0-1"
+	}
+}
+
 ;patch out of map spot
 add:
 {

--- a/stripper/ze_dust_escape_p3.cfg
+++ b/stripper/ze_dust_escape_p3.cfg
@@ -1,0 +1,56 @@
+;Prevent CTs from delaying on jumps at start of map by tping them forward if they are in spawn. (Just checking y coord cause map is linear, so only spawn is below this y)
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "trigger_clientcommands"
+	}
+	insert:
+	{
+		"OnTrigger" "player,AddOutput,OnUser1 !self:AddOutput:origin 0 -1840 16:0:1,25,-1"
+		"OnTrigger" "playerRunScriptCodeforeach(f,_ in {FireUser1=0})if(self.GetOrigin().y<(-2034)&&self.GetTeam()==3)EntFireByHandle(self,f,f,0,null,null);135-1"
+		"OnTrigger" "playerRunScriptCodeforeach(f,_ in {FireUser1=0})if(self.GetOrigin().y<(-2034)&&self.GetTeam()==3)EntFireByHandle(self,f,f,0,null,null);200-1"
+	}
+}
+
+;Prevent CTs from delaying on 2 skill jumps at end of map
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "resizeme1"
+	"origin" "-32 1368 312"
+	"StartDisabled" "0"
+	"wait" "0"
+	"spawnflags" "1"
+	"OnStartTouch" "!activator,AddOutput,origin 32 1520 16,0,-1"
+}
+
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "resizeme2"
+	"origin" "-152 416 296"
+	"StartDisabled" "0"
+	"wait" "0"
+	"spawnflags" "1"
+	"OnStartTouch" "!activator,AddOutput,origin 16 448 16,0,-1"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "trigger_clientcommands"
+	}
+	insert:
+	{
+		"OnTrigger" "resizeme1,AddOutput,solid 2,0.5,1"
+		"OnTrigger" "resizeme1,AddOutput,mins -112 -88 -104,1,1"
+		"OnTrigger" "resizeme1,AddOutput,maxs 112 88 104,1,1"
+		"OnTrigger" "resizeme2,AddOutput,solid 2,0.5,1"
+		"OnTrigger" "resizeme2,AddOutput,mins -72 -68 -120,1,1"
+		"OnTrigger" "resizeme2,AddOutput,maxs 72 68 120,1,1"
+	}
+}

--- a/stripper/ze_einstein_v7.cfg
+++ b/stripper/ze_einstein_v7.cfg
@@ -22,8 +22,8 @@ modify:
 	}
 	insert:
 	{
-		"OnMapSpawn" "modified_george_cade_sb_buttonRunScriptCodeInputUse<-function(){if(self.GetMoveParent().GetMoveParent()==activator){return true;}else{return false;}}51"
-		"OnMapSpawn" "sexy1_buttonRunScriptCodeInputUse<-function(){if(self.GetMoveParent().GetMoveParent()==activator){return true;}else{return false;}}51"
-		"OnMapSpawn" "FlamethrowerButtonRunScriptCodeInputUse<-function(){if(self.GetMoveParent().GetMoveParent()==activator){return true;}else{return false;}}51"
+		"OnMapSpawn" "modified_george_cade_sb_button*RunScriptCodeInputUse<-function(){if(self.GetMoveParent().GetMoveParent()==activator){return true;}else{return false;}}51"
+		"OnMapSpawn" "sexy1_button*RunScriptCodeInputUse<-function(){if(self.GetMoveParent().GetMoveParent()==activator){return true;}else{return false;}}51"
+		"OnMapSpawn" "FlamethrowerButton*RunScriptCodeInputUse<-function(){if(self.GetMoveParent().GetMoveParent()==activator){return true;}else{return false;}}51"
 	}
 }

--- a/stripper/ze_einstein_v7.cfg
+++ b/stripper/ze_einstein_v7.cfg
@@ -12,3 +12,18 @@ add:
 	"spawnflags" "8"
 	"StartDisabled" "0"
 }
+
+;Filter item buttons to their holders
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "modified_george_cade_sb_buttonRunScriptCodeInputUse<-function(){if(self.GetMoveParent().GetMoveParent()==activator){return true;}else{return false;}}51"
+		"OnMapSpawn" "sexy1_buttonRunScriptCodeInputUse<-function(){if(self.GetMoveParent().GetMoveParent()==activator){return true;}else{return false;}}51"
+		"OnMapSpawn" "FlamethrowerButtonRunScriptCodeInputUse<-function(){if(self.GetMoveParent().GetMoveParent()==activator){return true;}else{return false;}}51"
+	}
+}

--- a/stripper/ze_ffxii_ridorana_cataract_t5_3_w6.cfg
+++ b/stripper/ze_ffxii_ridorana_cataract_t5_3_w6.cfg
@@ -1,4 +1,4 @@
-Changes:
+;Changes:
 ;	- Make the door after the level 2/4 boss fight not make the breakable sound (since it can't be broken due to shooting)
 ;	- Give server settings priority (so people have time in spawn to buy guns)
 ;	- Make kevlar affect damaging triggers such as lightning and meteors (copys ps port behavior/balance)
@@ -10,6 +10,23 @@ Changes:
 ;	- Make Weapons get striped in spawn
 ;	- Make Item buttons easier to press
 ;	- Make items not speed up zombies after using them, since GFL default speed is 1
+;	- Add env_wind
+
+;Add env_wind
+add:
+{
+	"classname" "env_wind"
+	"minwind" "5"
+	"mingustdelay" "999999"
+	"mingust" "1"
+	"maxwind" "10"
+	"maxgustdelay" "999999"
+	"maxgust" "1"
+	"gustduration" "1"
+	"gustdirchange" "10"
+	"angles" "0 0 0"
+	"origin" "-5092 -772 172"
+}
 
 ;Make the door after the level 2/4 boss fight not make the breakable sound (since it can't be broken due to shooting)
 modify:

--- a/stripper/ze_forbidden_repository_a1_4.cfg
+++ b/stripper/ze_forbidden_repository_a1_4.cfg
@@ -11,3 +11,30 @@ modify:
 		"classname" "func_rot_button"
 	}
 }
+
+;Fix tp avoidance spots
+add:
+{
+	"classname" "trigger_teleport"
+	"CheckDestIfClearForPlayer" "0"
+	"origin" "151 1551.5 480.5"
+	"model" "*116"
+	"spawnflags" "4097"
+	"StartDisabled" "1"
+	"target" "teleport_dest_cannon"
+	"targetname" "teleport_cannon"
+	"UseLandmarkAngles" "1"
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"CheckDestIfClearForPlayer" "0"
+	"origin" "-2072 1307.5 10.5"
+	"model" "*76"
+	"spawnflags" "4097"
+	"StartDisabled" "1"
+	"target" "teleport_dest_boss2"
+	"targetname" "teleport_boss2"
+	"UseLandmarkAngles" "1"
+}

--- a/stripper/ze_touhou_gensokyo_o4.cfg
+++ b/stripper/ze_touhou_gensokyo_o4.cfg
@@ -8,6 +8,7 @@
 ;	- Fix tp avoidance spots
 ;	- Remove mapper backdoor
 ;	- Remove zm skins due to their small size and similarity to the human ones
+;	- Make teleport to library use !activator landmark for cleaner teleports, instead of throwing CTs to the side
 
 ;Make item button easier to press (so you dont have to look down to use it)
 modify:
@@ -171,7 +172,7 @@ modify:
 	}
 }
 
-;Fix tp avoidance spots in grass area after 1st tp. (Cleaner approach, without the need of 4 trigger brushes)
+;Fix tp avoidance spots in grass area after 1st tp.
 modify:
 {
 	match:
@@ -187,6 +188,33 @@ modify:
     {
         "model" "*199"
     }
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_door"
+		"targetname" "hmgdoor"
+	}
+	replace:
+	{
+		"forceclosed" "1"
+		"dmg" "99999"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"origin" "-8516.65 2029.28 -1186.38"
+	}
+	insert:
+	{
+		"OnStartTouch" "hmgdoor,Close,,45,1"
+	}
 }
 
 ;Remove zm skins due to their small size and similarity to the human ones
@@ -207,4 +235,18 @@ modify:
         "OnMapSpawn" "hmgtelAddOutputmins -2978 -870.5 -749.51-1"
         "OnMapSpawn" "hmgtelAddOutputmaxs 2978 870.5 749.51-1"
     }
+}
+
+;Make teleport to library use !activator landmark for cleaner teleports, instead of throwing CTs to the side
+modify:
+{
+	match:
+	{
+		"classname" "trigger_teleport"
+		"targetname" "hmgtelouthum"
+	}
+	insert:
+	{
+		"landmark" "!activator"
+	}
 }


### PR DESCRIPTION
Paranoid Rezurrection:
- EW: Lower max amount of items per https://discord.com/channels/223673175571955712/420095739562295296/850501068361302036

Einstein:
- EW: Fix max amount of each cade
- Filter all items to only be used by their holders

Dust Escape:
- Block delay spots. CTs only survive nuke at the end of the map, so they shouldn't be hiding in spawn or on a skill jump for 4 minutes

Forbidden Repository:
- Block TP avoidance spots

Touhou Gensokyo:
- Properly fixed tp avoidance spot in grass area, since previous tp fix missed the door
- Make teleport to library use !activator landmark for cleaner teleports, instead of throwing CTs to the side

Pirates Port Royale:
- (Hopefully) prevent zombies from getting locked in a TP loop as badly by lowering info_teleport_destination (to try and lower in air kb) and making trigger_teleport reset velocity (probably only need 1 of these changes, not both)

Ridorana Cataract:
- Add env_wind