### PR TITLE
Enable MultBoss on Wanderers Palace v6_2

### DIFF
--- a/bosshud/ze_FFXIV_Wanderers_Palace_v6_2z1.txt
+++ b/bosshud/ze_FFXIV_Wanderers_Palace_v6_2z1.txt
@@ -1,5 +1,9 @@
 "math_counter"
 {
+	"config"
+	{
+		"MultBoss"			"1"
+	}
 	"0"
 	{
 		"HP_counter"		"Boss_Health_Goobbue"


### PR DESCRIPTION
On stage 5, during the boss fight against Ultimate Weapon, rocks (named `gaol` in the config) can spawn at the same time.