### PR TITLE
doom3 changes

### DIFF
--- a/stripper/ze_doom3_v2.cfg
+++ b/stripper/ze_doom3_v2.cfg
@@ -1287,15 +1287,11 @@ modify:
 		"classname" "prop_dynamic"
 		"targetname" "npc_model4"
 	}
-	replace:
-	{
-		"classname" "prop_dynamic_glow"
-	}
 	insert:
 	{
 		"glowdist" "3096"
-		"glowcolor" "255 0 0"
-		"glowstyle" "0"
+		"glowcolor" "85 12 12"
+		"glowstyle" "1"
 		"glowenabled" "1"
 	}
 }
@@ -1306,15 +1302,11 @@ modify:
 		"classname" "prop_dynamic"
 		"targetname" "npc_model5_6"
 	}
-	replace:
-	{
-		"classname" "prop_dynamic_glow"
-	}
 	insert:
 	{
 		"glowdist" "3096"
-		"glowcolor" "255 95 95"
-		"glowstyle" "0"
+		"glowcolor" "70 30 0"
+		"glowstyle" "1"
 		"glowenabled" "1"
 	}
 }
@@ -1325,15 +1317,11 @@ modify:
 		"classname" "prop_dynamic"
 		"targetname" "npc_model5"
 	}
-	replace:
-	{
-		"classname" "prop_dynamic_glow"
-	}
 	insert:
 	{
 		"glowdist" "3096"
-		"glowcolor" "255 95 95"
-		"glowstyle" "0"
+		"glowcolor" "70 30 0"
+		"glowstyle" "1"
 		"glowenabled" "1"
 	}
 }
@@ -1559,5 +1547,35 @@ modify:
 	{
 		"wait" "0"
 		"OnStartTouch" "!activatorSetHealth00-1"
+	}
+}
+; NPC cleanup before round ending. Should help eliminate the chances of an empty glow.
+add:
+{
+	"classname" "logic_eventlistener"
+	"EventName" "cs_pre_restart"
+	"origin" "-855 8672 55"
+	"IsEnabled" "1"
+	"TeamNum" "-1"
+	"FetchEventData" "0"
+	"OnEventFired" "npc_physbox1&*Kill0-1"
+	"OnEventFired" "npc_thruster_forward1&*Kill0-1"
+	"OnEventFired" "npc_thruster_side1&*Kill0-1"
+	"OnEventFired" "npc_physbox&*Kill0-1"
+	"OnEventFired" "npc_thruster_forward&*Kill0-1"
+	"OnEventFired" "npc_thruster_side&*Kill0-1"
+}
+; Stage 2 boss, adjust sound so it doesn't go off as often
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "zwd1"
+	}
+	insert:
+	{
+		"OnStartTouch" "zwd1Disable0-1"
+		"OnStartTouch" "zwd1Enable6-1"
 	}
 }


### PR DESCRIPTION
- Changed style of NPC glow.
- Added an event listener to kill NPCs on round end. Since glow was added there is the occasional glow of an NPC without a model being there. Also seemed to persist through rounds. 
- Stage 2 boss would make a noise every time a CT touched it. Added a delay to stop the noise spam.