### PR TITLE
Enable StackDamage fix on Codex

### DIFF
--- a/zombiereloaded/ze_project_codex_v1_2.cfg
+++ b/zombiereloaded/ze_project_codex_v1_2.cfg
@@ -1,0 +1,1 @@
+sm_enable_hurt_fix 1


### PR DESCRIPTION
Purple blades that drop from the top deals stack damage when going down (2 ticks)