### PR TITLE
Update Johnny nukem bhud and Rabanastre stripper

### DIFF
--- a/bosshud/ze_johnny_nukem_go_b8_3a.txt
+++ b/bosshud/ze_johnny_nukem_go_b8_3a.txt
@@ -1,31 +1,21 @@
 "math_counter"
 {
-	"config"
-	{
-		"MultBoss"	"1"
-	}
 	"0"
-	{
-		"Type"	"breakable"
-		"BreakableName"	"NPCHitbox"
-		"CustomText"	"Nazi Soldier"
-	}
-	"1"
 	{
 		"HP_counter"	"frog_counter"
 		"CustomText"	"King of Frogs"
 	}
-	"2"
+	"1"
 	{
 		"HP_counter"	"frog2_counter"
 		"CustomText"	"Lego King IV"
 	}
-	"3"
+	"2"
 	{
 		"HP_counter"	"solid_paper_counter"
 		"CustomText"	"General Solid Paper"
 	}
-	"4"
+	"3"
 	{
 		"HP_counter"	"stage3_laser_counter"
 		"CustomText"	"Resurrected General Solid Paper"

--- a/stripper/ze_rabanastre_royal_t5.cfg
+++ b/stripper/ze_rabanastre_royal_t5.cfg
@@ -8,7 +8,6 @@
 ;	- The map default time might be a bit tight, increasing roundtime to not be short on the map
 ;	- Make item buttons less finicky to press
 ;	- Fix a TP avoidence spot on level 4
-;	- Remove an object that can screw people over if players bhop on their way to the lasers on level 4
 
 ;Make the first boss not get some players stuck when it spawns in
 add:
@@ -819,10 +818,4 @@ add:
 	"targetname" "TP_Bahamut_Boss"
 	"target" "TD_Bahamut_1"
 	"UseLandmarkAngles" "1"
-}
-
-;Why is this here? this can screw up the players if they bhop to the laser boss.
-filter:
-{
-	"origin" "-6776 7672 -11412"
 }

--- a/stripper/ze_rabanastre_royal_t5.cfg
+++ b/stripper/ze_rabanastre_royal_t5.cfg
@@ -824,5 +824,5 @@ add:
 ;Why is this here? this can screw up the players if they bhop to the laser boss.
 filter:
 {
-	"origin" "6776 7672 -11412"
+	"origin" "-6776 7672 -11412"
 }

--- a/stripper/ze_rabanastre_royal_t5.cfg
+++ b/stripper/ze_rabanastre_royal_t5.cfg
@@ -7,6 +7,8 @@
 ;	- Change up a boss attack name, since it is so similar to another attack that does something else. No need for confusion
 ;	- The map default time might be a bit tight, increasing roundtime to not be short on the map
 ;	- Make item buttons less finicky to press
+;	- Fix a TP avoidence spot on level 4
+;	- Remove an object that can screw people over if players bhop on their way to the lasers on level 4
 
 ;Make the first boss not get some players stuck when it spawns in
 add:

--- a/stripper/ze_rabanastre_royal_t5.cfg
+++ b/stripper/ze_rabanastre_royal_t5.cfg
@@ -793,3 +793,34 @@ modify:
 		"min_use_angle" "0.2"
 	}
 }
+
+;Patch some tp avoidence spots, this is a very rare spot to get to but it will still be needed due to avoiding nuke at the end.
+add:
+{
+	"classname" "trigger_teleport"
+	"model" "*15"
+	"origin" "-9832 4856 -11180"
+	"spawnflags" "4097"
+	"StartDisabled" "1"
+	"targetname" "TP_Bahamut_Boss"
+	"target" "TD_Bahamut_1"
+	"UseLandmarkAngles" "1"
+}
+
+add:
+{
+	"classname" "trigger_teleport"
+	"model" "*15"
+	"origin" "-9654 4856 -11180"
+	"spawnflags" "4097"
+	"StartDisabled" "1"
+	"targetname" "TP_Bahamut_Boss"
+	"target" "TD_Bahamut_1"
+	"UseLandmarkAngles" "1"
+}
+
+;Why is this here? this can screw up the players if they bhop to the laser boss.
+filter:
+{
+	"origin" "6776 7672 -11412"
+}


### PR DESCRIPTION
Johnny nukem:
- Remove multboss because theres no double boss and remove npc since it gets spawned multiple times.
Rabanastre royal: 
- Patch a TP avoidence spot after the boss dies on level 4, although its very rare to do, its still needed.