### PR TITLE
Update ze_retribution_pf.cfg

### DIFF
--- a/stripper/ze_retribution_pf.cfg
+++ b/stripper/ze_retribution_pf.cfg
@@ -1,10 +1,20 @@
-; What it does:
-;	- Extends round time so that CTs don't usually just win by time running out
-;	- Locks secret car buttons until after the nuke
-;	- Disable the artillery button to humans until post nuke, since they use it to troll teammates and it doesn't do enough damage to kill zombies till post-nuke.
-;	- Make is so that players cannot block the artillery ladder by rotating the gun on top of it, as well as make the rotating unblockable
-;	- Block cheesy van camping spot at end of the tunnel
-;	- Make it so players cannot camp bunkers
+;Modify Zombie HP timer so as to not heal zombies (preventing CTs from killing them with low DPS weapons) and instead to only act as a max hp.
+modify:
+{
+	match:
+	{
+		"classname" "logic_timer"
+		"targetname" "ZombieHP"
+	}
+	delete:
+	{
+		"playerAddOutputhealth 2500-1"
+	}
+	insert:
+	{
+		"playerRunScriptCodeif(self.GetHealth()>250){self.SetHealth(250)}0-1"
+	}
+}
 
 ;Locks secret car buttons until after the nuke since you cannot use cars until that time anyways
 modify:


### PR DESCRIPTION
Modify Zombie HP timer so as to not heal zombies (preventing CTs from killing them with low DPS weapons) and instead to only act as a max hp.

Untested as I do not have a computer to test with, so I hope I didn't mess up a simple change.