### PR TITLE
ze_light_escape_v1_final.cfg

### DIFF
--- a/stripper/ze_light_escape_v1_final.cfg
+++ b/stripper/ze_light_escape_v1_final.cfg
@@ -1,0 +1,53 @@
+;fix the middle door where it opened too fast than the others
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"hammerid" "272709"
+	}
+	delete:
+	{
+		"OnStartTouch" "door5Open201" 
+    }    
+	insert:
+	{
+		"OnStartTouch" "door5Open251" 
+	}
+}
+
+;delay zm fast tp from 0 to 5
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"hammerid" "355657"
+	}
+	delete:
+	{
+		"OnStartTouch" "teleport3Enable01" 
+    }    
+	insert:
+	{
+		"OnStartTouch" "teleport3Enable51" 
+	}
+}
+
+;fix nuke time from 55 to 46 seconds 
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"hammerid" "377197"
+	}
+	delete:
+	{
+		"OnStartTouch" "nuke_tempEnable551" 
+    }    
+	insert:
+	{
+		"OnStartTouch" "nuke_tempEnable461" 
+	}
+}


### PR DESCRIPTION
*Add ze_light_escape_v1_final.cfg
- fix the middle door where it opened too fast than the others
- delay zm fast tp from 0 to 5
- fix nuke time from 55 to 46 seconds