### PR TITLE
Modify Multiple Configs

### DIFF
--- a/bspconvar_whitelist/bspconvar_custom_whitelist.txt
+++ b/bspconvar_whitelist/bspconvar_custom_whitelist.txt
@@ -437,4 +437,8 @@
 	{
 		sm_gravity										1
 	}
+	"ze_v0u0v_csgo1"
+	{
+		sv_disable_radar								0
+	}
 }

--- a/stripper/ze_666_crazy_escape_v2_4.cfg
+++ b/stripper/ze_666_crazy_escape_v2_4.cfg
@@ -8,17 +8,40 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "nrk2_laser_timer,Kill,,91,-1"
-		"OnStartTouch" "Console,Command,say ### YOU TOOK TOO LONG ###,91,1"
-		"OnStartTouch" "nrk2_laser_maker,AddOutput,angles 0 0 0,92,-1"
-		"OnStartTouch" "nrk2_laser_maker,AddOutput,origin 1024 7680 4128,93,-1"
-		"OnStartTouch" "nrk2_laser_maker,ForceSpawn,,93.02,-1"
-		"OnStartTouch" "nrk2_laser_maker,AddOutput,origin 1024 7680 4136,93.04,-1"
-		"OnStartTouch" "nrk2_laser_maker,ForceSpawn,,93.06,-1"
-		"OnStartTouch" "nrk2_laser_maker,AddOutput,origin 1024 7680 4168,93.08,-1"
-		"OnStartTouch" "nrk2_laser_maker,ForceSpawn,,93.1,-1"
-		"OnStartTouch" "nrk2_laser_sound,PlaySound,,93,-1"
+		"OnStartTouch" "relay_lasers,Trigger,,0,1"
 	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "math_counter"
+		"targetname" "nrk2_boss_hp_iterations"
+	}
+	insert:
+	{
+		"OnHitMin" "relay_lasers,CancelPending,,0,-1"
+	}
+}
+
+add:
+{
+	"classname" "logic_relay"
+	"targetname" "relay_lasers"
+	"origin" "-1152 7680 4352"
+	"spawnflags" "0"
+	"StartDisabled" "0"
+	"OnTrigger" "nrk2_laser_timer,Kill,,91,-1"
+	"OnTrigger" "Console,Command,say ### YOU TOOK TOO LONG ###,91,1"
+	"OnTrigger" "nrk2_laser_maker,AddOutput,angles 0 0 0,92,-1"
+	"OnTrigger" "nrk2_laser_maker,AddOutput,origin 1024 7680 4128,93,-1"
+	"OnTrigger" "nrk2_laser_maker,ForceSpawn,,93.02,-1"
+	"OnTrigger" "nrk2_laser_maker,AddOutput,origin 1024 7680 4136,93.04,-1"
+	"OnTrigger" "nrk2_laser_maker,ForceSpawn,,93.06,-1"
+	"OnTrigger" "nrk2_laser_maker,AddOutput,origin 1024 7680 4168,93.08,-1"
+	"OnTrigger" "nrk2_laser_maker,ForceSpawn,,93.1,-1"
+	"OnTrigger" "nrk2_laser_sound,PlaySound,,93,-1"
 }
 
 ;buff boss hp

--- a/stripper/ze_ffvii_mako_reactor_v6_b09k2.cfg
+++ b/stripper/ze_ffvii_mako_reactor_v6_b09k2.cfg
@@ -1,3 +1,34 @@
+;rename this func_door to unlink it from a func_areaportal that is misplaced (since we can't edit areaportals in strippers)
+modify:
+{
+	match:
+	{
+		"classname" "func_door"
+		"targetname" "Button_Room_Door_Outer_B"
+	}
+	replace:
+	{
+		"targetname" "Button_Room_Door_Outer_C"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Button_Room_Block_Relay"
+	}
+	delete:
+	{
+		"OnTrigger" "Button_Room_Door_Outer_BOpen0-1"
+	}
+	insert:
+	{
+		"OnTrigger" "Button_Room_Door_Outer_COpen0-1"
+	}
+}
+
 ;fix logic_measure_movement targets i guess? idk was uncommented
 modify:
 {

--- a/stripper/ze_slender_escape_rc2.cfg
+++ b/stripper/ze_slender_escape_rc2.cfg
@@ -21,7 +21,7 @@ modify:
 	match:
 	{
 		"classname" "logic_case"
-		"targetname" "P_Forest_Case"
+		"targetname" "P_Forest_Case2"
 	}
 	insert:
 	{

--- a/stripper/ze_slender_escape_rc2.cfg
+++ b/stripper/ze_slender_escape_rc2.cfg
@@ -1,3 +1,38 @@
+;Fix a page that spawns inside of a rock prop, making it unobtainable
+modify:
+{
+	match:
+	{
+		"classname" "logic_case"
+		"targetname" "P_Forest_Case"
+	}
+	insert:
+	{
+		"OnCase03" "P_MakerAddOutputorigin 10850 -3000 -69440-1"
+	}
+	delete:
+	{
+		"OnCase03" "P_MakerAddOutputorigin 10752 -3232 -69440-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_case"
+		"targetname" "P_Forest_Case"
+	}
+	insert:
+	{
+		"OnCase03" "P_MakerAddOutputorigin 10380 -3425 -69600-1"
+	}
+	delete:
+	{
+		"OnCase03" "P_MakerAddOutputorigin 10208 -3232 -69600-1"
+	}
+}
+
 ;don't respawn zombies at the end of minigames to prevent server crashing
 modify:
 {

--- a/stripper/ze_sorrento_escape_v2.cfg
+++ b/stripper/ze_sorrento_escape_v2.cfg
@@ -1,3 +1,30 @@
+;prevent zombies from using the water to trigger repeat killer
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"origin" "105 -1057 -499"
+	}
+	replace:
+	{
+		"classname" "trigger_multiple"
+	}
+	insert:
+	{
+		"wait" "0.02"
+		"OnStartTouch" "!activator,SetHealth,0,0,-1"
+	}
+	delete:
+	{
+		"nodmgforce" "0"
+		"damagetype" "0"
+		"damagemodel" "0"
+		"damagecap" "20000"
+		"damage" "20000"
+	}
+}
+
 ;stop people from getting on a lamp to boost out of map
 add:
 {

--- a/stripper/ze_tyranny2_v1_csgo2.cfg
+++ b/stripper/ze_tyranny2_v1_csgo2.cfg
@@ -8,19 +8,42 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "s5boss_diablo_case,Kill,,60,-1"
-		"OnStartTouch" "command,Command,say >>> YOU TOOK TOO LONG <<<,60,1"
-		"OnStartTouch" "s5boss_diablo_model,SetAnimation,Attack,61.3,-1"
-		"OnStartTouch" "s5_boss_diablo_laser_temp,AddOutput,origin 3775 11045 8268,62,-1"
-		"OnStartTouch" "s5_boss_diablo_laser_temp,ForceSpawn,,62.02,-1"
-		"OnStartTouch" "s5boss_diablo_eff,DoSpark,,62.02,-1"
-		"OnStartTouch" "elecexp5_sound,PlaySound,,62.02,-1"
-		"OnStartTouch" "s5_boss_diablo_laser_temp,AddOutput,origin 3775 11045 8288,62.04,-1"
-		"OnStartTouch" "s5_boss_diablo_laser_temp,ForceSpawn,,62.06,-1"
-		"OnStartTouch" "s5_boss_diablo_laser_temp,AddOutput,origin 3775 11045 8310,62.08,-1"
-		"OnStartTouch" "s5_boss_diablo_laser_temp,ForceSpawn,,62.1,-1"
-		"OnStartTouch" "s5boss_diablo_model,SetAnimation,Stand,62.4,-1"
+		"OnStartTouch" "relay_lasers,Trigger,,0,1"
 	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_case"
+		"targetname" "bossdeath2"
+	}
+	insert:
+	{
+		"OnCase07" "relay_lasers,CancelPending,,0,-1"
+	}
+}
+
+add:
+{
+	"classname" "logic_relay"
+	"targetname" "relay_lasers"
+	"origin" "3775 12869 8372"
+	"spawnflags" "0"
+	"StartDisabled" "0"
+	"OnTrigger" "s5boss_diablo_case,Kill,,60,-1"
+	"OnTrigger" "command,Command,say >>> YOU TOOK TOO LONG <<<,60,1"
+	"OnTrigger" "s5boss_diablo_model,SetAnimation,Attack,61.3,-1"
+	"OnTrigger" "s5_boss_diablo_laser_temp,AddOutput,origin 3775 11045 8268,62,-1"
+	"OnTrigger" "s5_boss_diablo_laser_temp,ForceSpawn,,62.02,-1"
+	"OnTrigger" "s5boss_diablo_eff,DoSpark,,62.02,-1"
+	"OnTrigger" "elecexp5_sound,PlaySound,,62.02,-1"
+	"OnTrigger" "s5_boss_diablo_laser_temp,AddOutput,origin 3775 11045 8288,62.04,-1"
+	"OnTrigger" "s5_boss_diablo_laser_temp,ForceSpawn,,62.06,-1"
+	"OnTrigger" "s5_boss_diablo_laser_temp,AddOutput,origin 3775 11045 8310,62.08,-1"
+	"OnTrigger" "s5_boss_diablo_laser_temp,ForceSpawn,,62.1,-1"
+	"OnTrigger" "s5boss_diablo_model,SetAnimation,Stand,62.4,-1"
 }
 
 ;fix no kevlar on new round

--- a/stripper/ze_tyranny_v5_2k3.cfg
+++ b/stripper/ze_tyranny_v5_2k3.cfg
@@ -8,14 +8,37 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "map_command,Command,say >>> YOU TOOK TOO LONG <<<,49,-1"
-		"OnStartTouch" "bosslvl5_laser_timer,Kill,,49,-1"
-		"OnStartTouch" "bosslvl5_laser_down_temp,ForceSpawn,,50.5,-1"
-		"OnStartTouch" "bosslvl5_laser_up_temp,ForceSpawn,,50.5,-1"
-		"OnStartTouch" "bosslvl5_laser_mid_temp,ForceSpawn,,50.5,-1"
-		"OnStartTouch" "bosslvl5_laser_sound,PlaySound,,50.5,-1"
-		"OnStartTouch" "bosslvl5_laser_model,SetAnimation,balrog_attack1,50,-1"
+		"OnStartTouch" "relay_lasers,Trigger,,0,1"
 	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "math_counter"
+		"targetname" "bosslvl5_laser_counter"
+	}
+	insert:
+	{
+		"OnHitMin" "relay_lasers,CancelPending,,0,-1"
+	}
+}
+
+add:
+{
+	"classname" "logic_relay"
+	"targetname" "relay_lasers"
+	"origin" "10078 13679 3791.77"
+	"spawnflags" "0"
+	"StartDisabled" "0"
+	"OnTrigger" "map_command,Command,say >>> YOU TOOK TOO LONG <<<,49,-1"
+	"OnTrigger" "bosslvl5_laser_timer,Kill,,49,-1"
+	"OnTrigger" "bosslvl5_laser_down_temp,ForceSpawn,,50.5,-1"
+	"OnTrigger" "bosslvl5_laser_up_temp,ForceSpawn,,50.5,-1"
+	"OnTrigger" "bosslvl5_laser_mid_temp,ForceSpawn,,50.5,-1"
+	"OnTrigger" "bosslvl5_laser_sound,PlaySound,,50.5,-1"
+	"OnTrigger" "bosslvl5_laser_model,SetAnimation,balrog_attack1,50,-1"
 }
 
 ;remove unpacked sound

--- a/stripper/ze_v0u0v_csgo1.cfg
+++ b/stripper/ze_v0u0v_csgo1.cfg
@@ -1,0 +1,41 @@
+;If zombies are the first to trigger a door on level 1/ex 1, kill off all CT players to prevent people from hiding, kind of like ze_journey's triggers
+;Don't worry about hiders as long as a group of CTs is still triggering doors, as it means the hiders aren't delaying the time yet
+modify:
+{
+	match:
+	{
+		"classname" "filter_activator_team"
+		"targetname" "filter_zombie"
+	}
+	insert:
+	{
+		"OnPass" "commandCommandsay ** ZOMBIES HAVE REACHED THE DOOR FIRST, SLAYING HUMANS **11"
+		"OnPass" "playerRunScriptCodeforeach (k, _ in {SetHealth=0}) if (self.GetTeam()==3 && self.GetHealth()>0) EntFireByHandle(self, k,(0).tostring(),0.1,null,null);21"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "/s14door_\d_1/"
+	}
+	insert:
+	{
+		"OnPressed" "filter_zombieTestActivator01"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "/s14door_\d_1/"
+	}
+	insert:
+	{
+		"OnStartTouch" "filter_zombieTestActivator01"
+	}
+}


### PR DESCRIPTION
v0u0v:
- Prevent map from turning off radar for no reason, just cause porter was too lazy to add a minimap and hid it instead
- Prevent CTs from delaying on Level 1/ex 1 due to the lack of afk tps

Sorrento:
- Prevent the water from being used to trigger repeat killer with a zm tp on the docks

Slender:
- Fix an unobtainable page that spawns in a rock prop on the forest pages minigame.

666, tyranny, tyranny2:
- Prevent the 'out of time' lasers from activating after the boss was killed

Mako v6:
- Force a misplaced areaportal to always stay open to not cause visuals bugs (seeing the void)