### PR TITLE
Even more Paranoid fixes

### DIFF
--- a/stripper/ze_paranoid_rezurrection_csgo1.cfg
+++ b/stripper/ze_paranoid_rezurrection_csgo1.cfg
@@ -1,6 +1,6 @@
-// "ze_paranoid_rezurrection_csgo1" config, made by "Berke" "STEAM_1:0:95142811", version 2.
+// "ze_paranoid_rezurrection_csgo1" config, made by "Berke" "STEAM_1:0:95142811", version 3.
 
-// Delete low buy time, extend height of spawn trigger and fix zombies not getting teleported.
+// Delete low buy time, extend height of spawn trigger, fix zombies not getting teleported, fix getting to the safe spot without the winner status and delete delay of player resetting.
 modify:
 {
 	match:
@@ -9,14 +9,24 @@ modify:
 	}
 	insert:
 	{
+		"OnMapSpawn" "player,AddOutput,rendermode 0,,1"
+		"OnMapSpawn" "player,AddOutput,gravity 1,,1"
+		"OnMapSpawn" "player,SetDamageFilter,,,1"
+		"OnMapSpawn" "player,Color,255 255 255,,1"
 		"OnMapSpawn" "protect_player,AddOutput,solid 2,,1"
 		"OnMapSpawn" "protect_playerRunScriptCodeself.SetSize(Vector(-1600, -1178.5, -184.017), Vector(1600, 1178.5, 616));1"
+		"OnMapSpawn" "map1anticheat1,AddOutput,solid 2,,1"
+		"OnMapSpawn" "map1anticheat1RunScriptCodeself.SetSize(Vector(-0.5, -8, -302), Vector(0.5, 8, 302));1"
+		"OnMapSpawn" "protect_player,Enable,,1,1"
 		"OnMapSpawn" "playerRunScriptCodeif (self.GetTeam() == 2 && self.GetHealth() != 0) { self.SetOrigin(Vector(-12408, -8140, 318)); self.SetAngles(0, -89, 0); }301"
 	}
 	delete:
 	{
 		"OnMapSpawn" "consolaCommandmp_buytime 22-1"
 		"OnMapSpawn" "protect_playerEnable5-1"
+		"OnMapSpawn" "playerAddOutputrendermode 03-1"
+		"OnMapSpawn" "playerAddOutputgavity 13-1"
+		"OnMapSpawn" "playerSetDamageFilter3-1"
 	}
 }
 
@@ -46,10 +56,6 @@ modify:
 		"classname" "trigger_multiple"
 		"targetname" "protect_player"
 	}
-	replace:
-	{
-		"StartDisabled" "0"
-	}
 	delete:
 	{
 		"model" "*386"
@@ -60,6 +66,15 @@ modify:
 		"OnStartTouch" "!activator,Color,255 255 255,,-1"
 		"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 	}
+}
+
+// Fix getting to the safe spot without the winner status.
+add:
+{
+	"classname" "func_wall_toggle"
+	"targetname" "map1anticheat1"
+	"origin" "-11216.5 -9496 530"
+	"effects" "32"
 }
 
 // Fix "Jukebox".
@@ -82,7 +97,7 @@ add:
 	"classname" "game_round_end"
 	"targetname" "map1winnerstatusreset1"
 	"OnRoundEnded" "playerRunScriptCodeWINNER <- 0;1"
-	"OnRoundEnded" "!self,Kill,,,1"
+	"OnRoundEnded" "map1winnerstatusreset1,Kill,,,1"
 }
 
 modify:
@@ -91,6 +106,48 @@ modify:
 	{
 		"classname" "trigger_multiple"
 		"targetname" "har2"
+	}
+	insert:
+	{
+		"OnStartTouch" "map1winnerstatusreset1,Kill,,,1"
+		"OnStartTouch" "playerRunScriptCodeWINNER <- 0;1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "sh_dar"
+	}
+	insert:
+	{
+		"OnStartTouch" "map1winnerstatusreset1,Kill,,,1"
+		"OnStartTouch" "playerRunScriptCodeWINNER <- 0;1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "epic3"
+	}
+	insert:
+	{
+		"OnStartTouch" "map1winnerstatusreset1,Kill,,,1"
+		"OnStartTouch" "playerRunScriptCodeWINNER <- 0;1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "zm_salvarHumanos"
 	}
 	insert:
 	{

--- a/stripper/ze_paranoid_rezurrection_csgo1.cfg
+++ b/stripper/ze_paranoid_rezurrection_csgo1.cfg
@@ -1,6 +1,6 @@
 // "ze_paranoid_rezurrection_csgo1" config, made by "Berke" "STEAM_1:0:95142811", version 3.
 
-// Delete low buy time, extend height of spawn trigger, fix zombies not getting teleported, fix getting to the safe spot without the winner status and delete player resetting stuff since they are handled by the trigger.
+// Delete low buy time, extend height of spawn trigger, fix zombies not getting teleported, fix getting to the safe spot without the winner status and delete the delay of player property resetting outputs.
 modify:
 {
 	match:
@@ -13,11 +13,11 @@ modify:
 		"OnMapSpawn" "player,AddOutput,gravity 1,,1"
 		"OnMapSpawn" "player,SetDamageFilter,,,1"
 		"OnMapSpawn" "player,Color,255 255 255,,1"
-		"OnMapSpawn" "protect_player,Enable,,1,1"
 		"OnMapSpawn" "protect_player,AddOutput,solid 2,,1"
 		"OnMapSpawn" "protect_playerRunScriptCodeself.SetSize(Vector(-1600, -1178.5, -184.017), Vector(1600, 1178.5, 616));1"
 		"OnMapSpawn" "map1anticheat1,AddOutput,solid 2,,1"
 		"OnMapSpawn" "map1anticheat1RunScriptCodeself.SetSize(Vector(-0.5, -8, -302), Vector(0.5, 8, 302));1"
+		"OnMapSpawn" "protect_player,Enable,,1,1"
 		"OnMapSpawn" "playerRunScriptCodeif (self.GetTeam() == 2 && self.GetHealth() != 0) { self.SetOrigin(Vector(-12408, -8140, 318)); self.SetAngles(0, -89, 0); }301"
 	}
 	delete:

--- a/stripper/ze_paranoid_rezurrection_csgo1.cfg
+++ b/stripper/ze_paranoid_rezurrection_csgo1.cfg
@@ -1,6 +1,6 @@
 // "ze_paranoid_rezurrection_csgo1" config, made by "Berke" "STEAM_1:0:95142811", version 3.
 
-// Delete low buy time, extend height of spawn trigger, fix zombies not getting teleported, fix getting to the safe spot without the winner status and delete delay of player resetting.
+// Delete low buy time, extend height of spawn trigger, fix zombies not getting teleported, fix getting to the safe spot without the winner status and delete player resetting stuff since they are handled by the trigger.
 modify:
 {
 	match:
@@ -13,11 +13,11 @@ modify:
 		"OnMapSpawn" "player,AddOutput,gravity 1,,1"
 		"OnMapSpawn" "player,SetDamageFilter,,,1"
 		"OnMapSpawn" "player,Color,255 255 255,,1"
+		"OnMapSpawn" "protect_player,Enable,,1,1"
 		"OnMapSpawn" "protect_player,AddOutput,solid 2,,1"
 		"OnMapSpawn" "protect_playerRunScriptCodeself.SetSize(Vector(-1600, -1178.5, -184.017), Vector(1600, 1178.5, 616));1"
 		"OnMapSpawn" "map1anticheat1,AddOutput,solid 2,,1"
 		"OnMapSpawn" "map1anticheat1RunScriptCodeself.SetSize(Vector(-0.5, -8, -302), Vector(0.5, 8, 302));1"
-		"OnMapSpawn" "protect_player,Enable,,1,1"
 		"OnMapSpawn" "playerRunScriptCodeif (self.GetTeam() == 2 && self.GetHealth() != 0) { self.SetOrigin(Vector(-12408, -8140, 318)); self.SetAngles(0, -89, 0); }301"
 	}
 	delete:
@@ -27,6 +27,45 @@ modify:
 		"OnMapSpawn" "playerAddOutputrendermode 03-1"
 		"OnMapSpawn" "playerAddOutputgavity 13-1"
 		"OnMapSpawn" "playerSetDamageFilter3-1"
+	}
+}
+
+// Fix map giving players the "player" targetname, messing up the "player" "classname" targeted outputs.
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "zm_sorpresa"
+	}
+	delete:
+	{
+		"OnStartTouch" "!activatorAddOutputtargetname player0-1"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activator,AddOutput,targetname ,,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "clear_player"
+	}
+	delete:
+	{
+		"OnStartTouch" "!selfRunScriptCodeClearPlayer();0-1"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activator,AddOutput,rendermode 0,,-1"
+		"OnStartTouch" "!activator,AddOutput,gravity 1,,-1"
+		"OnStartTouch" "!activator,SetDamageFilter,,,-1"
+		"OnStartTouch" "!selfRunScriptCodeforeach (A, _ in {monstruo = 0}) if (activator.GetName() != A) foreach (A, _ in {FireUser1 = 0}) EntFireByHandle(self, A, A, 0, activator, null);-1"
+		"OnUser1" "!activator,AddOutput,targetname ,,-1"
 	}
 }
 
@@ -59,10 +98,12 @@ modify:
 	delete:
 	{
 		"model" "*386"
+		"OnStartTouch" "!activatorAddOutputtargetname player0-1"
 		"OnEndTouchAll" "!activatorSetDamageFilter0-1"
 	}
 	insert:
 	{
+		"OnStartTouch" "!activator,AddOutput,targetname ,,-1"
 		"OnStartTouch" "!activator,Color,255 255 255,,-1"
 		"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 	}


### PR DESCRIPTION
-Fixed spawn immunity breaking due to me removing the enable delay of the spawn immunity trigger but map also removing the immunity with logic_auto later.
-Fixed winner status getting reset when you win a mode that doesn't teleport you to coliseum.
-Fixed reaching the safe spot in spawn without winner status.
-Fixed some inputs to player not working.