### PR TITLE
Enable stack damage fix for certain maps

### DIFF
--- a/zombiereloaded/ze_dreamin_v3_3.cfg
+++ b/zombiereloaded/ze_dreamin_v3_3.cfg
@@ -1,0 +1,1 @@
+sm_enable_hurt_fix 1

--- a/zombiereloaded/ze_visualizer_v1_2.cfg
+++ b/zombiereloaded/ze_visualizer_v1_2.cfg
@@ -1,0 +1,1 @@
+sm_enable_hurt_fix 1


### PR DESCRIPTION
These two maps have stack damage issues but I don't know why it was never enabled.

I know it'll make the map a lot easier, but the whole entire point of stack damage fix was to fix these issues that mappers looked over/ignored. 

I also know that these arent the only maps with stack damage issue. There are several other maps that need stack damage fix but cba to play all the maps on GFL.