### PR TITLE
Modified stripper/ze_666_crazy_escape_v2_4.cfg

### DIFF
--- a/stripper/ze_666_crazy_escape_v2_4.cfg
+++ b/stripper/ze_666_crazy_escape_v2_4.cfg
@@ -1,4 +1,4 @@
-;Add a 30 second timelimit to laser boss fight to prevent the last few players from knifing out and delaying lasers forever.
+;Add a 45 second timelimit to laser boss fight to prevent the last few players from knifing out and delaying lasers forever.
 modify:
 {
 	match:
@@ -8,16 +8,16 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "nrk2_laser_timer,Kill,,61,-1"
-		"OnStartTouch" "Console,Command,say ### YOU TOOK TOO LONG ###,61,1"
-		"OnStartTouch" "nrk2_laser_maker,AddOutput,angles 0 0 0,62,-1"
-		"OnStartTouch" "nrk2_laser_maker,AddOutput,origin 1024 7680 4128,63,-1"
-		"OnStartTouch" "nrk2_laser_maker,ForceSpawn,,63.02,-1"
-		"OnStartTouch" "nrk2_laser_maker,AddOutput,origin 1024 7680 4136,63.04,-1"
-		"OnStartTouch" "nrk2_laser_maker,ForceSpawn,,63.06,-1"
-		"OnStartTouch" "nrk2_laser_maker,AddOutput,origin 1024 7680 4168,63.08,-1"
-		"OnStartTouch" "nrk2_laser_maker,ForceSpawn,,63.1,-1"
-		"OnStartTouch" "nrk2_laser_sound,PlaySound,,63,-1"
+		"OnStartTouch" "nrk2_laser_timer,Kill,,76,-1"
+		"OnStartTouch" "Console,Command,say ### YOU TOOK TOO LONG ###,76,1"
+		"OnStartTouch" "nrk2_laser_maker,AddOutput,angles 0 0 0,77,-1"
+		"OnStartTouch" "nrk2_laser_maker,AddOutput,origin 1024 7680 4128,78,-1"
+		"OnStartTouch" "nrk2_laser_maker,ForceSpawn,,78.02,-1"
+		"OnStartTouch" "nrk2_laser_maker,AddOutput,origin 1024 7680 4136,78.04,-1"
+		"OnStartTouch" "nrk2_laser_maker,ForceSpawn,,78.06,-1"
+		"OnStartTouch" "nrk2_laser_maker,AddOutput,origin 1024 7680 4168,78.08,-1"
+		"OnStartTouch" "nrk2_laser_maker,ForceSpawn,,78.1,-1"
+		"OnStartTouch" "nrk2_laser_sound,PlaySound,,78,-1"
 	}
 }
 


### PR DESCRIPTION
- Increase laser timelimit by 15 seconds, since it is a bit short due to the stripper hp changes raising default boss hp

Can't judge this too accurately due to the gfl stripper buff on the laser boss hp making videos from other servers not representative, so kinda has to be trial and error a bit.