### PR TITLE
Fixes for invalid configs

### DIFF
--- a/entwatch/ze_castlevania_p1_7.cfg
+++ b/entwatch/ze_castlevania_p1_7.cfg
@@ -370,7 +370,7 @@
         "cooldown"          "0"
         "maxamount"         "99"
     }
-    "19"
+    "20"
     {
         "name"              "Randomized ZM Weapon"
         "shortname"         "Randomized ZM Weapon"
@@ -390,7 +390,7 @@
         "maxamount"         "99"
         "trigger"           "118888"
     }
-    "20"
+    "21"
     {
         "name""             "ZM ITEM EBAN BLOCKER"
         "hammerid"          "-1"

--- a/entwatch/ze_cyberderp_p3_kia.cfg
+++ b/entwatch/ze_cyberderp_p3_kia.cfg
@@ -81,7 +81,7 @@
 	{
 		"name"              "Boss"
 		"shortname"         "Boss"
-		"color"             {darkred}"
+		"color"             "{darkred}"
 		"buttonclass"       "func_button"
 		"filtername"        "Boss"
 		"hasfiltername"     "true"

--- a/entwatch/ze_infested-industry_p2.cfg
+++ b/entwatch/ze_infested-industry_p2.cfg
@@ -1,4 +1,4 @@
-"entities:
+"entities"
 {
 	"0"
 	{

--- a/entwatch/ze_kraznov_poopata_p2.cfg
+++ b/entwatch/ze_kraznov_poopata_p2.cfg
@@ -17,7 +17,6 @@
 		"cooldown"          "0"
 		"maxamount"         "1"
 	}
-}
 	"1" {
 		"name"              "Penis"
 		"shortname"         "Penis"

--- a/entwatch/ze_paranoid_rezurrection_csgo1.cfg
+++ b/entwatch/ze_paranoid_rezurrection_csgo1.cfg
@@ -654,7 +654,7 @@
         "trigger"           "1465601"
     }
     "34"
-    {=
+    {
         "name"              "ZM Titan Monster"
         "shortname"         "ZM Titan"
         "color"             ""


### PR DESCRIPTION
**Fixes typos in configs that make them impossible to use on the server.**

```cpp
KeyValues Error: RecursiveLoadFromBuffer:  got } in key in file cfg/sourcemod/entwatch/ze_cyberderp_p3_kia.cfg
entities, 4, color, 
KeyValues Error: RecursiveLoadFromBuffer:  got } in key in file cfg/sourcemod/entwatch/ze_cyberderp_p3_kia.cfg
entities, 4,              , 
KeyValues Error: RecursiveLoadFromBuffer:  got EOF instead of keyname in file cfg/sourcemod/entwatch/ze_cyberderp_p3_kia.cfg
entities, 4, 1, (*             *), 
KeyValues Error: RecursiveLoadFromBuffer:  got EOF instead of keyname in file cfg/sourcemod/entwatch/ze_cyberderp_p3_kia.cfg
entities, (*4*), (*1*), (*             *), 
KeyValues Error: LoadFromBuffer: missing { in file cfg/sourcemod/entwatch/ze_infested-industry_p2.cfg

KeyValues Error: LoadFromBuffer: missing { in file cfg/sourcemod/entwatch/ze_infested-industry_p2.cfg

KeyValues Error: RecursiveLoadFromBuffer:  got NULL key in file cfg/sourcemod/entwatch/ze_castlevania_p1_7.cfg
entities, 20, 
KeyValues Error: RecursiveLoadFromBuffer:  got EOF instead of keyname in file cfg/sourcemod/entwatch/ze_castlevania_p1_7.cfg
entities, (*20*), 
KeyValues Error: LoadFromBuffer: missing { in file cfg/sourcemod/entwatch/ze_kraznov_poopata_p2.cfg
(*1*), (*maxamount*), (*0*), 
KeyValues Error: RecursiveLoadFromBuffer:  got empty keyname in file cfg/sourcemod/entwatch/ze_paranoid_rezurrection_csgo1.cfg
entities, 34, 
KeyValues Error: LoadFromBuffer: missing { in file cfg/sourcemod/entwatch/ze_paranoid_rezurrection_csgo1.cfg
(*43*), (*trigger*), (*34*), 
[SM] Plugin ew.smx reloaded successfully.
KeyValues Error: RecursiveLoadFromBuffer:  got NULL key in file cfg/sourcemod/entwatch/ze_castlevania_p1_7.cfg
entities, 21, 
KeyValues Error: RecursiveLoadFromBuffer:  got EOF instead of keyname in file cfg/sourcemod/entwatch/ze_castlevania_p1_7.cfg
entities, (*21*), 
```