### PR TITLE
Update pharos bhud

### DIFF
--- a/bosshud/ze_FFXIV_Pharos_Sirius_v1_6.txt
+++ b/bosshud/ze_FFXIV_Pharos_Sirius_v1_6.txt
@@ -28,10 +28,4 @@
 		"BreakableName"		"stage_savage_final_rock_body"
 		"CustomText"		"Rock Wall"
 	}
-	"5"
-	{
-		"Type"			"breakable"
-		"BreakableName"		"golem_body"
-		"CustomText"		"Golem"
-	}
 }


### PR DESCRIPTION
When the golem is summoned by the boss, it will not appear in the bhud, what this means is that no hitmarkers and no hp thing will appear on the screen, the boss can summon the golem infinitely once the boss dies or the boss is not defeated on time.