### PR TITLE
ze_escape_together_vb1a.cfg

### DIFF
--- a/stripper/ze_escape_together_vb1a.cfg
+++ b/stripper/ze_escape_together_vb1a.cfg
@@ -1,0 +1,71 @@
+;fix the door where it didn't kill players
+modify:
+{
+    match:
+    {
+		"classname" "func_door"
+		"targetname" "door1"
+    }
+    replace:
+    {
+		"forceclosed" "1"
+		"dmg" "99999"
+    }
+}
+modify:
+{
+    match:
+    {
+		"classname" "func_door"
+		"targetname" "end_door"
+    }
+    replace:
+    {
+		"forceclosed" "1"
+		"dmg" "99999"
+    }
+}
+
+;move trigger_teleport higher where people could walk on the white platform
+modify:
+{
+	match:
+	{
+		"classname" "trigger_teleport"
+		"hammerid" "163693"
+	}
+	replace:
+	{
+		"origin" "592.5 -543 -8091"
+	}
+}
+
+;nerf the defense from 40 to 30 seconds, also change the time of lasers and zombie teleport
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"hammerid" "607597"
+	}
+	delete:
+	{
+		"OnStartTouch" "door1Close351"
+    	"OnStartTouch" "teleport13Enable101"
+    	"OnStartTouch" "servercommandsCommandsay [ ZM TP ]101"
+    	"OnStartTouch" "trigger_uwuEnable451"
+        "OnStartTouch" "servercommandsCommandsay | 40s |01"
+        "OnStartTouch" "lasers_timer_togetherDisable401"
+        "OnStartTouch" "lasers_timer_togetherEnable361"
+    }    
+	insert:
+	{
+		"OnStartTouch" "door1Close251"
+    	"OnStartTouch" "teleport13Enable151"
+    	"OnStartTouch" "servercommandsCommandsay [ ZM TP ]151"
+    	"OnStartTouch" "trigger_uwuEnable301"
+        "OnStartTouch" "servercommandsCommandsay | 25s |01"
+        "OnStartTouch" "lasers_timer_togetherDisable251"
+        "OnStartTouch" "lasers_timer_togetherEnable291"
+	}
+}


### PR DESCRIPTION
*Add ze_escape_together_vb1a.cfg
- fix the door where it didn't kill players
- move trigger_teleport higher where people could walk on the white platform
- nerf the defense from 40 to 30 seconds, also change the time of lasers and zombie teleport