### PR TITLE
doom3 changes

### DIFF
--- a/stripper/ze_doom3_v2.cfg
+++ b/stripper/ze_doom3_v2.cfg
@@ -351,7 +351,7 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "!activatorAddContextzm_user:10-1"
+		"OnStartTouch" "!activatorAddContextzm_item_spider:10-1"
 	}
 }
 modify:
@@ -363,7 +363,7 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "!activatorAddContextzm_user:10-1"
+		"OnStartTouch" "!activatorAddContextzm_item_pinky:10-1"
 	}
 }
 modify:
@@ -375,7 +375,7 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "!activatorAddContextzm_user:10-1"
+		"OnStartTouch" "!activatorAddContextzm_item_m_spider:10-1"
 	}
 }
 modify:
@@ -387,7 +387,7 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "!activatorAddContextzm_user:10-1"
+		"OnStartTouch" "!activatorAddContextzm_item_skele:10-1"
 	}
 }
 modify:
@@ -405,11 +405,47 @@ modify:
 }
 add:
 {
-	"origin" "-5792 12144 -4128"
+	"origin" "-5935 11144 -4153"
 	"classname" "filter_activator_context"
-	"targetname" "filter_zm_user"
-	"ResponseContext" "zm_user"
+	"targetname" "filter_zm_skele"
+	"ResponseContext" "zm_item_skele"
 	"Negated" "Allow entities that match criteria"
+}
+add:
+{
+	"origin" "-5970 11326 -4153"
+	"classname" "filter_activator_context"
+	"targetname" "filter_zm_m_spider"
+	"ResponseContext" "zm_item_m_spider"
+	"Negated" "Allow entities that match criteria"
+}
+add:
+{
+	"origin" "-5968 11591 -4153"
+	"classname" "filter_activator_context"
+	"targetname" "filter_zm_pinky"
+	"ResponseContext" "zm_item_pinky"
+	"Negated" "Allow entities that match criteria"
+}
+add:
+{
+	"origin" "-5913 11929 -4150"
+	"classname" "filter_activator_context"
+	"targetname" "filter_zm_spider"
+	"ResponseContext" "zm_item_spider"
+	"Negated" "Allow entities that match criteria"
+}
+add:
+{
+	"origin" "-5952 12000 -4121"
+	"classname" "filter_multi"
+	"targetname" "filter_zm_user"
+	"filtertype" "1"
+	"Negated" "0"
+	"Filter01" "filter_zm_skele"
+	"Filter02" "filter_zm_m_spider"
+	"Filter03" "filter_zm_pinky"
+	"Filter04" "filter_zm_spider"
 }
 add:
 {
@@ -421,6 +457,63 @@ add:
 	"wait" "0"
 	"spawnflags" "1"
 	"OnStartTouch" "!activatorAddOutputorigin -6441 11506 -41200-1"
+}
+; Using the filters above, change zm item trigger hurts to only kill the item when their physbox breaks
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "skin_pauk_killer"
+	}
+	insert:
+	{
+		"filtername" "filter_zm_spider"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "pinky_skin_killer"
+	}
+	insert:
+	{
+		"filtername" "filter_zm_pinky"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "skin_spider_killer"
+	}
+	replace:
+	{
+		"damage" "99999999"
+	}
+	insert:
+	{
+		"filtername" "filter_zm_m_spider"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "skin_revenant_killer"
+	}
+	replace:
+	{
+		"damage" "99999999"
+	}
+	insert:
+	{
+		"filtername" "filter_zm_skele"
+	}
 }
 ; Add tp to stage 2 that exists on css 
 add:
@@ -545,7 +638,7 @@ modify:
 		"dmg" "99999"
 	}
 }
-; Add zm tp before stage 3 boss fight (prevents cheesing the boss where 1 ct goes in)
+; Add zm tp before stage 3 boss fight (prevents cheesing the boss where 1 ct goes in). Disable it when boss dies so ZMs can hide.
 add:
 {
 	"model" "*334"
@@ -568,6 +661,18 @@ modify:
 	{
 		"OnStartTouch" "CmdCommandsay ** ZMs tp outside arena in 10s **51"
 		"OnStartTouch" "strp_stg3_tp_bossEnable151"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "guardian_death"
+	}
+	insert:
+	{
+		"OnTrigger" "strp_stg3_tp_bossDisable01"
 	}
 }
 ; Change timings for minigun relay (gap between cd and i/o finishing)
@@ -1273,32 +1378,7 @@ modify:
 		"parentname" "Noctali_Boss_Break1"
 	}
 }
-; Small NPC nerfs
-modify:
-{
-	match:
-	{
-		"classname" "func_physbox_multiplayer"
-		"targetname" "npc_phys2gg2"
-	}
-	replace:
-	{
-		"health" "3600"
-	}
-}
-modify:
-{
-	match:
-	{
-		"classname" "func_physbox_multiplayer"
-		"targetname" "npc_phys2gg3"
-	}
-	replace:
-	{
-		"health" "1200"
-	}
-}
-; Make stage 3 rotating boss move a little faster
+; Make stage 3 rotating boss move a little faster (make minimum speed 240)
 modify:
 {
 	match:
@@ -1357,6 +1437,102 @@ modify:
 	replace:
 	{
 		"speed" "270"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stage3_path_demon1"
+	}
+	replace:
+	{
+		"speed" "240"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stage3_path_demon1_1"
+	}
+	replace:
+	{
+		"speed" "240"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stage3_path_demon5"
+	}
+	replace:
+	{
+		"speed" "240"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stage3_path_demon5_1"
+	}
+	replace:
+	{
+		"speed" "240"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stage3_path_demon9"
+	}
+	replace:
+	{
+		"speed" "240"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stage3_path_demon9_1"
+	}
+	replace:
+	{
+		"speed" "240"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stage3_path_demon11"
+	}
+	replace:
+	{
+		"speed" "240"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stage3_path_demon11_1"
+	}
+	replace:
+	{
+		"speed" "240"
 	}
 }
 ; Prevent repeat killer for stage 3 tp


### PR DESCRIPTION
- Changed the damage filter on the trigger hurts attached to the zm items. Breaking the physbox triggering the hurt kills all ZMs touching the zm item. It has caused repeat killer to turn on and can kill other zm items as well.
- Removed NPC health nerf. Adding glow makes the CTs focus them more so the health nerf was too much.
- Stage 3 rotating boss, changed minimum speed from 230 to 240.
- Stage 3 first boss, disable the TP outside the arena that was added with this stripper when the boss dies so ZM items can hide. 