### PR TITLE
Update: doom3

### DIFF
--- a/entwatch/ze_doom3_v2.cfg
+++ b/entwatch/ze_doom3_v2.cfg
@@ -135,6 +135,7 @@
 		"hud"               "true"
 		"hammerid"          "2644565"
 		"mathid"            "2644548"
+		"buttonid"          "2644557"
 		"mode"              "7"
 		"maxuses"           "10"
 		"cooldown"          "13"

--- a/stripper/ze_doom3_v2.cfg
+++ b/stripper/ze_doom3_v2.cfg
@@ -303,7 +303,6 @@ modify:
 	insert:
 	{
 		"OnPressed" "strp_stg2_tp_avoidEnable321"
-		"OnPressed" "CmdCommandsay ** ZMs tp in 10s **221"
 	}
 }
 ; Add tp avoidance stage 2 (2)
@@ -1153,7 +1152,7 @@ modify:
 		"OnTrigger" "pirate_counterSubtract1200-1"
 	}
 }
-; Make heal a trigger_hurt instead of healing by OnStartTouch and move it more on center
+; Make heal a trigger_hurt in addition to healing by OnStartTouch and move it more on center
 modify:
 {
 	match:
@@ -1166,10 +1165,6 @@ modify:
 		"origin" "-6563.5 13418 -4104.5"
 		"classname" "trigger_hurt"
 	}
-	delete:
-	{
-		"OnStartTouch" "!activatorAddOutputhealth 2200-1"
-	}
 	insert:
 	{
 		"damage" "-100"
@@ -1177,5 +1172,216 @@ modify:
 		"damagemodel" "0"
 		"damagecap" "20"
 		"OnStartTouch" "!activatorAddOutputmax_health 2200-1"
+	}
+}
+; Add glow to NPCs
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic"
+		"targetname" "npc_model4"
+	}
+	replace:
+	{
+		"classname" "prop_dynamic_glow"
+	}
+	insert:
+	{
+		"glowdist" "3096"
+		"glowcolor" "255 0 0"
+		"glowstyle" "0"
+		"glowenabled" "1"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic"
+		"targetname" "npc_model5_6"
+	}
+	replace:
+	{
+		"classname" "prop_dynamic_glow"
+	}
+	insert:
+	{
+		"glowdist" "3096"
+		"glowcolor" "255 95 95"
+		"glowstyle" "0"
+		"glowenabled" "1"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic"
+		"targetname" "npc_model5"
+	}
+	replace:
+	{
+		"classname" "prop_dynamic_glow"
+	}
+	insert:
+	{
+		"glowdist" "3096"
+		"glowcolor" "255 95 95"
+		"glowstyle" "0"
+		"glowenabled" "1"
+	}
+}
+; Fix stage 3 1st boss hurt triggers
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "pr2_kp1"
+	}
+	replace:
+	{
+		"StartDisabled" "1"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "Noctali_Boss_Hp_To_Boss1"
+	}
+	insert:
+	{
+		"OnStartTouch" "pr2_kp1Enable151"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "logh1"
+	}
+	replace:
+	{
+		"origin" "-11917 -5081.5 -371"
+	}
+	insert:
+	{
+		"parentname" "Noctali_Boss_Break1"
+	}
+}
+; Small NPC nerfs
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox_multiplayer"
+		"targetname" "npc_phys2gg2"
+	}
+	replace:
+	{
+		"health" "3600"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox_multiplayer"
+		"targetname" "npc_phys2gg3"
+	}
+	replace:
+	{
+		"health" "1200"
+	}
+}
+; Make stage 3 rotating boss move a little faster
+modify:
+{
+	match:
+	{
+		"classname" "func_tracktrain"
+		"targetname" "stage3_train_demon"
+	}
+	replace:
+	{
+		"startspeed" "280"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stage3_path_demon12"
+	}
+	replace:
+	{
+		"speed" "270"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stage3_path_demon12_1"
+	}
+	replace:
+	{
+		"speed" "270"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stage3_path_demon7"
+	}
+	replace:
+	{
+		"speed" "270"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stage3_path_demon7_1"
+	}
+	replace:
+	{
+		"speed" "270"
+	}
+}
+; Prevent repeat killer for stage 3 tp
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"origin" "-510.5 12729.5 -4728"
+	}
+	replace:
+	{
+		"classname" "trigger_multiple"
+	}
+	delete:
+	{
+		"nodmgforce" "0"
+		"damagetype" "0"
+		"damagemodel" "0"
+		"damagecap" "90000"
+		"damage" "90000"
+	}
+	insert:
+	{
+		"wait" "0"
+		"OnTrigger" "!activatorSetHealth00-1"
 	}
 }


### PR DESCRIPTION
- Gave a glow to the NPCs since the map is fairly dark
- Previous commit removed setting the health to 220 when touching the trigger but was re-added. Makes it too hard on moving parts of the map such as stage 3 rotating boss. 
- Stage 3 rotating boss, max speed for the train now set to 280. The speed of the boss now fluctuates between 230 and 280 speed when passing some tracks.
- Stage 3 first boss, trigger_hurt in middle of arena wasn't parented to the boss.
- Nerfed the health of the NPCs slightly. The larger NPC now has 400 less health and the smaller NPCs have 300 less health.
- Removed a repeating message
- Prevent repeat killer for added tp on stage 3
- Add buttonid to mini