### PR TITLE
Modified Multiple Configs

### DIFF
--- a/stripper/dz_blacksite.cfg
+++ b/stripper/dz_blacksite.cfg
@@ -710,3 +710,35 @@ add:
 	"enabled" "1"
 	"origin" "4496 -3456 416"
 }
+
+;Disable sv_water_swim_mode when friction is set to 0. GFL server specific fix for iceskates map modifier
+;############################# THIS CHANGE WILL NOT WORK WITHOUT HAVING ##################################
+;########################### csgo/scripts/vscripts/gfl/iceskates_or_floating.nut ################################
+;###################################### IN THE SERVER FILES ##############################################
+;######## https://github.com/gflclan-cs-go-ze/ZE-Configs/blob/master/vscripts/iceskates_or_floating.nut #########
+add:
+{
+	"classname" "logic_eventlistener"
+	"targetname" "event_server_cvar"
+	"origin" "-1504 1242.47 1888"
+	"TeamNum" "-1"
+	"IsEnabled" "1"
+	"FetchEventData" "1"
+	"EventName" "server_cvar"
+	"OnEventFired" "iceskates_checker,RunScriptCode,CheckIceskates(),0,-1"
+}
+
+add:
+{
+	"classname" "logic_script"
+	"targetname" "iceskates_checker"
+	"origin" "-1504 1242.47 1888"
+	"vscripts" "gfl/iceskates_or_floating.nut"
+}
+
+add:
+{
+	"classname" "point_servercommand"
+	"targetname" "console"
+	"origin" "-1504 1242.47 1888"
+}

--- a/stripper/dz_sirocco.cfg
+++ b/stripper/dz_sirocco.cfg
@@ -828,3 +828,35 @@ add:
 	"enabled" "1"
 	"origin" "2204.12 -225.567 280"
 }
+
+;Disable sv_water_swim_mode when friction is set to 0. GFL server specific fix for iceskates map modifier
+;############################# THIS CHANGE WILL NOT WORK WITHOUT HAVING ##################################
+;########################### csgo/scripts/vscripts/gfl/iceskates_or_floating.nut ################################
+;###################################### IN THE SERVER FILES ##############################################
+;######## https://github.com/gflclan-cs-go-ze/ZE-Configs/blob/master/vscripts/iceskates_or_floating.nut #########
+add:
+{
+	"classname" "logic_eventlistener"
+	"targetname" "event_server_cvar"
+	"origin" "-5895.53 6046.72 6071"
+	"TeamNum" "-1"
+	"IsEnabled" "1"
+	"FetchEventData" "1"
+	"EventName" "server_cvar"
+	"OnEventFired" "iceskates_checker,RunScriptCode,CheckIceskates(),0,-1"
+}
+
+add:
+{
+	"classname" "logic_script"
+	"targetname" "iceskates_checker"
+	"origin" "-5895.53 6046.72 6071"
+	"vscripts" "gfl/iceskates_or_floating.nut"
+}
+
+add:
+{
+	"classname" "point_servercommand"
+	"targetname" "console"
+	"origin" "-5895.53 6046.72 6071"
+}

--- a/stripper/ze_Pirates_Port_Royal_v5_6.cfg
+++ b/stripper/ze_Pirates_Port_Royal_v5_6.cfg
@@ -1,3 +1,21 @@
+;Fix 2nd wave's particles not showing on level 6 bridge that kraken knocks down
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "lvl_god_kraken_cesta"
+	}
+	delete:
+	{
+		"OnTrigger" "kraken_particl_wave_cestaStop3.81"
+	}
+	insert:
+	{
+		"OnTrigger" "kraken_particl_wave_cesta,DestroyImmediately,,4,1"
+	}
+}
+
 ;(hopefully) prevent zombies from getting locked in a TP loop as badly by lowering info_teleport_destination (to try and lower in air kb) and making trigger_teleport reset velocity (probably only need 1 of these changes, not both)
 modify:
 {

--- a/stripper/ze_easy_escape_r.cfg
+++ b/stripper/ze_easy_escape_r.cfg
@@ -52,11 +52,24 @@ add:
 {
 	"classname" "trigger_teleport"
 	"targetname" "window_camping_tp"
-	"target" "1_"
+	"target" "teleport3"
 	"StartDisabled" "1"
 	"origin" "9940.25 -2037.69 454.85"
 	"UseLandmarkAngles" "1"
 	"spawnflags" "4097"
+	"CheckDestIfClearForPlayer" "0"
+	"model" "*25"
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"targetname" "window_camping_tp"
+	"target" "teleport3"
+	"StartDisabled" "0"
+	"origin" "9940 -2041.5 591.15"
+	"UseLandmarkAngles" "1"
+	"spawnflags" "1"
 	"CheckDestIfClearForPlayer" "0"
 	"model" "*25"
 }
@@ -79,40 +92,11 @@ modify:
 	match:
 	{
 		"classname" "func_button"
-		"targetname" "button_key_4"
-	}
-	insert:
-	{
-		"OnPressed" "window_camping_tpEnable301"
-		"OnPressed" "window_camping_tpDisable30.11"
-	}
-}
-
-modify:
-{
-	match:
-	{
-		"classname" "func_button"
-		"targetname" "button_key_6"
-	}
-	insert:
-	{
-		"OnPressed" "window_camping_tpEnable301"
-		"OnPressed" "window_camping_tpDisable30.11"
-	}
-}
-
-modify:
-{
-	match:
-	{
-		"classname" "func_button"
 		"targetname" "button_key_9"
 	}
 	insert:
 	{
-		"OnPressed" "window_camping_tpEnable301"
-		"OnPressed" "window_camping_tpDisable30.11"
+		"OnPressed" "window_camping_tp,Kill,,30.1,1"
 	}
 }
 

--- a/stripper/ze_easy_escape_r.cfg
+++ b/stripper/ze_easy_escape_r.cfg
@@ -53,7 +53,7 @@ add:
 	"classname" "trigger_teleport"
 	"targetname" "window_camping_tp"
 	"target" "teleport3"
-	"StartDisabled" "1"
+	"StartDisabled" "0"
 	"origin" "9940.25 -2037.69 454.85"
 	"UseLandmarkAngles" "1"
 	"spawnflags" "4097"

--- a/stripper/ze_interception_p2.cfg
+++ b/stripper/ze_interception_p2.cfg
@@ -1,3 +1,27 @@
+;Block skipping over the door before it opens with GFL jump height
+add:
+{
+	"classname" "func_breakable"
+	"targetname" "skip_blocker"
+	"origin" "-4758 -815 -8455"
+	"angles" "0 0 0"
+	"model" "*104"
+	"rendermode" "10"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"origin" "-4706 -716 -8582"
+	}
+	insert:
+	{
+		"OnStartTouch" "skip_blocker,Kill,,15,1"
+	}
+}
+
 ;Players will no longer get stuck at the spawn gate if they try to play dumb.
 modify:
 {

--- a/vscripts/darksouls_item.nut
+++ b/vscripts/darksouls_item.nut
@@ -167,7 +167,7 @@ function UsePoison()
     if(PlayerValidationT(activator, Poison_Owner))
     {
         Poison_Used++;
-          EntFireByHandle(Poison_Counter, "SetValue", "" + Poison_Used, 0.00, null, null);
+        EntFireByHandle(Poison_Counter, "SetValue", "" + Poison_Used, 0.00, null, null);
         local Poison_Text_B = "POISON MIST("+Poison_Used+"/"+Poison_Max_Use+")";
         if(Poison_Used >= Poison_Max_Use)
         {
@@ -256,7 +256,7 @@ function UseBlackFlame()
     if(PlayerValidationT(activator, BlackFlame_Owner))
     {
         BlackFlame_Used++;
-          EntFireByHandle(BlackFlame_Counter, "SetValue", "" + BlackFlame_Used, 0.00, null, null);
+        EntFireByHandle(BlackFlame_Counter, "SetValue", "" + BlackFlame_Used, 0.00, null, null);
         local BlackFlame_Text_B = "BLACK FLAME("+BlackFlame_Used+"/"+BlackFlame_Max_Use+")";
         if(BlackFlame_Used >= BlackFlame_Max_Use)
         {
@@ -308,7 +308,7 @@ function UseAef()
     if(PlayerValidationCT(activator, AEF_OWNER))
     {
         AEF_USED++;
-          EntFireByHandle(AEF_Counter, "SetValue", "" + AEF_USED, 0.00, null, null);
+        EntFireByHandle(AEF_Counter, "SetValue", "" + AEF_USED, 0.00, null, null);
         local AEF_TEXT_B = "ASHEN ESTUS("+AEF_USED+"/"+AEF_MAX_USE+")";
         if(AEF_USED >= AEF_MAX_USE)
         {
@@ -350,7 +350,7 @@ function AddUseItems()
     if(ItemValidation(EstusFlask_Owner, EstusFlask_Weapon, EstusFlask_Button))
     {
         EstusFlask_Max_Use++;
-          EntFireByHandle(EstusFlask_Counter, "AddOutput", "max " + EstusFlask_Max_Use, 0.00, null, null);
+        EntFireByHandle(EstusFlask_Counter, "AddOutput", "max " + EstusFlask_Max_Use, 0.00, null, null);
         EntFireByHandle(EstusFlask_Text, "Display", "", 0.00, EstusFlask_Owner, null);
     }
     if(ItemValidation(GHSA_Owner, GHSA_Weapon, GHSA_Button))
@@ -374,7 +374,7 @@ function AddUseItems()
     if(ItemValidation(GreenBlossom_Owner, GreenBlossom_Weapon, GreenBlossom_Button))
     {
         GreenBlossom_Max_Use++;
-          EntFireByHandle(GreenBlossom_Counter, "AddOutput", "max " + GreenBlossom_Max_Use, 0.00, null, null);
+        EntFireByHandle(GreenBlossom_Counter, "AddOutput", "max " + GreenBlossom_Max_Use, 0.00, null, null);
         EntFireByHandle(GreenBlossom_Text, "Display", "", 0.00, GreenBlossom_Owner, null);
     }
     if(ItemValidation(SS_Owner, SS_Weapon, SS_Button))
@@ -652,6 +652,7 @@ function UseEstusFlask()
     if(PlayerValidationCT(activator, EstusFlask_Owner))
     {
         EstusFlask_Used++;
+        EntFireByHandle(EstusFlask_Counter, "SetValue", "" + EstusFlask_Used, 0.00, null, null);
         local EstusFlask_Text_B = "ESTUS FLASK("+EstusFlask_Used+"/"+EstusFlask_Max_Use+")";
         if(EstusFlask_Used >= EstusFlask_Max_Use)
         {
@@ -890,7 +891,7 @@ function UseGreenBlossom()
     if(PlayerValidationCT(activator, GreenBlossom_Owner))
     {
         GreenBlossom_Used++;
-          EntFireByHandle(GreenBlossom_Counter, "SetValue", "" + GreenBlossom_Used, 0.00, null, null);
+        EntFireByHandle(GreenBlossom_Counter, "SetValue", "" + GreenBlossom_Used, 0.00, null, null);
         local GreenBlossom_Text_B = "GREEN BLOSSOM("+GreenBlossom_Used+"/"+GreenBlossom_Max_Use+")";
         if(GreenBlossom_Used >= GreenBlossom_Max_Use)
         {
@@ -1221,11 +1222,11 @@ function SetItemLevel(n)
     Within_Max_Use = n;
     EntFireByHandle(Within_Counter, "AddOutput", "max " + Within_Max_Use, 0.00, null, null);
     Poison_Max_Use = n;
-     EntFireByHandle(Poison_Counter, "AddOutput", "max " + Poison_Max_Use, 0.00, null, null);
+    EntFireByHandle(Poison_Counter, "AddOutput", "max " + Poison_Max_Use, 0.00, null, null);
     BlackFlame_Max_Use = n;
-     EntFireByHandle(BlackFlame_Counter, "AddOutput", "max " + BlackFlame_Max_Use, 0.00, null, null);
+    EntFireByHandle(BlackFlame_Counter, "AddOutput", "max " + BlackFlame_Max_Use, 0.00, null, null);
     AEF_MAX_USE = n;
-     EntFireByHandle(AEF_Counter, "AddOutput", "max " + AEF_MAX_USE, 0.00, null, null);
+    EntFireByHandle(AEF_Counter, "AddOutput", "max " + AEF_MAX_USE, 0.00, null, null);
     ChaosStorm_Max_Use = n;
     EntFireByHandle(ChaosStorm_Counter, "AddOutput", "max " + ChaosStorm_Max_Use, 0.00, null, null);
     Darkstorm_Max_Use = n;
@@ -1233,7 +1234,7 @@ function SetItemLevel(n)
     DarkOrb_Max_Use = n;
     EntFireByHandle(DarkOrb_Counter, "AddOutput", "max " + DarkOrb_Max_Use, 0.00, null, null);
     EstusFlask_Max_Use = n;
-     EntFireByHandle(EstusFlask_Counter, "AddOutput", "max " + EstusFlask_Max_Use, 0.00, null, null);
+    EntFireByHandle(EstusFlask_Counter, "AddOutput", "max " + EstusFlask_Max_Use, 0.00, null, null);
     GHSA_Max_Use = n;
     EntFireByHandle(GHSA_Counter, "AddOutput", "max " + GHSA_Max_Use, 0.00, null, null);
     HiBo_Max_Use = n;
@@ -1241,7 +1242,7 @@ function SetItemLevel(n)
     LS_Max_Use = n;
     EntFireByHandle(LS_Counter, "AddOutput", "max " + LS_Max_Use, 0.00, null, null);
     GreenBlossom_Max_Use = n;
-     EntFireByHandle(GreenBlossom_Counter, "AddOutput", "max " + GreenBlossom_Max_Use, 0.00, null, null);
+    EntFireByHandle(GreenBlossom_Counter, "AddOutput", "max " + GreenBlossom_Max_Use, 0.00, null, null);
     SS_Max_Use = n;
     EntFireByHandle(SS_Counter, "AddOutput", "max " + SS_Max_Use, 0.00, null, null);
     WDB_Max_Use = n;

--- a/vscripts/iceskates_or_floating.nut
+++ b/vscripts/iceskates_or_floating.nut
@@ -1,0 +1,12 @@
+event_server_cvar <- Entities.FindByName(null, "event_server_cvar");
+
+function CheckIceskates() {
+  local data = event_server_cvar.GetScriptScope().event_data;
+  if (data.cvarname == "sv_friction") {
+    if (data.cvarvalue != "0") {
+      EntFire("console","Command","sv_water_swim_mode 1",0,null);
+    } else {
+      EntFire("console","Command","sv_water_swim_mode 0",0,null);
+    }
+  }
+} 


### PR DESCRIPTION
Easy Escape:
- Block another tp avoidance spot on outside of upper window
- Keep anti-window tps enabled during the entirety of the inside house defense, as the windows can be used by zombies to shortcut to the outside defense before the doors even open for CTs to get there and are both outside of any tps, meaning mapper almost certainly didn't intend for players to stand on these windows (though it would be cleaner to invis wall block standing on the outside of the window rather than a tp)

Interception:
- Block skipping over a door with a jump possible due to GFL jump height

Dark Souls:
- Fix estus counter being off on entwatch using mathid modes

Blacksite & Sirocco:
- GFL server specific fix: Set sv_water_swim_mode to 0 when sv_friction is set to 0 (iceskates map modifier turned on) and set sv_water_swim_mode to 1 when sv_friction is set to anything other than 0 (iceskates map modifier turned off)

Pirates Port Royal:
- Fix 2nd wave's particles not showing on level 6 bridge that kraken knocks down