### PR TITLE
Fix doom3: small gap where items wouldnt work

### DIFF
--- a/stripper/ze_doom3_v2.cfg
+++ b/stripper/ze_doom3_v2.cfg
@@ -196,7 +196,7 @@ modify:
 	}
 	replace:
 	{
-		"min_use_angle" "0"
+		"min_use_angle" "-0.4"
 	}
 }
 ; Adjust use angle for rocket button
@@ -209,7 +209,7 @@ modify:
 	}
 	replace:
 	{
-		"min_use_angle" "0"
+		"min_use_angle" "-0.4"
 	}
 }
 ; Fix rocket relay timing exceeding item cooldown. Also lock the button on use.


### PR DESCRIPTION
Even with min_use_angle set to 0 there was a small gap where rocket and bfg won't work. -0.4 seems to be fine.