### PR TITLE
Modified Multiple Configs

### DIFF
--- a/stripper/ze_Knife_Stray_v3.cfg
+++ b/stripper/ze_Knife_Stray_v3.cfg
@@ -1,0 +1,68 @@
+;Fix the whole premise of the map with 1 hit knives and no weapons...
+add:
+{
+	"classname" "logic_timer"
+	"origin" "0 0 0"
+	"UseRandomTime" "0"
+	"RefireTime" "1"
+	"spawnflags" "0"
+	"StartDisabled" "0"
+	"OnTimer" "weapon_ak47,Kill,,0,-1"
+	"OnTimer" "weapon_aug,Kill,,0,-1"
+	"OnTimer" "weapon_awp,Kill,,0,-1"
+	"OnTimer" "weapon_bizon,Kill,,0,-1"
+	"OnTimer" "weapon_deagle,Kill,,0,-1"
+	"OnTimer" "weapon_decoy,Kill,,0,-1"
+	"OnTimer" "weapon_elite,Kill,,0,-1"
+	"OnTimer" "weapon_famas,Kill,,0,-1"
+	"OnTimer" "weapon_fiveseven,Kill,,0,-1"
+	"OnTimer" "weapon_flashbang,Kill,,0,-1"
+	"OnTimer" "weapon_g3sg1,Kill,,0,-1"
+	"OnTimer" "weapon_galilar,Kill,,0,-1"
+	"OnTimer" "weapon_glock,Kill,,0,-1"
+	"OnTimer" "weapon_healthshot,Kill,,0,-1"
+	"OnTimer" "weapon_hegrenade,Kill,,0,-1"
+	"OnTimer" "weapon_hkp2000,Kill,,0,-1"
+	"OnTimer" "weapon_incgrenade,Kill,,0,-1"
+	"OnTimer" "weapon_m4a1,Kill,,0,-1"
+	"OnTimer" "weapon_m4a1_silencer,Kill,,0,-1"
+	"OnTimer" "weapon_m249,Kill,,0,-1"
+	"OnTimer" "weapon_mac10,Kill,,0,-1"
+	"OnTimer" "weapon_mag7,Kill,,0,-1"
+	"OnTimer" "weapon_molotov,Kill,,0,-1"
+	"OnTimer" "weapon_mp7,Kill,,0,-1"
+	"OnTimer" "weapon_mp9,Kill,,0,-1"
+	"OnTimer" "weapon_negev,Kill,,0,-1"
+	"OnTimer" "weapon_nova,Kill,,0,-1"
+	"OnTimer" "weapon_p90,Kill,,0,-1"
+	"OnTimer" "weapon_p250,Kill,,0,-1"
+	"OnTimer" "weapon_scar20,Kill,,0,-1"
+	"OnTimer" "weapon_sg556,Kill,,0,-1"
+	"OnTimer" "weapon_smokegrenade,Kill,,0,-1"
+	"OnTimer" "weapon_ssg08,Kill,,0,-1"
+	"OnTimer" "weapon_tagrenade,Kill,,0,-1"
+	"OnTimer" "weapon_tec9,Kill,,0,-1"
+	"OnTimer" "weapon_ump45,Kill,,0,-1"
+	"OnTimer" "weapon_usp_silencer,Kill,,0,-1"
+	"OnTimer" "weapon_xm1014,Kill,,0,-1"
+	"OnTimer" "weapon_taser,Kill,,0,-1"
+	"OnTimer" "ClientAll,Command,invnext,0.01,-1"
+}
+
+add:
+{
+	"classname" "logic_timer"
+	"origin" "0 0 0"
+	"UseRandomTime" "0"
+	"RefireTime" "0.1"
+	"spawnflags" "0"
+	"StartDisabled" "0"
+	"OnTimer" "player,AddOutput,health 1,0,-1"
+}
+
+add:
+{
+	"classname" "point_broadcastclientcommand"
+	"targetname" "ClientAll"
+	"origin" "0 0 0"
+}

--- a/stripper/ze_Knife_Stray_v3.cfg
+++ b/stripper/ze_Knife_Stray_v3.cfg
@@ -1,68 +1,593 @@
-;Fix the whole premise of the map with 1 hit knives and no weapons...
-add:
+;Prevent player respawn by having spawns off side of map (above a trigger_hurt) and just tp players from spawn for first couple seconds.
+modify:
 {
-	"classname" "logic_timer"
-	"origin" "0 0 0"
-	"UseRandomTime" "0"
-	"RefireTime" "1"
-	"spawnflags" "0"
-	"StartDisabled" "0"
-	"OnTimer" "weapon_ak47,Kill,,0,-1"
-	"OnTimer" "weapon_aug,Kill,,0,-1"
-	"OnTimer" "weapon_awp,Kill,,0,-1"
-	"OnTimer" "weapon_bizon,Kill,,0,-1"
-	"OnTimer" "weapon_deagle,Kill,,0,-1"
-	"OnTimer" "weapon_decoy,Kill,,0,-1"
-	"OnTimer" "weapon_elite,Kill,,0,-1"
-	"OnTimer" "weapon_famas,Kill,,0,-1"
-	"OnTimer" "weapon_fiveseven,Kill,,0,-1"
-	"OnTimer" "weapon_flashbang,Kill,,0,-1"
-	"OnTimer" "weapon_g3sg1,Kill,,0,-1"
-	"OnTimer" "weapon_galilar,Kill,,0,-1"
-	"OnTimer" "weapon_glock,Kill,,0,-1"
-	"OnTimer" "weapon_healthshot,Kill,,0,-1"
-	"OnTimer" "weapon_hegrenade,Kill,,0,-1"
-	"OnTimer" "weapon_hkp2000,Kill,,0,-1"
-	"OnTimer" "weapon_incgrenade,Kill,,0,-1"
-	"OnTimer" "weapon_m4a1,Kill,,0,-1"
-	"OnTimer" "weapon_m4a1_silencer,Kill,,0,-1"
-	"OnTimer" "weapon_m249,Kill,,0,-1"
-	"OnTimer" "weapon_mac10,Kill,,0,-1"
-	"OnTimer" "weapon_mag7,Kill,,0,-1"
-	"OnTimer" "weapon_molotov,Kill,,0,-1"
-	"OnTimer" "weapon_mp7,Kill,,0,-1"
-	"OnTimer" "weapon_mp9,Kill,,0,-1"
-	"OnTimer" "weapon_negev,Kill,,0,-1"
-	"OnTimer" "weapon_nova,Kill,,0,-1"
-	"OnTimer" "weapon_p90,Kill,,0,-1"
-	"OnTimer" "weapon_p250,Kill,,0,-1"
-	"OnTimer" "weapon_scar20,Kill,,0,-1"
-	"OnTimer" "weapon_sg556,Kill,,0,-1"
-	"OnTimer" "weapon_smokegrenade,Kill,,0,-1"
-	"OnTimer" "weapon_ssg08,Kill,,0,-1"
-	"OnTimer" "weapon_tagrenade,Kill,,0,-1"
-	"OnTimer" "weapon_tec9,Kill,,0,-1"
-	"OnTimer" "weapon_ump45,Kill,,0,-1"
-	"OnTimer" "weapon_usp_silencer,Kill,,0,-1"
-	"OnTimer" "weapon_xm1014,Kill,,0,-1"
-	"OnTimer" "weapon_taser,Kill,,0,-1"
-	"OnTimer" "ClientAll,Command,invnext,0.01,-1"
+	match:
+	{
+		"classname" "info_player_terrorist"
+	}
+	replace:
+	{
+		"classname" "info_teleport_destination"
+	}
+	delete:
+	{
+		"enabled" "/\d/"
+		"priority" "/\d/"
+	}
+	insert:
+	{
+		"targetname" "dest_spawns_t"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "info_player_counterterrorist"
+	}
+	replace:
+	{
+		"classname" "info_teleport_destination"
+	}
+	delete:
+	{
+		"enabled" "/\d/"
+		"priority" "/\d/"
+	}
+	insert:
+	{
+		"targetname" "dest_spawns_ct"
+	}
 }
 
 add:
 {
-	"classname" "logic_timer"
-	"origin" "0 0 0"
-	"UseRandomTime" "0"
-	"RefireTime" "0.1"
-	"spawnflags" "0"
+	"classname" "trigger_teleport"
+	"targetname" "tp_spawns_t"
+	"origin" "4528 -5024 1108"
+	"spawnflags" "1"
+	"target" "dest_spawns_t"
 	"StartDisabled" "0"
-	"OnTimer" "player,AddOutput,health 1,0,-1"
+	"UseLandmarkAngles" "1"
+	"CheckDestIfClearForPlayer" "0"
 }
 
 add:
 {
-	"classname" "point_broadcastclientcommand"
-	"targetname" "ClientAll"
-	"origin" "0 0 0"
+	"classname" "trigger_teleport"
+	"targetname" "tp_spawns_ct"
+	"origin" "4528 -4928 1108"
+	"spawnflags" "1"
+	"target" "dest_spawns_ct"
+	"StartDisabled" "0"
+	"UseLandmarkAngles" "1"
+	"CheckDestIfClearForPlayer" "0"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "tp_spawns_*,AddOutput,solid 2,0,-1"
+		"OnMapSpawn" "tp_spawns_*,AddOutput,mins -1020 -24 -1068,0.05,-1"
+		"OnMapSpawn" "tp_spawns_*,AddOutput,maxs 1020 24 1068,0.05,-1"
+		"OnMapSpawn" "dest_spawns_*,AddOutput,origin 4696 -4432 40,10,-1"
+	}
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "5024 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4992 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4960 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4928 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4896 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4864 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4832 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4800 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4768 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4736 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4704 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4672 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4640 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4608 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4576 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4544 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4512 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4480 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4448 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4416 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4384 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4352 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4320 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4288 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4256 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4224 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4192 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4160 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4128 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4096 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4064 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_terrorist"
+	"origin" "4032 -5024 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "5024 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4992 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4960 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4928 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4896 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4864 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4832 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4800 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4768 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4736 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4704 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4672 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4640 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4608 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4576 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4544 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4512 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4480 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4448 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4416 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4384 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4352 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4320 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4288 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4256 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4224 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4192 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4160 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4128 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4096 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4064 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
+}
+
+add:
+{
+	"classname" "info_player_counterterrorist"
+	"origin" "4032 -4928 2096"
+	"enabled" "1"
+	"priority" "0"
 }

--- a/stripper/ze_cyberpunk_x_a07.cfg
+++ b/stripper/ze_cyberpunk_x_a07.cfg
@@ -1,0 +1,13 @@
+;add backup nuke to level 1 ending in case CTs decide not to jump on ending car/all that jumped on die on it, since they cannot win at this point but can delay.
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "lvl1_escape_car_path4"
+	}
+	insert:
+	{
+		"OnPass" "FailRelay,Trigger,,15,-1"
+	}
+}

--- a/stripper/ze_ffxii_feywood_b6_3k.cfg
+++ b/stripper/ze_ffxii_feywood_b6_3k.cfg
@@ -1,3 +1,23 @@
+;Fix bad door timing
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "lvl_1_Action_4"
+	}
+	delete:
+	{
+		"OnTrigger" "cmdCommandsay **THE TOMB GATES WILL CLOSE IN 25 SECONDS**15-1"
+		"OnTrigger" "cmdCommandsay **THE TOMB GATES WILL CLOSE IN 5 SECONDS**30-1"
+	}
+	insert:
+	{
+		"OnTrigger" "cmd,Command,say **THE TOMB GATES WILL BEGIN TO CLOSE IN 25 SECONDS**,10,-1"
+		"OnTrigger" "cmd,Command,say **THE TOMB GATES WILL BEGIN TO CLOSE IN 5 SECONDS**,25,-1"
+	}
+}
+
 ;Make players do parkour for berserk rather than e-picking to skip map obstacle
 add:
 {

--- a/stripper/ze_funny_runner_v3_1.cfg
+++ b/stripper/ze_funny_runner_v3_1.cfg
@@ -1,6 +1,7 @@
 ;Changes:
 ;	- Make ipad door kill blockers
 ;	- Keep airacceleration 10 except during surf part
+;	- Prevent bump mines from being naded to push them away from a trap
 
 ;Keep airacceleration 10 except during surf part
 modify:
@@ -57,5 +58,19 @@ modify:
 	replace:
 	{
 		"dmg" "9999"
+	}
+}
+
+;Prevent bump mines from being naded to push them away from a trap, since this nade prevents the people that fall in the trap from escaping the cage
+modify:
+{
+	match:
+	{
+		"origin" "-4016 3232 80"
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "weapon_bumpmine,DisableDamageForces,,0,-1"
 	}
 }

--- a/stripper/ze_sorrento_escape_v2.cfg
+++ b/stripper/ze_sorrento_escape_v2.cfg
@@ -116,3 +116,36 @@ add:
 	"model" "*110"
 	"rendermode" "10"
 }
+
+;prevent CTs from hiding on the dumpster at the back of spawn behind the afk tp, so zms cant get to them after the tp enables
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "/spawn_tp_(\d)*/"
+	}
+	replace:
+	{
+		"origin" "2857 2296.5 202"
+	}
+	delete:
+	{
+		"filtername" "zombie_filter"
+		"model" "/[*](\d)+/"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "spawn_tp_*,AddOutput,solid 2,0.5,-1"
+		"OnMapSpawn" "spawn_tp_*,AddOutput,mins -192 -582.5 -328,1,-1"
+		"OnMapSpawn" "spawn_tp_*,AddOutput,maxs 192 582.5 328,1,-1"
+	}
+}

--- a/stripper/ze_tesv_skyrim_v5_6.cfg
+++ b/stripper/ze_tesv_skyrim_v5_6.cfg
@@ -1,3 +1,130 @@
+;Block spot on level 5 that giant and DP can nuke through walls and are unable to defend against
+add:
+{
+	"classname" "filter_activator_context"
+	"targetname" "filter_giant"
+	"origin" "-1769 -9737 470"
+	"ResponseContext" "giantplayer"
+	"Negated" "Allow entities that match criteria"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "giant_knife"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "!activator,AddContext,giantplayer:1,0.05,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox_multiplayer"
+		"targetname" "giant_phbox"
+	}
+	insert:
+	{
+		"OnBreak" "player,RemoveContext,giantplayer,0,-1"
+	}
+}
+
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "exploit_blocker"
+	"origin" "-2352 -10544 560"
+	"spawnflags" "1"
+	"StartDisabled" "1"
+	"wait" "0"
+	"filtername" "filter_giant"
+	"OnStartTouch" "giant_ui,Deactivate,,0,-1"
+	"OnEndTouch" "giant_ui,Activate,,0,-1"
+}
+
+add:
+{
+	"classname" "filter_activator_context"
+	"targetname" "filter_dp"
+	"origin" "-1769 -9737 470"
+	"ResponseContext" "dpplayer"
+	"Negated" "Allow entities that match criteria"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "knife_dr"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "!activator,AddContext,dpplayer:1,0.05,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox_multiplayer"
+		"targetname" "dr_phbox"
+	}
+	insert:
+	{
+		"OnBreak" "player,RemoveContext,dpplayer,0,-1"
+	}
+}
+
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "exploit_blocker"
+	"origin" "-2352 -10544 560"
+	"spawnflags" "1"
+	"StartDisabled" "1"
+	"wait" "0"
+	"filtername" "filter_dp"
+	"OnStartTouch" "dragon_ui,Deactivate,,0,-1"
+	"OnEndTouch" "dragon_ui,Activate,,0,-1"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "wr_once6"
+	}
+	insert:
+	{
+		"OnStartTouch" "exploit_blocker,Enable,,25,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+		"spawnflags" "1"
+	}
+	insert:
+	{
+		"OnMapSpawn" "player,RemoveContext,giantplayer,0,-1"
+		"OnMapSpawn" "player,RemoveContext,dpplayer,0,-1"
+		"OnMapSpawn" "exploit_blocker,AddOutput,solid 2,0.5,-1"
+		"OnMapSpawn" "exploit_blocker,AddOutput,mins -496 -912 -112,1,-1"
+		"OnMapSpawn" "exploit_blocker,AddOutput,maxs 496 912 112,1,-1"
+	}
+}
+
 ;remove misleading console msgs
 modify:
 {
@@ -158,6 +285,12 @@ modify:
 	}
 }
 
+filter:
+{
+	"classname" "trigger_push"
+	"targetname" "/giant_push(\d)*/"
+}
+
 ;Werewolf Hitbox
 modify:
 {
@@ -186,6 +319,12 @@ modify:
 	}
 }
 
+filter:
+{
+	"classname" "trigger_push"
+	"targetname" "/ww_push(\d)*/"
+}
+
 ;Troll Hitbox
 modify:
 {
@@ -212,6 +351,12 @@ modify:
 	{
 		"OnPlayerPickup" "troll_phbox,RunScriptCode,LoadActivatorAsEnemyTarget();,0,1"
 	}
+}
+
+filter:
+{
+	"classname" "trigger_push"
+	"targetname" "/troll_push(\d)*/"
 }
 
 ;Changed stage 4 boss zombie cage opening sequence.

--- a/zombiereloaded/ze_Knife_Stray_v3.cfg
+++ b/zombiereloaded/ze_Knife_Stray_v3.cfg
@@ -1,0 +1,5 @@
+zr_infect_spawntime_min "5.0"
+zr_infect_spawntime_max "5.0"
+zr_infect_mzombie_ratio "10"
+zr_respawn_delay "180"
+sm_cvar mce_extend "0"

--- a/zombiereloaded/ze_Knife_Stray_v3.cfg
+++ b/zombiereloaded/ze_Knife_Stray_v3.cfg
@@ -1,5 +1,12 @@
+zr_class_modify zombies health 1
+zr_class_modify zombies health_regen_interval 180
+zr_class_modify zombies health_regen_amount 0
 zr_infect_spawntime_min "5.0"
 zr_infect_spawntime_max "5.0"
-zr_infect_mzombie_ratio "10"
-zr_respawn_delay "180"
-sm_cvar mce_extend "0"
+zr_restrict "Pistol"
+zr_restrict "Shotgun"
+zr_restrict "SMG"
+zr_restrict "Rifle"
+zr_restrict "Sniper"
+zr_restrict "Machine Gun"
+zr_restrict "Grenades"


### PR DESCRIPTION
Feywood:
- Fix bad door timing

Funny Runner:
- Prevent bump mines from being naded to push them away from a trap, since this nade prevents the people that fall in the trap from escaping the cage

Cyberpunk:
- Added backup nuke to end of level 1 if CTs fail to trigger after car leaves

Skyrim:
- Block spot on level 5 that giant and DP can nuke through walls and are unable to defend against
- Remove trigger_push entities for zm items, as the whole point of the vscript spin fix was to replace these. They are removed in potti's port and 3 months ago in the pirates port royale stripper for the same reason

Sorrento:
- prevent CTs from hiding in spawn behind the afk tp, so zms cant get to them after the tp enables

Added Knife Stray configs for potentially redoing a map test:
- Delete non-knife weapons constantly, as it is a knife only map
- Force all player hp to 1 (though only T's really need this). A better way would be forcing the map modifier cvar for 1 hit knives to on, but then stripper and map settings config couldnt be used by other servers
- Makes respawn time the duration of the entire round. Zombies aren't supposed to respawn, but since spawns are in a place you can run back to later, repeat killer cannot be easily enabled
- Remove all extends on the map. Alternative could be reducing timelimit to ~9 minutes (~3-5 rounds) and time given by an extend to 6 minutes (~2-3 rounds worth per extend). However, even with this reduction, map should still be Sunday only if added. It is not like normal ZE maps AT ALL: there is no defending with guns and zombies just have to sit in spec for up to 3 minutes waiting for the next round after death since they don't respawn.
- An example of how the map is 'supposed' to play for reference: https://youtu.be/7muuqkSDjG8