### PR TITLE
Fixes to Mapeadores Museum

### DIFF
--- a/stripper/ze_mapeadores_museum_v1.cfg
+++ b/stripper/ze_mapeadores_museum_v1.cfg
@@ -273,3 +273,103 @@ modify:
 		"OnStartTouch" "zplit_targetbossAddHealth10000-1"
 	}
 }
+
+// Rest of the changes are made by "Berke" "STEAM_1:0:95142811", version 1.
+
+
+// Allow passing strings on the "RunScriptCode" outputs.
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "generalfixes"
+	}
+	insert:
+	{
+		"OnSpawn" "!selfRunScriptCode_ <- delegate { function _get(strKey) { return strKey; } } : {};1"
+	}
+}
+
+// Try to fix "Action Sack" sometimes not equipping hammers correctly, I am guessing it is caused by knife stripping sometimes being fired too late, change place of "OrdiAssignHammer" function to make sure it is run after knife stripping.
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "ord_assignhammer_trig"
+	}
+	delete:
+	{
+		"OnStartTouch" "generalfixesRunScriptCodeOrdiAssignHammer();0-1"
+	}
+	insert:
+	{
+		"OnStartTouch" "generalfixes,CallScriptFunction,OrdiAssignHammer,,-1"
+		"OnStartTouch" "generalfixesRunScriptCodeif (!ordiassign_cd) EntFire(_.weaponstrip, _.Strip, ' '.tochar(), 0, activator);-1"
+	}
+}
+
+// Delete the "Action Sack" knife strip trigger since we now use the above method for stripping knives.
+filter:
+{
+	"classname" "trigger_once"
+	"targetname" "ord_gravhammer_strip"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "ord_temp_gravhammer"
+	}
+	delete:
+	{
+		"Template05" "ord_gravhammer_strip"
+	}
+}
+
+// Add blocking damage to last 2 traps of "Deathrun".
+modify:
+{
+	match:
+	{
+		"classname" "func_movelinear"
+		"targetname" "/spaicklastrap\d/"
+	}
+	replace:
+	{
+		"blockdamage" "9999"
+	}
+}
+
+// Implement button claiming to "Deathrun" buttons to prevent other people from using the trap button you are standing near.
+// This change requires having the "museumbuttonclaiming1.nut" file placed inside "scripts/vscripts/gfl" folder.
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "spaickbuttons"
+	}
+	insert:
+	{
+		"vscripts" "gfl/museumbuttonclaiming1.nut"
+		"thinkfunction" "Think"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "spaickbuttons"
+		"wait" "-1"
+	}
+	insert:
+	{
+		"OnPressed" "!self,CallScriptFunction,StopClaiming,,1"
+	}
+}

--- a/vscripts/museumbuttonclaiming1.nut
+++ b/vscripts/museumbuttonclaiming1.nut
@@ -1,0 +1,64 @@
+// Made by "Berke" "STEAM_1:0:95142811" for "ze_mapeadores_museum_v1", version 1.
+// Prevents other people from using the trap button you are standing near.
+
+iOrigin <- self.GetOrigin(), hClaimer <- null;
+
+function Think()
+{
+	if (hClaimer)
+	{
+		if (!hClaimer.IsValid() || !hClaimer.GetHealth() || !IsEyePositionInRange(hClaimer))
+		{
+			hClaimer = null;
+
+			FindAClaimer();
+		}
+	}
+
+	else
+		FindAClaimer();
+
+	return 0;
+}
+
+function InputUse()
+{
+	return activator == hClaimer;
+}
+
+function FindAClaimer()
+{
+	local hPlayer;
+
+	while (hPlayer = Entities.FindByClassname(hPlayer, "player"))
+		if (hPlayer && hPlayer.GetTeam() == 2 && hPlayer.GetHealth() && IsEyePositionInRange(hPlayer))
+		{
+			hClaimer = hPlayer;
+
+			break;
+		}
+}
+
+function IsEyePositionInRange(hPlayer)
+{
+	local flPlayerEyePosition = hPlayer.EyePosition();
+
+	if (abs(iOrigin.x - flPlayerEyePosition.x) <= 64 && abs(iOrigin.y - flPlayerEyePosition.y) <= 64 && abs(iOrigin.z - flPlayerEyePosition.z) <= 128)
+		return true;
+
+	return false;
+}
+
+function StopClaiming()
+{
+	self.__KeyValueFromString("thinkfunction", "");
+
+	delete iOrigin;
+	delete hClaimer;
+
+	delete InputUse;
+	delete Think;
+	delete FindAClaimer;
+	delete IsEyePositionInRange;
+	delete StopClaiming;
+}


### PR DESCRIPTION
-Try to fix "Action Sack" sometimes not equipping hammers correctly.
-Add blocking damage to last 2 traps of "Deathrun".
-Implement button claiming to "Deathrun" buttons to prevent other people from using the trap button you are standing near.