### PR TITLE
Modified Multiple Files

### DIFF
--- a/entwatch/ze_8bit_csgo3.cfg
+++ b/entwatch/ze_8bit_csgo3.cfg
@@ -10,7 +10,7 @@
         "hasfiltername"     "false"
         "blockpickup"       "false"
         "allowtransfer"     "true"
-        "forcedrop"         "true"
+        "forcedrop"         "false"
         "chat"              "true"
         "hud"               "true"
         "hammerid"          "1201292"

--- a/entwatch/ze_rush_B_v2_2.cfg
+++ b/entwatch/ze_rush_B_v2_2.cfg
@@ -2,8 +2,8 @@
 {
     "0"
     {
-        "name"              "Jihad Item"
-        "shortname"         "Jihad"
+        "name"              "Zombie Jihad"
+        "shortname"         "ZM Jihad"
         "color"             "{green}"
         "buttonclass"       "func_button"
         "filtername"        ""
@@ -22,7 +22,7 @@
     }
     "1"
     {
-        "name"              "Money Item"
+        "name"              "Money"
         "shortname"         "Money"
         "color"             "{orange}"
         "buttonclass"       "func_button"
@@ -41,7 +41,7 @@
     }
     "2"
     {
-        "name"              "Laser Wall Item"
+        "name"              "Laser Wall"
         "shortname"         "Wall"
         "color"             "{orange}"
         "buttonclass"       "func_button"
@@ -60,8 +60,8 @@
     }
     "3"
     {
-        "name"              "Fidget Spinner"
-        "shortname"         "Spinner"
+        "name"              "Zombie Fidget Spinner"
+        "shortname"         "ZM Spinner"
         "color"             "{green}"
         "buttonclass"       "func_button"
         "filtername"        ""

--- a/stripper/ze_best_korea_v1.cfg
+++ b/stripper/ze_best_korea_v1.cfg
@@ -281,3 +281,265 @@ add:
 	"OnSpawn" "!selfRunScriptCodefunction b(){activator.SetVelocity(Vector(0,0,512));}11"
 	"OnSpawn" "!selfRunScriptCodeforeach(a,_ in {OnTrigger=0}){self.ConnectOutput(a, 'b'.tochar());}1.021"
 }
+
+;Add AFK tps on level 1 to prevent delaying CTs hiding in the spawn hills in spots near impossible for ZMs to get to them if defended
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "tp_afk_*,AddOutput,solid 2,0,1"
+		"OnMapSpawn" "tp_afk_1_1,AddOutput,mins -1856 -3712 -1024,0.5,1"
+		"OnMapSpawn" "tp_afk_1_1,AddOutput,maxs 1856 3712 1024,0.5,1"
+		"OnMapSpawn" "tp_afk_1_2,AddOutput,mins -768 -576 -1536,0.5,1"
+		"OnMapSpawn" "tp_afk_1_2,AddOutput,maxs 768 576 1536,0.5,1"
+		"OnMapSpawn" "tp_afk_1_3,AddOutput,mins -2240 -704 -1536,0.5,1"
+		"OnMapSpawn" "tp_afk_1_3,AddOutput,maxs 2240 704 1536,0.5,1"
+		"OnMapSpawn" "tp_afk_1_4,AddOutput,mins -1216 -1152 -1536,0.5,1"
+		"OnMapSpawn" "tp_afk_1_4,AddOutput,maxs 1216 1152 1536,0.5,1"
+		"OnMapSpawn" "tp_afk_1_5,AddOutput,mins -928 -2048 -2560,0.5,1"
+		"OnMapSpawn" "tp_afk_1_5,AddOutput,maxs 928 2048 2560,0.5,1"
+		"OnMapSpawn" "tp_afk_1_6,AddOutput,mins -64 -896 -160,0.5,1"
+		"OnMapSpawn" "tp_afk_1_6,AddOutput,maxs 64 896 160,0.5,1"
+		"OnMapSpawn" "tp_afk_2_1,AddOutput,mins -192 -192 -288,0.5,1"
+		"OnMapSpawn" "tp_afk_2_1,AddOutput,maxs 192 192 288,0.5,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"origin" "1728 941.76 384"
+	}
+	insert:
+	{
+		"OnStartTouch" "tp_afk_1_*,Enable,,41,1"
+	}
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"targetname" "tp_afk_1_1"
+	"spawnflags" "1"
+	"origin" "-192 -7552 0"
+	"target" "teleport_destination"
+	"CheckDestIfClearForPlayer" "0"
+	"StartDisabled" "1"
+	"UseLandmarkAngles" "1"
+	"filtername" "filter_ct"
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"targetname" "tp_afk_1_2"
+	"spawnflags" "1"
+	"origin" "-640 -3264 512"
+	"target" "teleport_destination"
+	"CheckDestIfClearForPlayer" "0"
+	"StartDisabled" "1"
+	"UseLandmarkAngles" "1"
+	"filtername" "filter_ct"
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"targetname" "tp_afk_1_3"
+	"spawnflags" "1"
+	"origin" "832 -1984 512"
+	"target" "teleport_destination"
+	"CheckDestIfClearForPlayer" "0"
+	"StartDisabled" "1"
+	"UseLandmarkAngles" "1"
+	"filtername" "filter_ct"
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"targetname" "tp_afk_1_4"
+	"spawnflags" "1"
+	"origin" "1856 -128 512"
+	"target" "teleport_destination"
+	"CheckDestIfClearForPlayer" "0"
+	"StartDisabled" "1"
+	"UseLandmarkAngles" "1"
+	"filtername" "filter_ct"
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"targetname" "tp_afk_1_5"
+	"spawnflags" "1"
+	"origin" "-96 3072 -512"
+	"target" "teleport_destination"
+	"CheckDestIfClearForPlayer" "0"
+	"StartDisabled" "1"
+	"UseLandmarkAngles" "1"
+	"filtername" "filter_ct"
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"targetname" "tp_afk_1_6"
+	"spawnflags" "1"
+	"origin" "1728 1920 576"
+	"target" "teleport_destination"
+	"CheckDestIfClearForPlayer" "0"
+	"StartDisabled" "1"
+	"UseLandmarkAngles" "1"
+	"filtername" "filter_ct"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"origin" "6720 1536 -736"
+	}
+	insert:
+	{
+		"OnStartTouch" "tp_afk_2_1,Enable,,51,1"
+	}
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"targetname" "tp_afk_2_1"
+	"spawnflags" "1"
+	"origin" "1856 3008 864"
+	"target" "teleport_destination"
+	"CheckDestIfClearForPlayer" "0"
+	"StartDisabled" "1"
+	"UseLandmarkAngles" "1"
+	"filtername" "filter_ct"
+}
+
+;Block level 1 top of hill exploit spot before tram building that players could reach by slowly climbing the hill and then surfing past a sky box brush
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "exploit_blocker_*,AddOutput,solid 2,0,1"
+		"OnMapSpawn" "exploit_blocker_1,AddOutput,mins -448 -192 -288,0.5,1"
+		"OnMapSpawn" "exploit_blocker_1,AddOutput,maxs 448 192 288,0.5,1"
+		"OnMapSpawn" "exploit_blocker_2,AddOutput,mins -1344 -896 -1056,0.5,1"
+		"OnMapSpawn" "exploit_blocker_2,AddOutput,maxs 1344 896 1056,0.5,1"
+		"OnMapSpawn" "exploit_blocker_3,AddOutput,mins -2112 -256 -1024,0.5,1"
+		"OnMapSpawn" "exploit_blocker_3,AddOutput,maxs 2112 256 1024,0.5,1"
+	}
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"targetname" "exploit_blocker_1"
+	"spawnflags" "1"
+	"origin" "2496 3008 864"
+	"target" "teleport_destination"
+	"CheckDestIfClearForPlayer" "0"
+	"UseLandmarkAngles" "1"
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"targetname" "exploit_blocker_2"
+	"spawnflags" "1"
+	"origin" "4672 1920 992"
+	"target" "teleport_destination"
+	"CheckDestIfClearForPlayer" "0"
+	"UseLandmarkAngles" "1"
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"targetname" "exploit_blocker_3"
+	"spawnflags" "1"
+	"origin" "8128 1280 1024"
+	"target" "teleport_destination"
+	"CheckDestIfClearForPlayer" "0"
+	"UseLandmarkAngles" "1"
+}
+
+;Block boosting zombies across the gap in level 1 to kill teammates at the end of the lift
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "boost_blocker,AddOutput,solid 2,0,1"
+		"OnMapSpawn" "boost_blocker,AddOutput,mins -224 -1280 -2560,0.5,1"
+		"OnMapSpawn" "boost_blocker,AddOutput,maxs 224 1280 2560,0.5,1"
+	}
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"targetname" "boost_blocker"
+	"spawnflags" "1"
+	"origin" "10464 2816 -512"
+	"target" "teleport_destination"
+	"CheckDestIfClearForPlayer" "0"
+	"UseLandmarkAngles" "1"
+}
+
+;Block level 2 using soldiers to skip past 2nd door and early trigger doors, which in turn led to an early zombie tp killing defenders
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "skip_blocker,AddOutput,solid 2,0,1"
+		"OnMapSpawn" "skip_blocker,AddOutput,mins -256 -32 -448,0.5,1"
+		"OnMapSpawn" "skip_blocker,AddOutput,maxs 256 32 448,0.5,1"
+	}
+}
+
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "skip_blocker"
+	"spawnflags" "1"
+	"origin" "-6400 -6688 320"
+	"wait" "0.02"
+	"StartDisabled" "0"
+	"OnStartTouch" "!activator,AddOutput,origin -6496 -6784 -128,0,-1"
+	"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(0,0,0));0-1"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "i_builder_hold_button"
+	}
+	insert:
+	{
+		"OnPressed" "skip_blocker,Kill,,40,1"
+	}
+}

--- a/stripper/ze_shroomforest2_p6.cfg
+++ b/stripper/ze_shroomforest2_p6.cfg
@@ -1,3 +1,17 @@
+;Move level 2 end ZM tp away from the web, so earth cant instant kill all zombies on tp by crushing them against the web
+modify:
+{
+	match:
+	{
+		"classname" "info_teleport_destination"
+		"origin" "-6859 -4398 2688"
+	}
+	replace:
+	{
+		"origin" "-6939 -4398 2688"
+	}
+}
+
 ;Prevent level 3 plank being broken by trolls to kill teammates by making it invincible until boss spawns in
 modify:
 {


### PR DESCRIPTION
8bit:
- EW: Change cannon forcedrop to false, since teammates cannot use the item anyways

Rush B:
- EW: Change zombie item names to include Zombie/ZM in them, and removed 'item' from the name

Best Korea:
- Add AFK tps on level 1 to prevent delaying CTs hiding in the spawn hills in spots near impossible for ZMs to get to them if defended
- Block level 1 top of hill exploit spot before tram building that players could reach by slowly climbing the hill and then surfing past a sky box brush
- Block boosting zombies across the gap in level 1 to kill teammates at the end of the lift
- Block level 2 using soldiers to skip past 2nd door and early trigger later doors, which in turn led to an early zombie tp killing defenders

Shroom Forest 2:
- Move level 2 end ZM tp away from the web, so earth cant instant kill all zombies on tp by crushing them against the web