### PR TITLE
More fixes to Mapeadores Museum

### DIFF
--- a/stripper/ze_mapeadores_museum_v1.cfg
+++ b/stripper/ze_mapeadores_museum_v1.cfg
@@ -374,22 +374,6 @@ modify:
 }
 
 // Delay nuke preperation to fix stages with longer than 10 second delays for zombie teleportation.
-modify:
-{
-	match:
-	{
-		"classname" "math_counter"
-		"targetname" "spaickbuttons"
-	}
-	delete:
-	{
-		"OnTrigger" "NumMapsPerRoundAdd125-1"
-	}
-	insert:
-	{
-		"OnTrigger" "NumMapsPerRound,Add,1,,,-1"
-	}
-}
 
 modify:
 {

--- a/stripper/ze_mapeadores_museum_v1.cfg
+++ b/stripper/ze_mapeadores_museum_v1.cfg
@@ -274,8 +274,7 @@ modify:
 	}
 }
 
-// Rest of the changes are made by "Berke" "STEAM_1:0:95142811", version 1.
-
+// Rest of the changes are made by "Berke" "STEAM_1:0:95142811", version 2.
 
 // Allow passing strings on the "RunScriptCode" outputs.
 modify:
@@ -371,5 +370,73 @@ modify:
 	insert:
 	{
 		"OnPressed" "!self,CallScriptFunction,StopClaiming,,1"
+	}
+}
+
+// Delay nuke preperation to fix stages with longer than 10 second delays for zombie teleportation.
+modify:
+{
+	match:
+	{
+		"classname" "math_counter"
+		"targetname" "spaickbuttons"
+	}
+	delete:
+	{
+		"OnTrigger" "NumMapsPerRoundAdd125-1"
+	}
+	insert:
+	{
+		"OnTrigger" "NumMapsPerRound,Add,1,,,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "MuseumPrepareNextStage"
+	}
+	delete:
+	{
+		"OnTrigger" "NumMapsPerRoundAdd125-1"
+	}
+	insert:
+	{
+		"OnTrigger" "NumMapsPerRound,Add,1,28,,-1"
+	}
+}
+
+// Fix avoiding the teleport on edges of the end platform in "Deathrun".
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "sr_spaick"
+	}
+	insert:
+	{
+		"OnTrigger" "spaicktphumantomuseum,AddOutput,solid 2,.01,1"
+		"OnTrigger" "spaicktphumantomuseumRunScriptCodeself.SetSize(Vector(-496, -432, -200), Vector(496, 432, 200));.011"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_teleport"
+		"targetname" "spaicktphumantomuseum"
+	}
+	replace:
+	{
+		"origin" "-24 14592 -5408"
+	}
+	delete:
+	{
+		"model" "*484"
 	}
 }


### PR DESCRIPTION
-Fix zombies not teleporting to the final stage if zombie teleport delay is more than 10 seconds.
-Fix avoiding the teleport on edges of the end platform in "Deathrun".