### PR TITLE
Modified Multiple Configs

### DIFF
--- a/entwatch/ze_lotr_minas_tirith_p5.cfg
+++ b/entwatch/ze_lotr_minas_tirith_p5.cfg
@@ -516,7 +516,7 @@
 	"26"
 	{
 		"name"              "Barricade - Explosive Barrel"
-		"shortname"         ""
+		"shortname"         "Explosives"
 		"color"             "{lightblue}"
 		"buttonclass"       "func_button"
 		"filtername"        ""
@@ -524,14 +524,13 @@
 		"blockpickup"       "false"
 		"allowtransfer"     "true"
 		"forcedrop"         "true"
-		"chat"              "false"
-		"hud"               "false"
+		"chat"              "true"
+		"hud"               "true"
 		"hammerid"          "3334835"
 		"mode"              "3"
 		"maxuses"           "1"
 		"cooldown"          "0"
 		"maxamount"         "2"
-		"trigger"           "4658425"
 	}
 	"27"
 	{

--- a/stripper/ze_castle_bridge_v1_4.cfg
+++ b/stripper/ze_castle_bridge_v1_4.cfg
@@ -1,4 +1,4 @@
-;Remove the ignite that heal gives, it can kill 1 HP players.
+;Remove the annoying ignite that heal gives
 modify:
 {
 	match:

--- a/stripper/ze_funny_runner_v3_1.cfg
+++ b/stripper/ze_funny_runner_v3_1.cfg
@@ -2,6 +2,7 @@
 ;	- Make ipad door kill blockers
 ;	- Keep airacceleration 10 except during surf part
 ;	- Prevent bump mines from being naded to push them away from a trap
+;	- Block a spot at end defense where zombies could avoid a push and block a spot hiding behind the doorframe
 
 ;Keep airacceleration 10 except during surf part
 modify:
@@ -73,4 +74,41 @@ modify:
 	{
 		"OnMapSpawn" "weapon_bumpmine,DisableDamageForces,,0,-1"
 	}
+}
+
+;Block a spot at end defense where zombies could avoid a push and block a spot hiding behind the doorframe
+add:
+{
+	"classname" "func_brush"
+	"origin" "-10800 912 -508.51"
+	"angles" "0 0 0"
+	"model" "*69"
+	"rendermode" "10"
+}
+
+add:
+{
+	"classname" "func_brush"
+	"origin" "-10800 1264 -508.51"
+	"angles" "0 0 0"
+	"model" "*69"
+	"rendermode" "10"
+}
+
+add:
+{
+	"classname" "func_brush"
+	"origin" "-10800 -880 -508.51"
+	"angles" "0 0 0"
+	"model" "*69"
+	"rendermode" "10"
+}
+
+add:
+{
+	"classname" "func_brush"
+	"origin" "-10800 -528 -508.51"
+	"angles" "0 0 0"
+	"model" "*69"
+	"rendermode" "10"
 }

--- a/stripper/ze_skill_escape_v09.cfg
+++ b/stripper/ze_skill_escape_v09.cfg
@@ -47,15 +47,14 @@ modify:
 	}
 }
 
-;If zombie reaches top, end game.
+;If zombie is at top when zms tp to cage, end game.
 add:
 {
-	"model" "*52"
 	"wait" "1"
 	"targetname" "ZMWatcher"
-	"StartDisabled" "0"
-	"spawnflags" "4097"
-	"origin" "3384 3806 -534"
+	"StartDisabled" "1"
+	"spawnflags" "1"
+	"origin" "3907.5 3735.5 -311.5"
 	"classname" "trigger_multiple"
 	"filtername" "filterzombies"
 	"OnStartTouch" "server,Command,say << ZOMBIE REACHED THE TOP >>,0,1"
@@ -64,6 +63,21 @@ add:
 	"OnStartTouch" "server,Command,say << GAME OVER >>,3,1"
 	"OnStartTouch" "player,AddOutput,origin 2124 3736 66,4,1"
 	"OnStartTouch" "trigger_teleport,Enable,,5,1"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "ZMWatcher,AddOutput,solid 2,0,1"
+		"OnMapSpawn" "ZMWatcher,AddOutput,mins -537.5 -544.5 -258.5,0.05,1"
+		"OnMapSpawn" "ZMWatcher,AddOutput,maxs 537.5 544.5 258.5,0.05,1"
+		"OnMapSpawn" "ZMWatcher,AddOutput,targetname lasersztp,0.1,1"
+	}
 }
 
 ;Stopmusic obey.

--- a/stripper/ze_tyranny_v5_2k3.cfg
+++ b/stripper/ze_tyranny_v5_2k3.cfg
@@ -1,3 +1,73 @@
+;Fix level 4 boss killer attack particle not showing if the killer attack is used twice in a row
+modify:
+{
+	match:
+	{
+		"classname" ""
+		"targetname" ""
+	}
+	delete:
+	{
+		"OnCase05" "bosslvl4_killerStop8.5-1"
+	}
+	insert:
+	{
+		"OnCase05" "bosslvl4_killer,DestroyImmediately,,9.4,-1"
+	}
+}
+
+;Clip up a common stuck spot area
+add:
+{
+	"classname" "prop_dynamic"
+	"model" "models/props/cs_militia/crate_extrasmallmill.mdl"
+	"origin" "-7048 -6256 -312"
+	"angles" "0 0 0"
+	"rendermode" "10"
+	"StartDisabled" "0"
+	"solid" "6"
+}
+
+add:
+{
+	"classname" "prop_dynamic"
+	"model" "models/props/cs_militia/crate_extrasmallmill.mdl"
+	"origin" "-6872 -6248 -416"
+	"angles" "0 0 0"
+	"rendermode" "10"
+	"StartDisabled" "0"
+	"solid" "6"
+}
+
+add:
+{
+	"classname" "prop_dynamic"
+	"model" "models/props/cs_militia/crate_extrasmallmill.mdl"
+	"origin" "-6968 -6272 -408"
+	"angles" "0 0 0"
+	"rendermode" "10"
+	"StartDisabled" "0"
+	"solid" "6"
+}
+
+;Fix nuke not killing all ZMs (?). It looks like the VScript nuke should kill all of them off, but apparently 1 survived somehow according to players.
+;Just make it go off again 0.05 seconds after in case it was a perfect respawn or something and hopefully it is fixed, but it may well be a different issue I don't know of.
+
+;Kill off fail detector if map is counted as a win so every round doesnt have the '>FAIL ROUND<' message at the end when CTs swap to both teams.
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "lvl_change"
+	}
+	insert:
+	{
+		"OnStartTouch" "Map_BrushRunScriptCodeKillT();1.051"
+		"OnStartTouch" "lvl_fail,Disable,,0.95,1"
+	}
+}
+
 ;fix game_player_equip dropping weapons
 modify:
 {

--- a/stripper/ze_tyranny_v5_2k3.cfg
+++ b/stripper/ze_tyranny_v5_2k3.cfg
@@ -3,8 +3,8 @@ modify:
 {
 	match:
 	{
-		"classname" ""
-		"targetname" ""
+		"classname" "logic_case"
+		"targetname" "bosslvl4_case"
 	}
 	delete:
 	{
@@ -50,9 +50,6 @@ add:
 	"solid" "6"
 }
 
-;Fix nuke not killing all ZMs (?). It looks like the VScript nuke should kill all of them off, but apparently 1 survived somehow according to players.
-;Just make it go off again 0.05 seconds after in case it was a perfect respawn or something and hopefully it is fixed, but it may well be a different issue I don't know of.
-
 ;Kill off fail detector if map is counted as a win so every round doesnt have the '>FAIL ROUND<' message at the end when CTs swap to both teams.
 modify:
 {
@@ -63,7 +60,6 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "Map_BrushRunScriptCodeKillT();1.051"
 		"OnStartTouch" "lvl_fail,Disable,,0.95,1"
 	}
 }


### PR DESCRIPTION
Castle Bridge:
- Change comment, since the item won't actually kill you at 1 hp; the ignite will just cause a stutter step (cause of fire slowdown plugin) and ruin the 200 hp by one or two, since the hp is set before fire would deal damage.

Minas Tirith:
- EW: Remove duplicate trigger id
- EW: Show explosive barrel on hud and chat to more easily identify who trolls when it is used to kill teammates

Skill Escape:
- Change ZM detector at end of map to only be enabled if zombies are at the top of the tower when their cage tp enables, rather than if they get up at all. The previous way made the final defense significantly harder than vanilla behavior for no apparent reason other than the potential to stop 'friendly zombies' from doing the lasers with the CTs.

Funny Runner:
- Block spots that avoid a ZM push and hiding spots at the end

Tyranny:
- Fix level 4 boss killer attack particle not showing if the killer attack is used twice in a row
- Clip up a common stuck spot area
- Fix nuke not killing all ZMs (?) It looks like the VScript nuke should kill all of them off, but apparently 1 survived somehow according to players. Just make it go off again 0.05 seconds after in case it was a perfect respawn or something and hopefully it is fixed, but it may well be a different issue I don't know of.
- Kill off fail detector if map is counted as a win so every round doesnt have the '>FAIL ROUND<' message at the end when CTs swap to both teams.