### PR TITLE
Modify stripper/ze_lotr_mount_doom_p3.cfg

### DIFF
--- a/stripper/ze_lotr_mount_doom_p3.cfg
+++ b/stripper/ze_lotr_mount_doom_p3.cfg
@@ -1,4 +1,32 @@
-;Add timer to slay CTs if player with ring doesn't trigger (in case player with ring delays or dies). This does not include dropping/not dropping the ring into mount doom
+;Prevent shortcuting past the rock at the bottom of the hill on ring path by surfing up hill
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "resizeme"
+	"origin" "-1712 4768 -3464"
+	"spawnflags" "1"
+	"parentname" "paso2"
+	"StartDisabled" "0"
+	"wait" "0.02"
+	"OnStartTouch" "!activator,AddOutput,origin -1600 4288 -3891,0,-1"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "resizeme,AddOutput,solid 2,0,-1"
+		"OnMapSpawn" "resizeme,AddOutput,mins -208 -16 -344,0.5,-1"
+		"OnMapSpawn" "resizeme,AddOutput,maxs 208 16 344,0.5,-1"
+	}
+}
+
+;Add timer to slay CTs if player with ring doesn't trigger (in case player with ring delays or dies).
+;This only includes ring-player-only triggers that are required to win a round for CTs (whether good/bad ending doesn't matter)
 add:
 {
 	"classname" "logic_relay"
@@ -9,7 +37,6 @@ add:
 	"OnTrigger" "consola,Command,say ***The Ring player has been corrupted! All hope is lost!***,40,-1"
 	"OnTrigger" "playerRunScriptCodeforeach(k,_ in{SetHealth=0}){if(self.GetTeam()==3&&self.GetHealth()>0)EntFireByHandle(self, k,(0).tostring(),0,null,null)}40-1"
 	"OnUser1" "!self,Trigger,,60,-1"
-	"OnUser2" "!self,Trigger,,30,-1"
 }
 
 modify:
@@ -64,49 +91,6 @@ modify:
 	insert:
 	{
 		"OnBreak" "relay_notrigger,CancelPending,,0,-1"
-		"OnBreak" "relay_notrigger,FireUser1,,1,-1"
-	}
-}
-
-modify:
-{
-	match:
-	{
-		"classname" "trigger_once"
-		"targetname" "areadeanillo3"
-	}
-	insert:
-	{
-		"OnTrigger" "relay_notrigger,CancelPending,,0,-1"
-		"OnTrigger" "relay_notrigger,FireUser2,,1,-1"
-	}
-}
-
-modify:
-{
-	match:
-	{
-		"classname" "trigger_once"
-		"targetname" "anillofn"
-		"origin" "-2000.63 15187 -85.69"
-	}
-	insert:
-	{
-		"OnTrigger" "relay_notrigger,CancelPending,,0,-1"
-	}
-}
-
-modify:
-{
-	match:
-	{
-		"classname" "trigger_once"
-		"targetname" "areadeanillo4"
-		"origin" "-1999.99 15499.9 -662.18"
-	}
-	insert:
-	{
-		"OnTrigger" "relay_notrigger,CancelPending,,0,-1"
 	}
 }
 


### PR DESCRIPTION
- Make previous fix only apply to triggers that are ring-player-only AND required to finish a round _(ending doesnt matter)_. This means that once the rock at the bottom of the hill is triggered there is no longer a chance for an early slay, since the bad ending can be done without the ring player from that point forward.
- Patch a skip spot on ring level that could be used by players to early trigger the final defense without opening the rock at the bottom.

Despite what people claimed in Discord before, the previous change was not causing rounds to be slain early _(or at least I still have yet to see any evidence of such an occurrence)_. They were simply triggering the bad ending early _(by abusing the rock skip now patched)_, which disabled any stripper slay from occurring. Then, the map's bad ending nuke went off to kill all players outside of Mount Doom. This bug would have already been present in the map before any stripper changes.