### PR TITLE
Restore "Paranoid" "Destroyer"

### DIFF
--- a/stripper/ze_paranoid_rezurrection_csgo1.cfg
+++ b/stripper/ze_paranoid_rezurrection_csgo1.cfg
@@ -1,10 +1,12 @@
-;fix game_player_equip dropping weapons and kevlar buying
+// "ze_paranoid_rezurrection_csgo1" config, made by "Berke" "STEAM_1:0:95142811", version 1.
+
+// Changes from "GFL".
+// Fix "game_player_equip" dropping weapons and fix kevlar buying.
 modify:
 {
 	match:
 	{
-		"classname" "game_player_equip"
-		"origin" "-4304 -13888 213.949"
+		"targetname" "darP90"
 	}
 	replace:
 	{
@@ -16,8 +18,7 @@ modify:
 	}
 }
 
-;why is this so low?
-modify:
+// Delete low buy time.
 {
 	match:
 	{
@@ -25,6 +26,59 @@ modify:
 	}
 	delete:
 	{
-		"OnMapSpawn" "consolaCommandmp_buytime 22-1"
+		"OnMapSpawn" "consola,Command,mp_buytime 22-1"
 	}
+}
+
+// Changes by "Berke".
+// Restore "Destroyer".
+{
+	match:
+	{
+		"origin" "-1942.5 5040 757.02"
+	}
+	insert:
+	{
+		"OnPressed" "!self,Kill,,,1"
+		"OnPressed" "map1destroyertemplate1,ForceSpawn,,,1"
+		"OnPressed" "map1destroyertemplate1,Kill,,.01,1"
+	}
+}
+
+add:
+{
+	"classname" "point_template"
+	"targetname" "map1destroyertemplate1"
+	"spawnflags" "2"
+	"Template01" "map1destroyer1*"
+}
+
+{
+	"classname" "prop_physics_override"
+	"targetname" "map1destroyer1prop1"
+	"origin" "-1495.24 5386.4 66"
+	"spawnflags" "5774"
+	"model" "models/props/de_dust/hr_dust/dust_soccerball/dust_soccer_ball001.mdl"
+	"effects" "32"
+}
+
+{
+	"classname" "info_particle_system"
+	"targetname" "map1destroyer1stuff1"
+	"parentname" "map1destroyer1prop1"
+	"origin" "-1493.24 5386.4 69.156"
+	"effect_name" "destruction_sphere"
+	"start_active" "1"
+}
+
+{
+	"classname" "trigger_hurt"
+	"targetname" "map1destroyer1stuff1"
+	"parentname" "map1destroyer1prop1"
+	"origin" "-1494.24 5385.4 70.5"
+	"spawnflags" "9"
+	"model" "*118"
+	"filtername" "nohumanos"
+	"damagetype" "512"
+	"damage" "100000"
 }

--- a/stripper/ze_paranoid_rezurrection_csgo1.cfg
+++ b/stripper/ze_paranoid_rezurrection_csgo1.cfg
@@ -26,7 +26,7 @@ modify:
 	}
 	delete:
 	{
-		"OnMapSpawn" "consola,Command,mp_buytime 22-1"
+		"OnMapSpawn" "consolaCommandmp_buytime 22-1"
 	}
 }
 

--- a/stripper/ze_paranoid_rezurrection_csgo1.cfg
+++ b/stripper/ze_paranoid_rezurrection_csgo1.cfg
@@ -6,6 +6,7 @@ modify:
 {
 	match:
 	{
+		"classname" "game_player_equip"
 		"targetname" "darP90"
 	}
 	replace:
@@ -19,6 +20,7 @@ modify:
 }
 
 // Delete low buy time.
+modify:
 {
 	match:
 	{
@@ -32,6 +34,7 @@ modify:
 
 // Changes by "Berke".
 // Restore "Destroyer".
+modify:
 {
 	match:
 	{
@@ -53,6 +56,7 @@ add:
 	"Template01" "map1destroyer1*"
 }
 
+add:
 {
 	"classname" "prop_physics_override"
 	"targetname" "map1destroyer1prop1"
@@ -62,6 +66,7 @@ add:
 	"effects" "32"
 }
 
+add:
 {
 	"classname" "info_particle_system"
 	"targetname" "map1destroyer1stuff1"
@@ -71,6 +76,7 @@ add:
 	"start_active" "1"
 }
 
+add:
 {
 	"classname" "trigger_hurt"
 	"targetname" "map1destroyer1stuff1"


### PR DESCRIPTION
Restores the "Destroyer" secret in the "LMS" room that was removed in the "CS:GO" port.