### PR TITLE
Enable Stack-Damage Fix on Hydroponic Garden

### DIFF
--- a/zombiereloaded/ze_hydroponic_garden_v1_1.cfg
+++ b/zombiereloaded/ze_hydroponic_garden_v1_1.cfg
@@ -1,0 +1,1 @@
+sm_enable_hurt_fix 1


### PR DESCRIPTION
Stage 4 laser minigame room has stack damage issues where players would be instantly killed if they happened to touch the laser while moving in the same direction when it wasn't designed to do so. 