### PR TITLE
doom3 stripper updates

### DIFF
--- a/entwatch/ze_doom3_v2.cfg
+++ b/entwatch/ze_doom3_v2.cfg
@@ -156,6 +156,7 @@
 		"hud"               "true"
 		"hammerid"          "2647191"
 		"mathid"            "2647288"
+		"buttonid"          "2647306"
 		"mode"              "7"
 		"maxuses"           "7"
 		"cooldown"          "15"

--- a/stripper/ze_doom3_v2.cfg
+++ b/stripper/ze_doom3_v2.cfg
@@ -796,7 +796,7 @@ modify:
 		"filtername" "zm"
 	}
 }
-; Surround stage 3 ending lava lake with trigger hurts to kill boosted zms from landing outside the map
+; Surround stage 3 ending lava lake with walls to stop boosted zms from landing outside the map
 add:
 {
 	"targetname" "strp_wall_1"

--- a/stripper/ze_doom3_v2.cfg
+++ b/stripper/ze_doom3_v2.cfg
@@ -268,6 +268,20 @@ modify:
 		"OnStartTouch" "strp_tp_stg2_startEnable101"
 	}
 }
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+		"hammerid" "135137"
+	}
+	insert:
+	{
+		"OnMapSpawn" "strp_tp_stg2_startAddOutputsolid 20.51"
+		"OnMapSpawn" "strp_tp_stg2_startAddOutputmins -1232 -1400 -111.511"
+		"OnMapSpawn" "strp_tp_stg2_startAddOutputmaxs 1232 1400 111.511"
+	}
+}
 ; Add tp avoidance stage 2 start area (1)
 add:
 {
@@ -278,6 +292,33 @@ add:
 	"StartDisabled" "1"
 	"target" "teler1"
 	"UseLandmarkAngles" "1"
+}
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+		"hammerid" "135137"
+	}
+	insert:
+	{
+		"OnMapSpawn" "strp_stg2_tp_avoidAddOutputsolid 20.51"
+		"OnMapSpawn" "strp_stg2_tp_avoidAddOutputmins -468 -352 -110.511"
+		"OnMapSpawn" "strp_stg2_tp_avoidAddOutputmaxs 468 352 110.511"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"hammerid" "2786"
+	}
+	insert:
+	{
+		"OnPressed" "strp_stg2_tp_avoidEnable321"
+		"OnPressed" "CmdCommandsay ** ZMs tp in 10s **221"
+	}
 }
 ; Add tp avoidance stage 2 (2)
 add:
@@ -396,39 +437,6 @@ add:
 	"spawnflags" "1"
 	"OnStartTouch" "!activatorAddOutputorigin -6441 11506 -41200-1"
 }
-; Add tp avoid for stage 3 (start area) (3 spots)
-add:
-{
-	"classname" "trigger_teleport"
-	"targetname" "strp_stg3_tp_avoid"
-	"spawnflags" "1"
-	"origin" "-7110 14200 -3822.5"
-	"StartDisabled" "1"
-	"target" "hellteleport"
-	"UseLandmarkAngles" "1"
-}
-add:
-{
-	"model" "*38"
-	"classname" "trigger_teleport"
-	"targetname" "stage3_mars_tp"
-	"spawnflags" "1"
-	"origin" "-8494.82 11267.6 -4021.5"
-	"StartDisabled" "1"
-	"target" "hellteleport"
-	"UseLandmarkAngles" "1"
-}
-add:
-{
-	"model" "*203"
-	"targetname" "stage3_mars_tp"
-	"classname" "trigger_teleport"
-	"origin" "-3303 13052.1 -3903.08"
-	"spawnflags" "1"
-	"StartDisabled" "1"
-	"target" "hellteleport"
-	"UseLandmarkAngles" "1"
-}
 ; Add tp to stage 2 that exists on css 
 add:
 {
@@ -449,7 +457,22 @@ modify:
 	}
 	insert:
 	{
-		"onpressed" "strp_tp_stg2_gapEnable321"
+		"OnPressed" "strp_tp_stg2_gapEnable321"
+		"OnPressed" "CmdCommandsay ** ZMs tp in 10s **221"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+		"hammerid" "135137"
+	}
+	insert:
+	{
+		"OnMapSpawn" "strp_tp_stg2_gapAddOutputsolid 20.51"
+		"OnMapSpawn" "strp_tp_stg2_gapAddOutputmins -2078 -718 -111.511"
+		"OnMapSpawn" "strp_tp_stg2_gapAddOutputmaxs 2078 718 111.511"
 	}
 }
 ; Nerf zm spider fireball (This nerf most likely needs tweaking)
@@ -475,7 +498,7 @@ modify:
 	}
 	replace:
 	{
-		"iMagnitude" "45"
+		"iMagnitude" "100"
 	}
 }
 ; Fix bfg math counter to reflect model (7 uses instead of 8)
@@ -557,10 +580,10 @@ add:
 	"classname" "trigger_multiple"
 	"targetname" "strp_stg3_tp_boss"
 	"spawnflags" "1"
-	"origin" "-11525 -9921.5 -262"
+	"origin" "-11525 -9593.5 -262"
 	"StartDisabled" "1"
 	"wait" "0"
-	"OnStartTouch" "!activatorAddOutputorigin -11568 -8250 -4880-1"
+	"OnStartTouch" "!activatorAddOutputorigin -11568 -8172 -4880-1"
 }
 modify:
 {
@@ -600,7 +623,54 @@ modify:
 		"OnTrigger" "minigun_particle1Start12-1"
 	}
 }
-; ======= LOGIC AUTO FOR CUSTOM SIZED TRIGGERS =======
+; Prevent ZMs from walking into stage 3 boss arena (tp avoidance)
+modify:
+{
+	match:
+	{
+		"classname" "trigger_teleport"
+		"targetname" "telehell1"
+	}
+	delete:
+	{
+		"OnStartTouch" "logs1Kill21"
+	}
+}
+; Fix npc models being invisible during stage 3 boss fight
+modify:
+{
+	match:
+	{
+		"classname" "env_entity_maker"
+		"hammerid" "1052347"
+	}
+	insert:
+	{
+		"OnEntitySpawned" "npc_ents_randomPickRandom0.55-1"
+	}
+}
+; Add (missing?) tp to stage 3 (also contains tp avoidance)
+add:
+{
+	"model" "*209"
+	"classname" "trigger_teleport"
+	"targetname" "strp_stg3_tp_gap"
+	"spawnflags" "1"
+	"StartDisabled" "1"
+	"target" "teler1"
+	"UseLandmarkAngles" "1"
+	"origin" "-5378 13091.5 -4051"
+}
+add:
+{
+	"classname" "trigger_teleport"
+	"targetname" "strp_stg3_tp_avoid"
+	"spawnflags" "1"
+	"origin" "-7110 14200 -3822.5"
+	"StartDisabled" "1"
+	"target" "teler1"
+	"UseLandmarkAngles" "1"
+}
 modify:
 {
 	match:
@@ -610,23 +680,498 @@ modify:
 	}
 	insert:
 	{
-		"OnMapSpawn" "strp_tp_stg2_startAddOutputsolid 20.51"
-		"OnMapSpawn" "strp_tp_stg2_startAddOutputmins -1232 -1400 -111.511"
-		"OnMapSpawn" "strp_tp_stg2_startAddOutputmaxs 1232 1400 111.511"
-
-		"OnMapSpawn" "strp_stg2_tp_avoidAddOutputsolid 20.51"
-		"OnMapSpawn" "strp_stg2_tp_avoidAddOutputmins -468 -352 -110.511"
-		"OnMapSpawn" "strp_stg2_tp_avoidAddOutputmaxs 468 352 110.511"
-		"OnMapSpawn" "strp_stg2_tp_avoidAddOutputtargetname porttele11.51"
-
 		"OnMapSpawn" "strp_stg3_tp_avoidAddOutputsolid 20.51"
 		"OnMapSpawn" "strp_stg3_tp_avoidAddOutputmins -478 -352 -110.511"
 		"OnMapSpawn" "strp_stg3_tp_avoidAddOutputmaxs 478 352 110.511"
-		"OnMapSpawn" "strp_stg3_tp_avoidAddOutputtargetname stage3_mars_tp1.51"
-
-		"OnMapSpawn" "strp_tp_stg2_gapAddOutputsolid 20.51"
-		"OnMapSpawn" "strp_tp_stg2_gapAddOutputmins -2078 -718 -111.511"
-		"OnMapSpawn" "strp_tp_stg2_gapAddOutputmaxs 2078 718 111.511"
+		"OnMapSpawn" "strp_stg3_tp_avoidAddOutputtargetname strp_stg3_tp_gap1.51"
 	}
 }
-; ======= LOGIC AUTO FOR CUSTOM SIZED TRIGGERS =======
+add:
+{
+	"model" "*38"
+	"classname" "trigger_teleport"
+	"targetname" "strp_stg3_tp_gap"
+	"spawnflags" "1"
+	"origin" "-8494.82 11267.6 -4021.5"
+	"StartDisabled" "1"
+	"target" "teler1"
+	"UseLandmarkAngles" "1"
+}
+add:
+{
+	"model" "*203"
+	"targetname" "strp_stg3_tp_gap"
+	"classname" "trigger_teleport"
+	"origin" "-3303 13052.1 -3903.08"
+	"spawnflags" "1"
+	"StartDisabled" "1"
+	"target" "teler1"
+	"UseLandmarkAngles" "1"
+}
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"hammerid" "2709"
+	}
+	insert:
+	{
+		"OnStartTouch" "CmdCommandsay ** ZMs tp in 5s **01"
+		"OnStartTouch" "strp_stg3_tp_gapEnable51"
+	}
+}
+; Add quality of life messages
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"hammerid" "419197"
+	}
+	insert:
+	{
+		"OnPressed" "cmdCommandsay *** Teleporter activating in 15s ***261"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "stage3_hell_die"
+	}
+	insert:
+	{
+		"OnTrigger" "CmdCommandsay ** Lift rising in 30s **751"
+		"OnTrigger" "CmdCommandsay ** Lift rising **1051"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "trigger_teleport"
+		"hammerid" "2673"
+	}
+	insert:
+	{
+		"OnStartTouch" "CmdCommandsay ** ZMs tp in 10s **01"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"hammerid" "3634"
+	}
+	insert:
+	{
+		"OnStartTouch" "CmdCommandsay ** ZMs tp in 10s **01"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"hammerid" "4060"
+	}
+	insert:
+	{
+		"OnStartTouch" "CmdCommandsay ** ZMs tp in 10s **01"
+	}
+}
+; Stage 3 lava lake should only tp zms
+modify:
+{
+	match:
+	{
+		"targetname" "stage3_hell_tp_lava"
+		"classname" "trigger_teleport"
+	}
+	replace:
+	{
+		"filtername" "zm"
+	}
+}
+; Surround stage 3 ending lava lake with trigger hurts to kill boosted zms from landing outside the map
+add:
+{
+	"targetname" "strp_wall_1"
+	"classname" "func_wall_toggle"
+	"rendermode" "10"
+	"origin" "-10848 -5160 6459"
+}
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+		"hammerid" "135137"
+	}
+	insert:
+	{
+		"OnMapSpawn" "strp_wall_1AddOutputsolid 20.51"
+		"OnMapSpawn" "strp_wall_1AddOutputmins -4576 -680 -269311"
+		"OnMapSpawn" "strp_wall_1AddOutputmaxs 4576 680 269311"
+	}
+}
+add:
+{
+	"targetname" "strp_wall_2"
+	"classname" "func_wall_toggle"
+
+	"origin" "-10976 1280 6496"
+}
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+		"hammerid" "135137"
+	}
+	insert:
+	{
+		"OnMapSpawn" "strp_wall_2AddOutputsolid 20.51"
+		"OnMapSpawn" "strp_wall_2AddOutputmins -4608 -464 -269311"
+		"OnMapSpawn" "strp_wall_2AddOutputmaxs 4608 464 269311"
+	}
+}
+add:
+{
+	"targetname" "strp_wall_3"
+	"classname" "func_wall_toggle"
+	"rendermode" "10"
+	"origin" "-6016 -2024 6400"
+}
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+		"hammerid" "135137"
+	}
+	insert:
+	{
+		"OnMapSpawn" "strp_wall_3AddOutputsolid 20.51"
+		"OnMapSpawn" "strp_wall_3AddOutputmins -400 -3816 -262411"
+		"OnMapSpawn" "strp_wall_3AddOutputmaxs 400 3816 262411"
+	}
+}
+add:
+{
+	"targetname" "strp_wall_4"
+	"classname" "func_wall_toggle"
+	"rendermode" "10"
+	"origin" "-15656.4 -2062.58 6427"
+}
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+		"hammerid" "135137"
+	}
+	insert:
+	{
+		"OnMapSpawn" "strp_wall_4AddOutputsolid 20.51"
+		"OnMapSpawn" "strp_wall_4AddOutputmins -400 -3816 -262411"
+		"OnMapSpawn" "strp_wall_4AddOutputmaxs 400 3816 262411"
+	}
+}
+; Remove tp avoidance in stage 3, 2nd boss fight
+add:
+{
+	"model" "*222"
+	"targetname" "stage3_end_tp_hell"
+	"classname" "trigger_teleport"
+	"StartDisabled" "1"
+	"spawnflags" "1"
+	"UseLandmarkAngles" "1"
+	"origin" "-1477.5 -3984 8381.5"
+}
+add:
+{
+	"model" "*316"
+	"origin" "1974.21 -5294.05 7615"
+	"classname" "func_wall_toggle"
+	"rendermode" "10"
+}
+; Surround stage 3 boss 2 lava lake with walls to stop boosted zms from landing outside the map
+add:
+{
+	"targetname" "strp_wall_5"
+	"classname" "func_wall_toggle"
+	"rendermode" "10"
+	"origin" "376 -2736 8736"
+}
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+		"hammerid" "135137"
+	}
+	insert:
+	{
+		"OnMapSpawn" "strp_wall_5AddOutputsolid 20.51"
+		"OnMapSpawn" "strp_wall_5AddOutputmins -1944 -152 -150411"
+		"OnMapSpawn" "strp_wall_5AddOutputmaxs 1944 152 150411"
+	}
+}
+add:
+{
+	"targetname" "strp_wall_6"
+	"classname" "func_wall_toggle"
+	"rendermode" "10"
+	"origin" "-1320 -4224 8736"
+}
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+		"hammerid" "135137"
+	}
+	insert:
+	{
+		"OnMapSpawn" "strp_wall_6AddOutputsolid 20.51"
+		"OnMapSpawn" "strp_wall_6AddOutputmins -264 -1440 -150411"
+		"OnMapSpawn" "strp_wall_6AddOutputmaxs 264 1440 150411"
+	}
+}
+add:
+{
+	"targetname" "strp_wall_7"
+	"classname" "func_wall_toggle"
+	"rendermode" "10"
+	"origin" "824 -5752 8752"
+}
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+		"hammerid" "135137"
+	}
+	insert:
+	{
+		"OnMapSpawn" "strp_wall_7AddOutputsolid 20.51"
+		"OnMapSpawn" "strp_wall_7AddOutputmins -1944 -152 -150411"
+		"OnMapSpawn" "strp_wall_7AddOutputmaxs 1944 152 150411"
+	}
+}
+; Stages 1 and 2 if zm enters the ending, nuke should kill cts
+add:
+{
+	"model" "*211"
+	"classname" "trigger_hurt"
+	"targetname" "strp_stg2_ct_nuke"
+	"origin" "-4290.15 14292.8 -11744.9"
+	"StartDisabled" "1"
+	"spawnflags" "1"
+	"filtername" "Filter_Team_Humans"
+	"damage" "99999"
+}
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "zm_detec"
+	}
+	delete:
+	{
+		"OnStartTouch" "nukeEnable5-1"
+	}
+	insert:
+	{
+		"OnStartTouch" "strp_stg2_ct_nukeEnable5-1"
+		"OnStartTouch" "nukeEnable10-1"
+	}
+}
+add:
+{
+	"model" "*271"
+	"classname" "trigger_hurt"
+	"targetname" "strp_stg1_ct_nuke"
+	"origin" "-5707 11709 -4096"
+	"StartDisabled" "1"
+	"spawnflags" "1"
+	"filtername" "Filter_Team_Humans"
+	"damage" "99999"
+}
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "stage1_zmwin"
+	}
+	delete:
+	{
+		"OnStartTouch" "nukeEnable51"
+	}
+	insert:
+	{
+		"OnStartTouch" "strp_stg1_ct_nukeEnable51"
+		"OnStartTouch" "nukeEnable101"
+	}
+}
+; Stage 2 tp before boss fight, if cts are doorhugging back of teleporter they can miss the tp
+add:
+{
+	"model" "*183"
+	"classname" "trigger_teleport"
+	"targetname" "stage2_teleport"
+	"target" "kren"
+	"StartDisabled" "1"
+	"spawnflags" "1"
+	"UseLandmarkAngles" "1"
+	"origin" "-3103 10575.5 -5125.5"
+}
+; Make bfg item hurt more on center
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "bfg_hurt"
+	}
+	replace:
+	{
+		"origin" "-7442.29 14130.3 -4024.22"
+	}
+}
+; Move heal trigger more on center
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "Item_Heal_Trigger"
+	}
+	replace:
+	{
+		"origin" "-6563.5 13418 -4104.5"
+	}
+}
+; Fix ZM Skeleton triggering explosion too many times when CTs were stacked together (this is also a massive nerf)
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "hurtskeleton"
+	}
+	delete:
+	{
+		"OnStartTouch" "gila3Explode0.1-1"
+		"OnStartTouch" "gila3ClearParent0-1"
+		"OnStartTouch" "revenant_attack_relayTrigger1-1"
+	}
+	insert:
+	{
+		"OnStartTouch" "gila3Explode0.051"
+		"OnStartTouch" "gila3ClearParent01"
+		"OnStartTouch" "revenant_attack_relayTrigger0.11"
+	}
+}
+; Remake bfg and rocket templates so they spawn with name fixup. measure.nut set both player's targetname to Owner instead of, for example, Owner&0047. Without this, if bfg
+; and rocket were both held by players, one of the items (model, button, etc) would attempt to shift to the other player essentially making only one of them work.
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "bfg_launcher_spawn"
+	}
+	delete:
+	{
+		"OnEntitySpawned" "test_weapon1ToggleCanBePickedUp0.5-1"
+	}
+	replace:
+	{
+		"spawnflags" "0"
+	}
+}
+modify:
+{
+	match:
+	{
+		"targetname" "test_relay1"
+		"classname" "logic_relay"
+	}
+	insert:
+	{
+		"OnSpawn" "test_weapon1ToggleCanBePickedUp0.1-1"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "rocket_launcher_spawn"
+	}
+	delete:
+	{
+		"OnEntitySpawned" "test_weaponToggleCanBePickedUp0.5-1"
+	}
+	replace:
+	{
+		"spawnflags" "0"
+	}
+}
+modify:
+{
+	match:
+	{
+		"targetname" "test_relay"
+		"classname" "logic_relay"
+	}
+	insert:
+	{
+		"OnSpawn" "test_weaponToggleCanBePickedUp0.1-1"
+	}
+}
+; Same as above but with the zm skeleton and zm spider
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "pauk_template_skin"
+	}
+	replace:
+	{
+		"spawnflags" "0"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "skin_template_revenant"
+	}
+	replace:
+	{
+		"spawnflags" "0"
+	}
+}
+; According to heart item game text, it should deal damage to bosses
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "heart_relay"
+	}
+	insert:
+	{
+		"OnTrigger" "pirate_counterSubtract1200-1"
+	}
+}

--- a/stripper/ze_doom3_v2.cfg
+++ b/stripper/ze_doom3_v2.cfg
@@ -1176,3 +1176,28 @@ modify:
 		"OnTrigger" "pirate_counterSubtract1200-1"
 	}
 }
+; Make heal a trigger_hurt instead of healing by OnStartTouch
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "Item_Heal_Trigger"
+	}
+	replace:
+	{
+		"classname" "trigger_hurt"
+	}
+	delete:
+	{
+		"OnStartTouch" "!activatorAddOutputhealth 2200-1"
+	}
+	insert:
+	{
+		"damage" "-100"
+		"damagetype" "0"
+		"damagemodel" "0"
+		"damagecap" "20"
+		"OnStartTouch" "!activatorAddOutputmax_health 2200-1"
+	}
+}

--- a/stripper/ze_doom3_v2.cfg
+++ b/stripper/ze_doom3_v2.cfg
@@ -887,6 +887,7 @@ add:
 	"model" "*222"
 	"targetname" "stage3_end_tp_hell"
 	"classname" "trigger_teleport"
+	"target" "hell_tp1"
 	"StartDisabled" "1"
 	"spawnflags" "1"
 	"UseLandmarkAngles" "1"

--- a/stripper/ze_doom3_v2.cfg
+++ b/stripper/ze_doom3_v2.cfg
@@ -38,7 +38,7 @@ add:
 	"spawnflags" "1"
 }
 
-;stop zms from walking into tp free area after 1st lvl 3 boss dies?
+;Adds a slight delay from letting cts walk out of arena after 1st lvl 3 boss dies
 modify:
 {
 	match:
@@ -186,45 +186,31 @@ modify:
 		"OnTrigger" "item_bfg_launcher_modelColor255 255 255 15-1"
 	}
 }
-; Remake bfg button as npcclip instead of nodraw (seems like flag 16384 didnt work well)
-filter:
+; Adjust use angle for bfg button
+modify:
 {
-	"classname" "func_button"
-	"targetname" "test_button1"
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "test_button1"
+	}
+	replace:
+	{
+		"min_use_angle" "0"
+	}
 }
-add:
+; Adjust use angle for rocket button
+modify:
 {
-	"model" "*27"
-	"classname" "func_button"
-	"targetname" "test_button1"
-	"spawnflags" "1025"
-	"origin" "-7376.08 14212.5 -4028.76"
-	"vscripts" "testmike/button.nut"
-	"wait" "0"
-	"min_use_angle" "0.8"
-	"parentname" "test_center_move1"
-	"OnPressed" "!selfRunScriptCodefilter();0-1"
-	"OnUser4" "bfg_relayTrigger0.05-1"
-}
-; Remake rocket button as npcclip (same reasoning as above)
-filter:
-{
-	"classname" "func_button"
-	"targetname" "test_button"
-}
-add:
-{
-	"model" "*27"
-	"classname" "func_button"
-	"targetname" "test_button"
-	"spawnflags" "1025"
-	"origin" "-7203.01 13380.5 -4145.76"
-	"vscripts" "testmike/button.nut"
-	"wait" "0"
-	"min_use_angle" "0.8"
-	"parentname" "test_center_move"
-	"OnPressed" "!selfRunScriptCodefilter();0-1"
-	"OnUser4" "rocket_relayTrigger0.05-1"
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "test_button"
+	}
+	replace:
+	{
+		"min_use_angle" "0"
+	}
 }
 ; Fix rocket relay timing exceeding item cooldown. Also lock the button on use.
 modify:
@@ -488,19 +474,6 @@ modify:
 		"damage" "100"
 	}
 }
-; Nerf zm skeleton firebomb (This nerf most likely needs tweaking)
-modify:
-{
-	match:
-	{
-		"classname" "env_explosion"
-		"targetname" "gila3"
-	}
-	replace:
-	{
-		"iMagnitude" "100"
-	}
-}
 ; Fix bfg math counter to reflect model (7 uses instead of 8)
 modify:
 {
@@ -634,6 +607,10 @@ modify:
 	delete:
 	{
 		"OnStartTouch" "logs1Kill21"
+	}
+	insert:
+	{
+		"OnStartTouch" "logs1Kill101"
 	}
 }
 ; Fix npc models being invisible during stage 3 boss fight
@@ -1046,20 +1023,7 @@ modify:
 		"origin" "-7442.29 14130.3 -4024.22"
 	}
 }
-; Move heal trigger more on center
-modify:
-{
-	match:
-	{
-		"classname" "trigger_multiple"
-		"targetname" "Item_Heal_Trigger"
-	}
-	replace:
-	{
-		"origin" "-6563.5 13418 -4104.5"
-	}
-}
-; Fix ZM Skeleton triggering explosion too many times when CTs were stacked together (this is also a massive nerf)
+; Fix ZM Skeleton triggering explosion too many times when CTs were stacked together
 modify:
 {
 	match:
@@ -1080,7 +1044,20 @@ modify:
 		"OnStartTouch" "revenant_attack_relayTrigger0.11"
 	}
 }
-; Remake bfg and rocket templates so they spawn with name fixup. measure.nut set both player's targetname to Owner instead of, for example, Owner&0047. Without this, if bfg
+; Adjust zm skeleton firebomb (This may need tweaking)
+modify:
+{
+	match:
+	{
+		"classname" "env_explosion"
+		"targetname" "gila3"
+	}
+	replace:
+	{
+		"iMagnitude" "100"
+	}
+}
+; Adjust bfg and rocket templates so they spawn with name fixup. measure.nut set both player's targetname to Owner instead of, for example, Owner&0047. Without this, if bfg
 ; and rocket were both held by players, one of the items (model, button, etc) would attempt to shift to the other player essentially making only one of them work.
 modify:
 {
@@ -1176,7 +1153,7 @@ modify:
 		"OnTrigger" "pirate_counterSubtract1200-1"
 	}
 }
-; Make heal a trigger_hurt instead of healing by OnStartTouch
+; Make heal a trigger_hurt instead of healing by OnStartTouch and move it more on center
 modify:
 {
 	match:
@@ -1186,6 +1163,7 @@ modify:
 	}
 	replace:
 	{
+		"origin" "-6563.5 13418 -4104.5"
 		"classname" "trigger_hurt"
 	}
 	delete:


### PR DESCRIPTION
This should fix everything revealed from the last map test. Hopefully all items that seemed to be randomly buggy (bfg, rocket, zm skele, zm spider) should work now. I had already left it as a comment, but there was a bug where the zm skeleton rocket would cause an explosion per ct that it hit, even after the initial explosion. Fixing this nerfed the item quite a bit so I buffed it a little beyond the default value. 