### PR TITLE
Update deadcore stripper

### DIFF
--- a/stripper/ze_deadcore_k2.cfg
+++ b/stripper/ze_deadcore_k2.cfg
@@ -1,40 +1,16 @@
-;remove stuff that shouldn't be in the map by default
-;trigger redcore by using "sm_forceinput RedcoreRelay Trigger"
-filter:
+;beating normal D progresses to insane D (since Airvulpes is fine with it being an official stage)
+modify:
 {
-	"targetname" "admin_button_ex_d_ents"
-}
-filter:
-{
-	"targetname" "admin_button_ex_d"
-}
-filter:
-{
-	"targetname" "admin_button_ex_d_off"
-}
-add:
-{
-	"classname" "logic_relay"
-	"origin" "-15000 -14632 -16184"
-	"targetname" "RedcoreRelay"
-	"StartDisabled" "0"
-	"spawnflags" "0"
-	"OnTrigger" "serverCommandsay *** ADMIN HAS ENABLED D INSANE MODE ***0-1"
-	"OnTrigger" "level_stockAddOutputOnUser1 level_counter:SetValue:8:0.06:10.02-1"
-	"OnTrigger" "serverCommandsay *** RESTARTING ROUND IN 3 ***1-1"
-	"OnTrigger" "serverCommandsay *** 2 ***2-1"
-	"OnTrigger" "serverCommandsay *** 1 ***3-1"
-	"OnTrigger" "admin_nukeCountPlayersInZone4-1"
-}
-add:
-{
-	"classname" "point_worldtext"
-	"origin" "-14813 -15071 -16132"
-	"angles" "-0 -90 0"
-	"message" "sm_forceinput RedcoreRelay Trigger"
-	"color" "255 0 0"
-	"textsize" "8"
-	"spawnflags" "0"
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "d_win_detecttrigger"
+	}
+	insert:
+	{
+		"OnStartTouch" "serverCommandsay *** D INSANE MODE ENABLED FOR NEXT ROUND ***0-1"
+		"OnStartTouch" "level_stockAddOutputOnUser1 level_counter:SetValue:8:0.06:10.02-1"
+	}
 }
 
 ;Not sure why this is here. Teleports players to admin room. NOT needed.


### PR DESCRIPTION
Following today's discussion and with Airvulpes' permission, D Insane stage will now be automatically enabled once D is beaten.