### PR TITLE
Modified Multiple Configs

### DIFF
--- a/stripper/ze_bioshock_v6_2_csgo7.cfg
+++ b/stripper/ze_bioshock_v6_2_csgo7.cfg
@@ -1,11 +1,3 @@
-;Changes:
-;	- Fix nuke avoidance spot
-;	- Nerfs Songbird HP
-;	- Make it so players hopefully dont die in level 4 elevator if doorhugging
-;	- Make items easier to press (dont have to look right at button to use it)
-;	- Increase blocking damage on 1st elevator in 1999 level
-;	- Prevent zombies from getting locked into TPs due to in-air knockback
-
 ;add notice about stripper changes (requested by mapper)
 modify:
 {
@@ -20,9 +12,34 @@ modify:
 	}
 }
 
-; ------------------------------------------------------------------------
-; | Prevent zombies from getting locked into TPs due to in-air knockback |
-; ------------------------------------------------------------------------
+;Reduce game_text channels used so that map doesn't conflict with plugins as much
+modify:
+{
+	match:
+	{
+		"classname" "game_text"
+		"targetname" "difficulty_hudhint"
+	}
+	replace:
+	{
+		"channel" "2"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "game_text"
+		"targetname" "spawn_hudhint"
+	}
+	replace:
+	{
+		"channel" "1"
+	}
+}
+
+;Prevent zombies from getting locked into TPs due to in-air knockback
 modify:
 {
 	match:
@@ -59,9 +76,7 @@ modify:
 	}
 }
 
-; ----------------------------------------------------------
-; | Increase blocking damage on 1st elevator in 1999 level |
-; ----------------------------------------------------------
+;Increase blocking damage on 1st elevator in 1999 level
 modify:
 {
 	match:
@@ -75,10 +90,7 @@ modify:
 	}
 }
 
-; ----------------------------------------------------------------
-; | Make item uses track more accurately on Entwatch with mathid |
-; ----------------------------------------------------------------
-
+;Make item uses track more accurately on Entwatch with mathid
 modify:
 {
 	match:
@@ -181,10 +193,7 @@ modify:
 	}
 }
 
-; ---------------------------------------------------------------------
-; | Make nuke kill zombies crouching at bottom of water on bad ending |
-; ---------------------------------------------------------------------
-
+;Make nuke kill zombies crouching at bottom of water on bad ending
 modify:
 {
 	match:
@@ -199,10 +208,7 @@ modify:
 	}
 }
 
-; ---------------------
-; | Nerfs Songbird HP |
-; ---------------------
-
+;Nerfs Songbird HP
 modify:
 {
 	match:
@@ -233,9 +239,7 @@ modify:
 	}
 }
 
-; ----------------------------------------------------------------------------
-; | Make it so players hopefully dont die in level 4 elevator if doorhugging |
-; ----------------------------------------------------------------------------
+;Make it so players hopefully dont die in level 4 elevator if doorhugging 
 modify:
 {
 	match:
@@ -249,9 +253,7 @@ modify:
 	}
 }
 
-; ----------------------------------------------------------------------------
-; | Make items easier to press (dont have to look right at button to use it) |
-; ----------------------------------------------------------------------------
+;Make items easier to press (dont have to look right at button to use it)
 modify:
 {
 	match:

--- a/stripper/ze_death_star_escape_v4_3_p2.cfg
+++ b/stripper/ze_death_star_escape_v4_3_p2.cfg
@@ -476,7 +476,7 @@ modify:
 	}
 }
 
-;Repeat killer not easily toggleable.
+;Make repeat killer not easily toggleable without changing map behavior
 modify:
 {
 	match:
@@ -486,12 +486,13 @@ modify:
 	}
 	replace:
 	{
-		"damagecap" "4000"
-		"damage" "4000"
+		"classname" "trigger_multiple"
+		"damagecap" "0"
+		"damage" "0"
 	}
 	insert:
 	{
-		"OnStartTouch" "!activator,AddOutput,origin -1664 12736 265,0,-1"
+		"OnStartTouch" "!activator,SetHealth,0,0,-1"
 	}
 }
 
@@ -504,12 +505,32 @@ modify:
 	}
 	replace:
 	{
-		"damagecap" "4000"
-		"damage" "4000"
+		"classname" "trigger_multiple"
+		"damagecap" "0"
+		"damage" "0"
 	}
 	insert:
 	{
-		"OnStartTouch" "!activator,AddOutput,origin -96 2080 25,0,-1"
+		"OnStartTouch" "!activator,SetHealth,0,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"origin" "-1152 11360 24"
+	}
+	replace:
+	{
+		"classname" "trigger_multiple"
+		"damagecap" "0"
+		"damage" "0"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activator,SetHealth,0,0,-1"
 	}
 }
 

--- a/stripper/ze_games_v2_1.cfg
+++ b/stripper/ze_games_v2_1.cfg
@@ -1,7 +1,4 @@
-; -------------------------------------------
-; | Optional: Remove Advertisement in Spawn |
-; -------------------------------------------
-;
+;Optional: Remove Advertisement in Spawn
 ;filter:
 ;{
 ;	"classname" "func_illusionary"
@@ -9,47 +6,22 @@
 ;	"hammerid" "65203"
 ;}
 
-; -------------------------------------------------------------------------------------------------------------------------
-; | Make it so zombies get pushed up by the Trap's obstacles coming back up, rather than getting stuck and unable to move |
-; -------------------------------------------------------------------------------------------------------------------------
-
-filter:
+;Make it so zombies get pushed up by the Trap's obstacles coming back up, rather than getting stuck and unable to move (due to noblock plugin causing players to be of type debris)
+modify:
 {
-	"classname" "func_door"
-	"targetname" "trap_obstacle"
-	"origin" "1096 2816 -4000"
+	match:
+	{
+		"classname" "func_door"
+		"targetname" "trap_obstacle"
+	}
+	replace:
+	{
+		"ignoredebris" "0"
+		"dmg" "999999"
+	}
 }
 
-add:
-{
-	"model" "*315"
-	"classname" "func_movelinear"
-	"blockdamage" "999999"
-	"disablereceiveshadows" "0"
-	"fademaxdist" "0"
-	"fademindist" "-1"
-	"fadescale" "1"
-	"movedir" "90 0 0"
-	"movedistance" "192"
-	"origin" "1096 2816 -4000"
-	"renderamt" "255"
-	"rendercolor" "255 255 255"
-	"renderfx" "0"
-	"rendermode" "0"
-	"spawnflags" "0"
-	"speed" "50"
-	"startposition" "0"
-	"targetname" "trap_obstacle"
-	"OnFullyClosed" "trap_entrance_door_*Open0-1"
-	"OnFullyClosed" "trap_door_relayEnable0-1"
-	"OnFullyOpen" "trap_door_relay_rungrinderTrigger0-1"
-	"OnFullyClosed" "trap_door_relay_2Enable0-1"
-}
-
-; -----------------------------------------------------------------------------------------------------
-; | Changes Trap's barbed wire to do 2x damage to zombies, since right now zombies can just ignore it |
-; -----------------------------------------------------------------------------------------------------
-
+;Changes Trap's barbed wire to do 2x damage to zombies, since right now zombies can just ignore it
 modify:
 {
 	match:
@@ -64,10 +36,7 @@ modify:
 	}
 }
 
-; ----------------------------------------------------------------------------------------------------------
-; | Adds 8 CT Spawns and 8 T Spawns (to bring total up to 64 total, so cts dont spawn in same spawn point) |
-; ----------------------------------------------------------------------------------------------------------
-
+;Adds 8 CT Spawns and 8 T Spawns (to bring total up to 64 total, so cts dont spawn in same spawn point)
 add:
 {
 	"origin" "1408 -3992 2567"
@@ -196,10 +165,7 @@ add:
 	"classname" "info_player_counterterrorist"
 }
 
-; ---------------------------------------------------------------------
-; | Adds extra TP locations in spawn to prevent stacking while frozen |
-; ---------------------------------------------------------------------
-
+;Adds extra TP locations in spawn to prevent stacking while frozen
 add:
 {
 	"classname" "info_teleport_destination"
@@ -264,10 +230,7 @@ add:
 	"origin" "1568 -4096 2561"
 }
 
-; -------------------------------------------------------------------------------
-; | Blocks jumps on hills in castle defense so it is like the other hills there |
-; -------------------------------------------------------------------------------
- 
+;Blocks jumps on hills in castle defense so it is like the other hills there
 add:
 {
 	"classname" "func_brush"
@@ -340,10 +303,7 @@ add:
 	"rendermode" "10"
 }
 
-; -------------------------------------------------------
-; | Disables player control on obstacle course platform |
-; -------------------------------------------------------
-
+;Disables player control on obstacle course platform
 modify:
 {
 	match:
@@ -357,10 +317,7 @@ modify:
 	}
 }
 
-; ----------------------------------------------------------
-; | Disables getting on top of the wall in obstacle course |
-; ----------------------------------------------------------
-
+;Disables getting on top of the wall in obstacle course
 add:
 {
 	"classname" "func_brush"
@@ -433,9 +390,8 @@ add:
 	"rendermode" "10"
 }
 
-; -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
-; | Prevents zombies from choosing a 2nd minigame immediately after one with a delayed ZM TP is chosen, which resulted in cts and zombies going into seperate minigames |
-; -----------------------------------------------------------------------------------------------------------------------------------------------------------------------
+;Prevent zombies from choosing a 2nd minigame immediately after one with a delayed ZM TP is chosen,
+;which resulted in CTs and zombies going into seperate minigames
 
 ;Add targetnames to game triggers so they can be turned off and on
 modify:
@@ -480,10 +436,7 @@ modify:
 	}
 }
 
-; -------------------------------------------------------------------------------------------------------------
-; | Makes the zombie cage in castle defense open based on a timer, rather than when humans go into the castle |
-; -------------------------------------------------------------------------------------------------------------
-
+;Makes the zombie cage in castle defense open based on a timer, rather than when humans go into the castle
 modify:
 {
 	match:
@@ -503,10 +456,7 @@ modify:
 	}
 }
 
-; ------------------------------------------------------------------------------------------
-; | Fixes frogger exploit spot so that humans are tped if they stay there after zombies tp |
-; ------------------------------------------------------------------------------------------
-
+;Fixes frogger exploit spot so that humans are tped if they stay there after zombies tp
 add:
 {
 	"model" "*198"

--- a/stripper/ze_harry_potter_v2_1_csgo.cfg
+++ b/stripper/ze_harry_potter_v2_1_csgo.cfg
@@ -1,3 +1,17 @@
+;Attempt to fix sets of 2 barrels not dealing explosion damage when they are supposed to (I am assuming the model is somehow blocking the explosion, but might be wrong)
+modify:
+{
+	match:
+	{
+		"classname" "func_door"
+		"targetname" "map_barrelset3_brush"
+	}
+	insert:
+	{
+		"OnUser1" "map_barrelset3_props,AddOutput,solid 0,0.97,1"
+	}
+}
+
 ;remove old animation models that can crash clients
 filter:
 {

--- a/stripper/ze_surf_danger_p2.cfg
+++ b/stripper/ze_surf_danger_p2.cfg
@@ -1,3 +1,34 @@
+;Block jumping on top of some boxes (by making invis versions of them, slightly raised up) on final defense that can be used to delay
+add:
+{
+	"classname" "prop_dynamic"
+	"angles" "0 85.5 0"
+	"model" "models/props/cs_militia/crate_stackmill.mdl"
+	"origin" "11052 -7201.08 4614.13"
+	"solid" "6"
+	"rendermode" "10"
+}
+
+add:
+{
+	"classname" "prop_dynamic"
+	"angles" "0 36.5 0"
+	"model" "models/props/cs_militia/crate_stackmill.mdl"
+	"origin" "11983.9 -7133.81 4669"
+	"solid" "6"
+	"rendermode" "10"
+}
+
+add:
+{
+	"classname" "prop_dynamic"
+	"angles" "0 2 0"
+	"model" "models/props/props_crates/wooden_crate_64x64.mdl"
+	"origin" "10717 -6854 4614"
+	"solid" "6"
+	"rendermode" "10"
+}
+
 ;fix tp avoidance spot at last surf
 add:
 {


### PR DESCRIPTION
ze_bioshock_v6_2_csgo7
- Change comment styling to be like other strippers
- Reduce game_text channels used by the map

ze_death_star_escape_v4_3_p2
- Try to prevent repeat killer from being triggered (since it still was with old fix) without changing default map behavior

ze_games_v2_1
- Change comment styling to be like other strippers
- Rework previous change to simply set ignoredebris to 0, rather than remake the entire entity, to prevent players clipping through walls in the Trap

ze_harry_potter_v2_1_csgo
- Attempt to make sets of 2 barrels correctly deal damage to nearby players (as they currently do not hurt, despite having an ExplodeDamage of 99999)

ze_surf_danger_p2
- Block jumping on top of some boxes (by making invis versions of them, slightly raised up) on final defense that can be used to delay