### PR TITLE
Modified Multiple Configs

### DIFF
--- a/entwatch/ze_FFVII_Mako_Reactor_V6_b09k2.cfg
+++ b/entwatch/ze_FFVII_Mako_Reactor_V6_b09k2.cfg
@@ -179,7 +179,7 @@
 	{
 		"name" 				"Bio Materia"
 		"shortname" 		"Bio"
-		"color" 			"{purple}"
+		"color" 			"{green}"
 		"buttonclass" 		"func_button"
 		"filtername" 		"player_bio"
 		"hasfiltername" 	"true"

--- a/entwatch/ze_cyberpunk_x_a07.cfg
+++ b/entwatch/ze_cyberpunk_x_a07.cfg
@@ -16,7 +16,7 @@
         "hammerid"          "1982822"
         "mode"              "2"
         "maxuses"           "0"
-        "cooldown"          "60"
+        "cooldown"          "80"
         "maxamount"         "1"
     }
     "1"

--- a/stripper/ze_babylon_v1.cfg
+++ b/stripper/ze_babylon_v1.cfg
@@ -1,0 +1,23 @@
+;Block a delay spot on top of red building roof that players can get to by parkouring on windows
+add:
+{
+    "classname" "trigger_teleport"
+    "targetname" "resizeme"
+    "origin" "3238 1119 608"
+    "spawnflags" "4097"
+    "StartDisabled" "1"
+    "CheckDestIfClearForPlayer" "0"
+    "target" "AFK_teleport_destination"
+    "UseLandmarkAngles" "1"
+}
+
+add:
+{
+    "classname" "logic_auto"
+    "origin" "3200 768 360"
+    "spawnflags" "0"
+    "OnMapSpawn" "resizeme,AddOutput,solid 2,0,-1"
+    "OnMapSpawn" "resizeme,AddOutput,mins -90 -353 -416,0.5,-1"
+    "OnMapSpawn" "resizeme,AddOutput,maxs 90 353 416,0.5,-1"
+    "OnMapSpawn" "resizeme,AddOutput,targetname AFK_teleport_trigger,2,1"
+}

--- a/stripper/ze_deathinvain_palace_v2.cfg
+++ b/stripper/ze_deathinvain_palace_v2.cfg
@@ -1,3 +1,17 @@
+;If level 2 DPS check is failed and round becomes unwinnable, kill all CTs 5 seconds later rather than let them delay
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "L2_END_hopper_relay"
+	}
+	insert:
+	{
+		"OnSpawn" "playerRunScriptCodeforeach(k,_ in{SetHealth=0}){if(self.GetTeam()==3&&self.GetHealth()>0)EntFireByHandle(self, k,(0).tostring(),0,null,null)}15-1"
+	}
+}
+
 ;fix awful game_text placement behind hint hud
 modify:
 {

--- a/stripper/ze_deathinvain_palace_v2.cfg
+++ b/stripper/ze_deathinvain_palace_v2.cfg
@@ -12,6 +12,19 @@ modify:
 	}
 }
 
+modify:
+{
+	match:
+	{
+		"classname" "func_breakable"
+		"targetname" "L2_END_hopper_hit"
+	}
+	insert:
+	{
+		"OnBreak" "L2_END_hopper_relay,CancelPending,,0,-1"
+	}
+}
+
 ;fix awful game_text placement behind hint hud
 modify:
 {

--- a/stripper/ze_games_v2_1.cfg
+++ b/stripper/ze_games_v2_1.cfg
@@ -489,45 +489,7 @@ modify:
 	match:
 	{	
 		"classname" "logic_relay"
-		"targetname" "castle_relay_normal"
-	}
-	insert:
-	{
-		"OnTrigger" "castle_entrance_closetriggerDisable2-1"
-		"OnTrigger" "castle_maindoor_leftClose20-1"
-		"OnTrigger" "cmdCommandsay -=[ Doors closing in 5 seconds ]=-15-1"
-		"OnTrigger" "castle_maindoor_rightClose20-1"
-		"OnTrigger" "cmdCommandsay -=[ Zombies are free ]=-17-1"
-		"OnTrigger" "castle_zombiestart_rockwall_clipDisable17-1"
-		"OnTrigger" "castle_zombiestart_rockwallKill17-1"
-	}
-}
-
-modify:
-{
-	match:
-	{	
-		"classname" "logic_relay"
-		"targetname" "castle_relay_hard"
-	}
-	insert:
-	{
-		"OnTrigger" "castle_entrance_closetriggerDisable2-1"
-		"OnTrigger" "castle_maindoor_leftClose20-1"
-		"OnTrigger" "cmdCommandsay -=[ Doors closing in 5 seconds ]=-15-1"
-		"OnTrigger" "castle_maindoor_rightClose20-1"
-		"OnTrigger" "cmdCommandsay -=[ Zombies are free ]=-17-1"
-		"OnTrigger" "castle_zombiestart_rockwall_clipDisable17-1"
-		"OnTrigger" "castle_zombiestart_rockwallKill17-1"
-	}
-}
-
-modify:
-{
-	match:
-	{	
-		"classname" "logic_relay"
-		"targetname" "castle_relay_extreme"
+		"targetname" "/castle_relay_\S+/"
 	}
 	insert:
 	{

--- a/stripper/ze_surf_ffxiv_beachescape_camper_isengard_laser_mako.cfg
+++ b/stripper/ze_surf_ffxiv_beachescape_camper_isengard_laser_mako.cfg
@@ -1,3 +1,17 @@
+;shift nuke over a bit so it doesn't overlap ending tower wall. If all CTs were on top with ZMs below, this led to CTs being unable to go down and ZMs unable to go up which caused delays.
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Map Ending"
+	}
+	replace:
+	{
+		"origin" "-1922.35 1359.76 96"
+	}
+}
+
 ;move final trigger so it can't be mistriggered early
 modify:
 {


### PR DESCRIPTION
ze_babylon_v1:
- Block a delay spot on the red building's roof that people can use the windows to parkour up to

ze_cyberpunk_x_a07:
- EW: Change tracerifle cooldown

ze_deathinvain_palace_v2:
- Make All CTs die if they fail the level 2 DPS check. Because the boss hallway instantly kills CTs if the DPS check is failed, the round becomes unwinnable and just delays time.

ze_FFVII_Mako_Reactor_V6_b09k2:
- EW: Make bio color match the color of its item particle

ze_games_v2_1:
- Use regex to neaten a previous edit. Should not have any new effects on the map.

ze_surf_ffxiv_beachescape_camper_isengard_laser_mako:
- Stop nuke from protruding into ending room by a couple units that could lead to delaying if CTs and ZMs were on separate floors.