### PR TITLE
Fix in config `ze_castlevania_p1_7.cfg`

### DIFF
--- a/entwatch/ze_castlevania_p1_7.cfg
+++ b/entwatch/ze_castlevania_p1_7.cfg
@@ -392,7 +392,7 @@
     }
     "21"
     {
-        "name""             "ZM ITEM EBAN BLOCKER"
+        "name"              "ZM ITEM EBAN BLOCKER"
         "hammerid"          "-1"
         "maxamount"         "1"
         "trigger"           "971213"


### PR DESCRIPTION
```cpp
KeyValues Error: RecursiveLoadFromBuffer:  got NULL key in file cfg/sourcemod/entwatch/ze_castlevania_p1_7.cfg
entities, 21, 
KeyValues Error: RecursiveLoadFromBuffer:  got EOF instead of keyname in file cfg/sourcemod/entwatch/ze_castlevania_p1_7.cfg
entities, (*21*), 
```