### PR TITLE
Fix Mako Reactor v5 heal immunity not working

### DIFF
--- a/stripper/ze_ffvii_mako_reactor_v5_3_v5.cfg
+++ b/stripper/ze_ffvii_mako_reactor_v5_3_v5.cfg
@@ -1918,10 +1918,10 @@ add:
 
 add:
 {
-    "classname" "logic_relay"
-    "targetname" "CheckIfExist"
-    "StartDisabled" "1"
-    "spawnflags" "0"
+	"classname" "logic_relay"
+	"targetname" "CheckIfExist"
+	"StartDisabled" "1"
+	"spawnflags" "0"
 	"OnTrigger" "makomap,AddOutput,OnUser1 dsadsa:Kill::3:-1,0,1"
 	"OnTrigger" "makomap,AddOutput,OnUser1 AdminRoomButtons:Lock::3:-1,0,1"	
 	"OnTrigger" "makomap,AddOutput,OnUser1 CheckIfExist:Kill::5:-1,0,1"
@@ -1929,10 +1929,10 @@ add:
 
 add:
 {
-    "classname" "logic_relay"
-    "targetname" "CheckIfWin"
-    "StartDisabled" "1"
-    "spawnflags" "0"
+	"classname" "logic_relay"
+	"targetname" "CheckIfWin"
+	"StartDisabled" "1"
+	"spawnflags" "0"
 	"OnTrigger" "makomap,AddOutput,OnUser3 AdminRoomWall:Toggle::0:1,0,1"
 	"OnTrigger" "makomap,AddOutput,OnUser3 CheckIfExist:Enable::3:1,0,1"
 	"OnTrigger" "makomap,AddOutput,OnUser3 dsadsa:Enable::3:1,0,1"
@@ -3455,28 +3455,28 @@ modify:
 
 modify:
 {
-    match:
-    {
-        "classname" "trigger_teleport"
-    }
-    insert:
-    {
-        "UseLandmarkAngles" "1"
-    }
+	match:
+	{
+		"classname" "trigger_teleport"
+	}
+	insert:
+	{
+		"UseLandmarkAngles" "1"
+	}
 }
 
 add:
 {
-    "model" "*103"
-    "wait" "1"
-    "targetname" "DontAbuseGlitch"
-    "StartDisabled" "0"
-    "spawnflags" "1"
-    "parentname" "puerta_dasc1"
-    "origin" "-9796 8600 224"
-    "classname" "trigger_multiple"
-    "hammerid" "3133"
-    "OnStartTouch" "!activator,SetHealth,-99999,0,-1"
+	"model" "*103"
+	"wait" "1"
+	"targetname" "DontAbuseGlitch"
+	"StartDisabled" "0"
+	"spawnflags" "1"
+	"parentname" "puerta_dasc1"
+	"origin" "-9796 8600 224"
+	"classname" "trigger_multiple"
+	"hammerid" "3133"
+	"OnStartTouch" "!activator,SetHealth,-99999,0,-1"
 }
 
 add:
@@ -4085,4 +4085,53 @@ modify:
 filter:
 {
 	"classname" "point_viewcontrol"
+}
+
+;fix heal not properly giving immunity
+modify:
+{
+	match:
+	{
+		"hammerid" "1512"
+		"targetname" "curacion3"
+	}
+	delete:
+	{
+		"OnEndTouch" "!activatorSetDamageFiltercualquiera0-1"
+		"OnEndTouch" "consolaT2ShowHudHint0.01-1"
+		"OnEndTouch" "consolaT2ShowHudHint0.01-1"
+		"OnEndTouch" "consolaT2AddOutputmessage YOU ARE MORTAL AGAIN0-1"
+	}
+}
+modify:
+{
+	match:
+	{
+		"hammerid" "1503"
+		"targetname" "magia_cura_t3"
+	}
+	insert:
+	{
+		"OnTrigger" "curacion3_fixEnable6.1-1"
+		"OnTrigger" "curacion3_fixDisable6.2-1"
+	}
+}
+add:
+{
+	"model" "*177"
+	"targetname" "curacion3_fix"
+	"StartDisabled" "1"
+	"spawnflags" "1"
+	"parentname" "magia_cura"
+	"origin" "-7822.37 222.52 -2538"
+	"nodmgforce" "0"
+	"filtername" "humanos"
+	"damagetype" "0"
+	"damagemodel" "0"
+	"damagecap" "-2"
+	"damage" "-2"
+	"classname" "trigger_hurt"
+	"OnStartTouch" "!activatorSetDamageFiltercualquiera0-1"
+	"OnStartTouch" "consolaT2ShowHudHint0.01-1"
+	"OnStartTouch" "consolaT2AddOutputmessage YOU ARE MORTAL AGAIN0-1"
 }

--- a/stripper/ze_ffvii_mako_reactor_v5_3_v5.cfg
+++ b/stripper/ze_ffvii_mako_reactor_v5_3_v5.cfg
@@ -4103,35 +4103,3 @@ modify:
 		"OnEndTouch" "consolaT2AddOutputmessage YOU ARE MORTAL AGAIN0-1"
 	}
 }
-modify:
-{
-	match:
-	{
-		"hammerid" "1503"
-		"targetname" "magia_cura_t3"
-	}
-	insert:
-	{
-		"OnTrigger" "curacion3_fixEnable6.1-1"
-		"OnTrigger" "curacion3_fixDisable6.2-1"
-	}
-}
-add:
-{
-	"model" "*177"
-	"targetname" "curacion3_fix"
-	"StartDisabled" "1"
-	"spawnflags" "1"
-	"parentname" "magia_cura"
-	"origin" "-7822.37 222.52 -2538"
-	"nodmgforce" "0"
-	"filtername" "humanos"
-	"damagetype" "0"
-	"damagemodel" "0"
-	"damagecap" "-2"
-	"damage" "-2"
-	"classname" "trigger_hurt"
-	"OnStartTouch" "!activatorSetDamageFiltercualquiera0-1"
-	"OnStartTouch" "consolaT2ShowHudHint0.01-1"
-	"OnStartTouch" "consolaT2AddOutputmessage YOU ARE MORTAL AGAIN0-1"
-}


### PR DESCRIPTION
I do not know why or how this bug occurs. Just some weird edge case that happens every once in a while. This stripper change fixes immunity not properly applying by redoing the system so that it works 100% of the time.