### PR TITLE
Modify Multiple Configs

### DIFF
--- a/entwatch/ze_aooka_v3_t6_override.cfg
+++ b/entwatch/ze_aooka_v3_t6_override.cfg
@@ -156,7 +156,7 @@
     {
         "name"              "Zombie Shackles"
         "shortname"         "ZM Shackles"
-        "color"             "{darkred}"
+        "color"             "{purple}"
         "buttonclass"       "func_button"
         "filtername"        "Player_ZM_Shackles"
         "hasfiltername"     "true"
@@ -176,7 +176,7 @@
     {
         "name"              "Zombie Lure"
         "shortname"         "ZM Lure"
-        "color"             "{darkred}"
+        "color"             "{purple}"
         "buttonclass"       "func_button"
         "filtername"        "Player_ZM_Lure"
         "hasfiltername"     "true"
@@ -196,7 +196,7 @@
     {
         "name"              "Zombie Rise"
         "shortname"         "ZM Rise"
-        "color"             "{darkred}"
+        "color"             "{red}"
         "buttonclass"       "func_button"
         "filtername"        "Player_ZM_Rise"
         "hasfiltername"     "true"
@@ -216,7 +216,7 @@
     {
         "name"              "Zombie Shield"
         "shortname"         "ZM Shield"
-        "color"             "{darkred}"
+        "color"             "{green}"
         "buttonclass"       "func_button"
         "filtername"        "Player_ZM_Shield"
         "hasfiltername"     "true"
@@ -236,7 +236,7 @@
     {
         "name"              "Zombie IceFire"
         "shortname"         "ZM IceFire"
-        "color"             "{darkred}"
+        "color"             "{lightblue}"
         "buttonclass"       "func_button"
         "filtername"        "Player_ZM_IceFire"
         "hasfiltername"     "true"

--- a/stripper/ze_mgden_v2_5fix.cfg
+++ b/stripper/ze_mgden_v2_5fix.cfg
@@ -1,0 +1,18 @@
+;Remove swastika attack...
+modify:
+{
+	match:
+	{
+		"classname" "logic_case"
+		"targetname" "skill_case"
+	}
+	delete:
+	{
+		"OnCase05" "skill_5_relayTrigger0-1"
+		"OnCase07" "skill_6_relayTrigger0-1"
+	}
+	insert:
+	{
+		"OnCase05" "skill_6_relayTrigger0-1"
+	}
+}


### PR DESCRIPTION
- Remove swastika attack on mgden. Even if it isn't 'racist', it is just unneeded controversy/shock content in the map
- Recolor aooka zm items in entwatch to be more like actual item colors (as it was in the v3_t5 entwatch for the map)