### PR TITLE
entWatch got_the_north: Fix maxamount for heal and ammo

### DIFF
--- a/entwatch/ze_got_the_north_csgo3.cfg
+++ b/entwatch/ze_got_the_north_csgo3.cfg
@@ -77,13 +77,13 @@
         "mode"              "3"
         "maxuses"           "1"
         "cooldown"          "0"
-        "maxamount"         "1"
+        "maxamount"         "8"
     }
     "4"
     {
         "name"              "Heal"
         "shortname"         "Heal"
-        "color"             "{lightgreen}"
+        "color"             "{default}"
         "buttonclass"       "func_button"
         "filtername"        ""
         "hasfiltername"     "false"
@@ -96,6 +96,6 @@
         "mode"              "3"
         "maxuses"           "1"
         "cooldown"          "0"
-        "maxamount"         "1"
+        "maxamount"         "8"
     }
 }


### PR DESCRIPTION
Heal and ammo appear to spawn about 5 times when max level is reached.