### PR TITLE
fix paramina fire staff crash random client on stage 2 boss

### DIFF
--- a/stripper/ze_ffxii_paramina_rift_r4.cfg
+++ b/stripper/ze_ffxii_paramina_rift_r4.cfg
@@ -367,3 +367,22 @@ modify:
 		"OnStartTouch" "!activatorIgniteLifetime00-1"
 	}
 }
+
+// Fix Fire Staff crash random client when facing the boss.
+filter:
+{
+	"targetname" "Boss_Igniter"
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "Boss_Damage_Fire"
+		"hammerid" "835804"
+	}
+	delete:
+	{
+		"OnEqualTo" "Boss_IgniterIgnite0-1"
+	}
+}


### PR DESCRIPTION
This fix crash on some player when using fire staff on stage 2 boss area. Client only crash if their vision is looking at the boss.