### PR TITLE
Modified Configs

### DIFF
--- a/stripper/ze_biohazard_manor_004_p4.cfg
+++ b/stripper/ze_biohazard_manor_004_p4.cfg
@@ -1,3 +1,61 @@
+;Prevent zombies from getting stuck in the end helicopter and subsequently getting pulled forward (instead of backwards?? Thanks CS:GO physics!) causing a round loss for when it should be a win
+;Fix just TPs zombies at the very back of the helicopter out of it when the heli starts, since it is safe to assume the ZMs here would have been shot out anyways or are stuck
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "NoAccess"
+	"origin" "-1920 3648 784"
+	"spawnflags" "1"
+	"StartDisabled" "1"
+	"wait" "0.02"
+	"filtername" "zombie_filter"
+	"OnStartTouch" "!activator,AddOutput,origin -1650 3632 790,0,-1"
+	"OnStartTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(0,0,0))0.02-1"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "NoAccess,AddOutput,solid 2,0,1"
+		"OnMapSpawn" "NoAccess,AddOutput,mins -125 -128 -112,0.5,1"
+		"OnMapSpawn" "NoAccess,AddOutput,maxs 96 128 112,0.5,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "eli_07"
+	}
+	insert:
+	{
+		"OnTrigger" "NoAccess,Enable,,16,1"
+	}
+}
+
+;Add an env_wind to prevent carry over from previous maps
+add:
+{
+	"classname" "env_wind"
+	"minwind" "5"
+	"mingustdelay" "0"
+	"mingust" "1"
+	"maxwind" "10"
+	"maxgustdelay" "60"
+	"maxgust" "1"
+	"gustduration" "1"
+	"gustdirchange" "10"
+	"angles" "0 0 0"
+	"origin" "0 0 0"
+}
+
 ;fix flickering detailsprite dropping fps?
 add:
 {

--- a/stripper/ze_ffxii_westersand_v7_z9.cfg
+++ b/stripper/ze_ffxii_westersand_v7_z9.cfg
@@ -1,11 +1,3 @@
-;Changes:
-;	- Fix tp angles
-;	- Kill components of holy when lasers begin on all levels if the map has not yet been beaten fully at least once
-;	- Make it so that Earth doesn't block CTs during lasers.
-;	- Disable collision on Earth at exit door to airport that trolls (god gaymers) have taken to blocking the entire team so they get first shot at the item spawns outside
-;	- Prevent bridging in ZM mode to multiple spots that are unreachable to zombies by disabling earth collision
-;	- Make it so 2 boss fire attacks in a row doesn't occasionally have invisible fire
-
 ;Fix tp angles
 modify:
 {
@@ -230,6 +222,33 @@ modify:
 	{
 		"OnStartTouch" "Staff_Earth_Nonsolid_Relay,Enable,,8,-1"
 		"OnStartTouch" "Staff_Earth_Nonsolid_Relay,Disable,,18,-1"
+	}
+}
+
+;Disable collision on Earth during the dragon boss to prevent killing teammates with it
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "ZE_Easy_Button"
+	}
+	insert:
+	{
+		"OnPressed" "Staff_Earth_Nonsolid_Relay,Enable,,40,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Boss_Relay"
+	}
+	insert:
+	{
+		"OnTrigger" "Staff_Earth_Nonsolid_Relay,Disable,,10,-1"
 	}
 }
 

--- a/stripper/ze_outlast_v2_cm1_fix1.cfg
+++ b/stripper/ze_outlast_v2_cm1_fix1.cfg
@@ -10,6 +10,21 @@ modify:
 		"OnPressed" "Stage2_tp1AddOutputtarget Stage2_dest901"
 	}
 }
+
+;Prevent players from closing the level 2 boss door early
+modify:
+{
+	match:
+	{
+		"classname" "func_door"
+		"targetname" "/Ice_fall_trap\d/"
+	}
+	replace:
+	{
+		"spawnflags" "0"
+	}
+}
+
 ;fix zombies not tp when jumping to side railings
 add:
 {

--- a/stripper/ze_serpentis_temple_p2.cfg
+++ b/stripper/ze_serpentis_temple_p2.cfg
@@ -1,3 +1,53 @@
+;Make the collision of the snake mouth door a bit larger, so people can't hide in a spot Medusa cant target (might be able to avoid targetting in all doorways, but this is the spot commonly exploited). A better fix would be to allow targetting here, but cba to do that
+add:
+{
+	"targetname" "NoAccess"
+	"classname" "func_wall_toggle"
+	"origin" "-2522 6522 6829"
+	"angles" "0 0 0"
+	"model" "*226"
+	"rendermode" "10"
+}
+
+add:
+{
+	"targetname" "NoAccess"
+	"classname" "func_wall_toggle"
+	"origin" "-2522 6498 6794"
+	"angles" "0 0 0"
+	"model" "*227"
+	"rendermode" "10"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_door"
+		"targetname" "chamber_mouthdoor"
+	}
+	insert:
+	{
+		;Players will never be against the door when it closes due to timing on its inputs, so don't have to worry about them getting stuck in the invisible extended collision
+		"OnOpen" "NoAccess,AddOutput,solid 5,0,-1"
+		"OnFullyClosed" "NoAccess,AddOutput,solid 1,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_door"
+		"targetname" "chamber_mouthdoor"
+	}
+	insert:
+	{
+		"OnOpen" "NoAccess,Disable,,0,-1"
+		"OnFullyClosed" "NoAccess,Enable,,0,-1"
+	}
+}
+
 ;patch ammo for gfl ammo values
 modify:
 {

--- a/stripper/ze_serpentis_temple_p2.cfg
+++ b/stripper/ze_serpentis_temple_p2.cfg
@@ -34,20 +34,6 @@ modify:
 	}
 }
 
-modify:
-{
-	match:
-	{
-		"classname" "func_door"
-		"targetname" "chamber_mouthdoor"
-	}
-	insert:
-	{
-		"OnOpen" "NoAccess,Disable,,0,-1"
-		"OnFullyClosed" "NoAccess,Enable,,0,-1"
-	}
-}
-
 ;patch ammo for gfl ammo values
 modify:
 {

--- a/stripper/ze_skygarden_v2_1.cfg
+++ b/stripper/ze_skygarden_v2_1.cfg
@@ -1,0 +1,13 @@
+;Prevent the boss door from being blocked open
+modify:
+{
+	match:
+	{
+		"classname" "func_movelinear"
+		"targetname" "move_door_boss"
+	}
+	replace:
+	{
+		"blockdamage" "999999"
+	}
+}

--- a/stripper/ze_yurilnier_beta007_hdr.cfg
+++ b/stripper/ze_yurilnier_beta007_hdr.cfg
@@ -1,0 +1,17 @@
+;If zombies are the first to press a door button, kill off all CT players to prevent people from hiding, kind of like ze_journey
+;Don't worry about hiders as long as a group of CTs is still pressing door buttons, as it means the hiders aren't delaying the time yet
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "/lvl\d_btn\d+/"
+	}
+	insert:
+	{
+		"OnPressed" "!selfRunscriptcodeforeach (f, _ in {FireUser1=0});01"
+		"OnPressed" "!selfRunscriptcodeforeach (f, _ in {FireUser1=0}) if (activator.GetTeam()==2) EntFireByHandle(self,f,f,0,null,null);0.11"
+		"OnUser1" "map_serverSayCommandsay ** ZOMBIES HAVE REACHED THE DOOR FIRST, SLAYING HUMANS **11"
+		"OnUser1" "playerRunScriptCodeforeach (k, _ in {SetHealth=0}) if (self.GetTeam()==3 && self.GetHealth()>0) EntFireByHandle(self, k,(0).tostring(),0.1,null,null);21"
+	}
+}


### PR DESCRIPTION
Yurilnier:
- ZMs pressing door buttons first kills all CTs to prevent delaying

Outlast:
- Prevent players from closing the level 2 boss door early

SkyGarden:
- Prevent players from holding open the boss door

Westersand:
- Disable collision on Earth during the dragon boss to prevent killing teammates with it (per hh trolling with it here and there being no need to use the item during the boss other than to troll)

Biohazard manor:
- Add env_wind to prevent carryover from other maps
- Prevent Zombies from getting stuck in end heli and then turning a round that should have been a win into a loss

Serpentis:
- Make the collision of the snake mouth door a bit larger, so people can't hide in a spot Medusa cant target (actually tested this fix for once to make sure it didnt break other levels :>)