### PR TITLE
Modify stripper/ze_sam_hd_v1_fix.cfg

### DIFF
--- a/stripper/ze_sam_hd_v1_fix.cfg
+++ b/stripper/ze_sam_hd_v1_fix.cfg
@@ -58,19 +58,6 @@ modify:
 	match:
 	{
 		"classname" "func_tracktrain"
-		"spawnflags" "24"
-	}
-	replace:
-	{
-		"spawnflags" "26"
-	}
-}
-
-modify:
-{
-	match:
-	{
-		"classname" "func_tracktrain"
 		"spawnflags" "25"
 	}
 	replace:


### PR DESCRIPTION
- Remove no user control flag from boss trains (specifically need to take it off great_boss_ugzhan_train), since somehow it causes the boss to spawn in the middle of the arena instead of the corner, insta killing CTs on teleport