### PR TITLE
Modified zombiereloaded/ze_Knife_Stray_v3.cfg

### DIFF
--- a/zombiereloaded/ze_Knife_Stray_v3.cfg
+++ b/zombiereloaded/ze_Knife_Stray_v3.cfg
@@ -1,10 +1,10 @@
 mce_extend 0
-mp_respawn_immunitytime 2
 zr_class_modify zombies health 1
 zr_class_modify zombies health_infect_gain 0
 zr_class_modify zombies health_regen_interval 180
 zr_class_modify zombies health_regen_amount 0
 zr_infect_mzombie_ratio 5
+zr_infect_mzombie_respawn 0
 zr_infect_spawntime_min "5.0"
 zr_infect_spawntime_max "5.0"
 zr_restrict "Pistol"

--- a/zombiereloaded/ze_Knife_Stray_v3.cfg
+++ b/zombiereloaded/ze_Knife_Stray_v3.cfg
@@ -1,6 +1,10 @@
+mce_extend 0
+mp_respawn_immunitytime 2
 zr_class_modify zombies health 1
+zr_class_modify zombies health_infect_gain 0
 zr_class_modify zombies health_regen_interval 180
 zr_class_modify zombies health_regen_amount 0
+zr_infect_mzombie_ratio 5
 zr_infect_spawntime_min "5.0"
 zr_infect_spawntime_max "5.0"
 zr_restrict "Pistol"


### PR DESCRIPTION
- Remove extends
- Enable classic spawns to prevent spawn camping and CTs getting to camping spots first with some fun RNG
- Stop zms from gaining hp for stabbing a CT
- Increase zm ratio a bit, since it was too easy for CTs (may have to be rebalanced more, since spawn camping definately influenced balance)