### PR TITLE
Updating some files

### DIFF
--- a/bosshud/ze_random_escape_gp4.txt
+++ b/bosshud/ze_random_escape_gp4.txt
@@ -6,4 +6,11 @@
 		"BreakableName" 	"ZombieMurder_Boss_Break"
 		"CustomText" 		"Droneship (Push)"
 	}
+
+	"1"
+	{
+		"Type"			"breakable"
+		"BreakableName"	"Zeal_Boss_Break"
+		"CustomText"	"Droneship"
+	}
 }

--- a/stripper/ze_boatescapex_b8.cfg
+++ b/stripper/ze_boatescapex_b8.cfg
@@ -210,3 +210,18 @@ modify:
 		"OnPressed" "T_SpaceshipTestActivator0-1"
 	}
 }
+
+;moving the tp destination at spawn a bit forward so afk zombies won't accidentally pick up the secret item...
+;...leaving the actual activator frozen in place.
+modify:
+{
+	match:
+	{
+		"classname" "info_teleport_destination"
+		"targetname" "BullshitDoorDestination"
+	}
+	replace:
+	{
+		"origin" "-832 -13824 257"
+	}
+}

--- a/stripper/ze_dark_souls_ptd_csgo2.cfg
+++ b/stripper/ze_dark_souls_ptd_csgo2.cfg
@@ -95,51 +95,6 @@ modify:
 	}
 }
 
-;Fix delay spot (left path trigger inside Sen's Fortress).
-add:
-{
-	"classname" "trigger_teleport"
-	"targetname" "the_sagi_incident_tp"
-	"target" "sagi_destination"
-	"origin" "3050 6496 1743.9"
-	"spawnflags" "1"
-	"UseLandmarkAngles" "1"
-	"StartDisabled" "1"
-	"CheckDestIfClearForPlayer" "0"
-}
-add:
-{
-	"classname" "info_teleport_destination"
-	"targetname" "sagi_destination"
-	"origin" "3486 6903 1423"
-	"angles" "0 0 0"
-}
-modify:
-{
-	match:
-	{
-		"classname" "logic_auto"
-	}
-	insert:
-	{
-		"OnMapSpawn" "the_sagi_incident_tp,AddOutput,solid 2,0.5,1"
-		"OnMapSpawn" "the_sagi_incident_tp,AddOutput,mins -354 -672 -200.1,1,1"
-		"OnMapSpawn" "the_sagi_incident_tp,AddOutput,maxs 354 672 200.1,1,1"
-	}
-}
-modify:
-{
-	match:
-	{
-		"classname" "math_counter"
-		"targetname" "Gate5_Counter"
-	}
-	insert:
-	{
-		"OnHitMax" "the_sagi_incident_tp,Enable,,10,-1"
-	}
-}
-
 ;Add blockdamage to the lift (left path trigger) inside Sen's Fortress so players won't delay, not sure why it hasn't been there in the first place.
 modify:
 {


### PR DESCRIPTION
Dark Souls:
- Removing the the TP avoidance spot fix, no longer needed as the mapper made the door stay opened after using the lever in the new version. The door used to open and then close permanently a few seconds after trigger, making it impossible to reach the spot when humans tried to camp.

Boat Escape X:
- Moving a TP destination to avoid AFKs accidentally picking up a certain item.

Random Escape:
- Adding another boss in the bosshud config.