### PR TITLE
Deathinvain: Properly lock Ava item until after the boss

### DIFF
--- a/entwatch/ze_deathinvain_palace_v1_9.cfg
+++ b/entwatch/ze_deathinvain_palace_v1_9.cfg
@@ -184,9 +184,9 @@
         "chat"              "true"
         "hud"               "true"
         "hammerid"          "360263"
-        "mode"              "4"
+        "mode"              "1"
         "maxuses"           "1"
-        "cooldown"          "15"
+        "cooldown"          "0"
         "maxamount"         "1"
     }
     "10"

--- a/entwatch/ze_deathinvain_palace_v2.cfg
+++ b/entwatch/ze_deathinvain_palace_v2.cfg
@@ -184,9 +184,9 @@
         "chat"              "true"
         "hud"               "true"
         "hammerid"          "360263"
-        "mode"              "4"
+        "mode"              "1"
         "maxuses"           "1"
-        "cooldown"          "15"
+        "cooldown"          "0"
         "maxamount"         "1"
     }
     "10"

--- a/stripper/ze_deathinvain_palace_v2.cfg
+++ b/stripper/ze_deathinvain_palace_v2.cfg
@@ -12,3 +12,17 @@ modify:
 		"y" "0.65"
 	}
 }
+
+;Properly disable AVA item until after the boss dies and L3_zavistend_relay sends an enable input to ava_relay
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "ava_relay"
+	}
+	replace:
+	{
+		"StartDisabled" "1"
+	}
+}


### PR DESCRIPTION
Entwatch mode is changed to 1, since if someone tries to use the item before it was enabled, entwatch would think it was depleted and lock the item, even though it wasn't actually used.

If there is a way to stripper change modes like darkerZ's entwatch's sm_ewsetmode, then simply add an equivalent of `OnTrigger CMDCommandsm_ewsetmode 360263 4 15 11-1` to L3_zavistend_relay