### PR TITLE
Modified stripper/ze_aooka_v3_t5.cfg

### DIFF
--- a/stripper/ze_aooka_v3_t5.cfg
+++ b/stripper/ze_aooka_v3_t5.cfg
@@ -1,3 +1,21 @@
+;nuke players when warmup ends so they cant endlessly delay (since mp_restartgame isnt whitelisted)
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Warmup_Relay"
+	}
+	delete:
+	{
+		"OnUser1" "CommandCommandmp_restartgame 152-1"
+	}
+	insert:
+	{
+		"OnUser1" "player,SetHealth,0,50,1"
+	}
+}
+
 ;workaround for effectively missing buyzone (there is one in spawn room, which players spend 0.05 secs in..)
 modify:
 {


### PR DESCRIPTION
- Fix warmup round not ending (use 50s delay instead of 52 because that is the proper time based on countdown in chat)