### PR TITLE
Fixes to Last Man Standing

### DIFF
--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -110,7 +110,7 @@ modify:
 	}
 	insert:
 	{
-		"OnTrigger" "Z_Items_Filter,AddOutput,OnPass !self:FireUser1:::-1,,-1"
+		"OnTrigger" "Z_Items_Filter,AddOutput,OnPass !self:FireUser1:::-1,,1"
 	}
 }
 

--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -51,6 +51,53 @@ add:
 }
 
 // Rest of the changes are made by "Berke" "STEAM_1:0:95142811", version 1.
+
+// Fix spawn trigger not resetting players.
+filter:
+{
+	"classname" "trigger_multiple"
+	"targetname" "teleporter_main_trigger_positioner"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_teleport"
+		"targetname" "teleporter_main_trigger_positioner"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activator,AddOutput,targetname ,,-1"
+		"OnStartTouch" "!activator,AddOutput,gravity 1,,-1"
+		"OnStartTouch" "!activator,AddOutput,OnUser3 !self:AddOutput:health 1200::1,0,-1"
+		"OnStartTouch" "!activator,AddOutput,rendermode 0,,-1"
+		"OnStartTouch" "!activator,AddOutput,gravity 1,,-1"
+		"OnStartTouch" "!activator,AddOutput,renderfx 0,,-1"
+		"OnStartTouch" "!activator,SetDamageFilter,,,-1"
+		"OnStartTouch" "!activator,ClearContext,,,-1"
+		"OnStartTouch" "teleporter_main_counter,Add,1,,-1"
+		"OnStartTouch" "Global_Speed_suppress,ModifySpeed,1,,-1"
+		"OnStartTouch" "stage_end_explosion_working,Trigger,,540,1"
+		"OnStartTouch" "stage_5_top_teleport_counter,Add,1,,-1"
+		"OnStartTouch" "Z_Items_Filter,TestActivator,,,-1"
+		"OnUser1" "!activator,AddOutput,OnUser3 !self:AddOutput:health 10000:.1:1,,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "filter_multi"
+		"targetname" "Z_Items_Filter"
+	}
+	insert:
+	{
+		"OnPass" "teleporter_main_trigger_positioner,FireUser1,,,-1"
+	}
+}
+
 // Remove the message related to checkpoints in warmup round since this version doesn't have them.
 modify:
 {
@@ -160,32 +207,32 @@ modify:
 	}
 }
 
-// Prevent the "Portal Gun" skip.
-modify:
-{
-	match:
-	{
-		"classname" "func_button"
-		"targetname" "Weapon_PortalGun_UI"
-	}
-	replace:
-	{
-		"origin" "-1004 13248 -8512"
-	}
-}
+// Optional: Prevent the "Portal Gun" skip.
+//modify:
+//{
+//	match:
+//	{
+//		"classname" "func_button"
+//		"targetname" "Weapon_PortalGun_UI"
+//	}
+//	replace:
+//	{
+//		"origin" "-1004 13248 -8512"
+//	}
+//}
 
-modify:
-{
-	match:
-	{
-		"classname" "env_entity_maker"
-		"targetname" "Weapon_PortalGun_Projectile_Spawner"
-	}
-	replace:
-	{
-		"origin" "-1088 13248 -8520"
-	}
-}
+//modify:
+//{
+//	match:
+//	{
+//		"classname" "env_entity_maker"
+// 		"targetname" "Weapon_PortalGun_Projectile_Spawner"
+//	}
+//	replace:
+//	{
+//		"origin" "-1088 13248 -8520"
+//	}
+//}
 
 // Fix stage 2 last vent fall breaking despite second room being "Mutator Test".
 modify:

--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -13,7 +13,6 @@ modify:
 		"OnUser1" "Mode_Extreme_CompareCompare0.06-1"
 	}
 }
-
 ;fix early triggering nuke on stage 4
 modify:
 {
@@ -27,7 +26,6 @@ modify:
 		"OnStartTouch" "stage_4_trigger_end,Enable,0,-1"
 	}
 }
-
 modify:
 {
 	match:
@@ -40,7 +38,6 @@ modify:
 		"StartDisabled" "1"
 	}
 }
-
 ;Fix possible skip with tank on Stage4
 add:
 {
@@ -49,9 +46,7 @@ add:
 	"model" "*142"
 	"rendermode" "10"
 }
-
 // Rest of the changes are made by "Berke" "STEAM_1:0:95142811", version 1.
-
 // Remove the message related to checkpoints in warmup round since this version doesn't have them.
 modify:
 {
@@ -65,7 +60,6 @@ modify:
 		"OnTrigger" "Global_GameText_AnnouncementAddOutputmessage CHECKPOINT REACHED MEANS STAGE WONT REPEAT WHEN IT ENDS5-1"
 	}
 }
-
 // Add a prop to get out of a stuck spot near tank spawn on extreme stage 1.
 add:
 {
@@ -76,7 +70,6 @@ add:
 	"model" "models/props/props_crates/wooden_crate_64x64.mdl"
 	"solid" "6"
 }
-
 add:
 {
 	"classname" "prop_dynamic"
@@ -85,7 +78,6 @@ add:
 	"model" "models/props/props_crates/wooden_crate_64x64.mdl"
 	"solid" "6"
 }
-
 add:
 {
 	"classname" "prop_dynamic"
@@ -95,8 +87,7 @@ add:
 	"model" "models/props/de_nuke/crate_large.mdl"
 	"solid" "6"
 }
-
-// Add viewcontrol template related outputs and filter stage 1 "Juggernaut" trigger to humans.
+// Add viewcontrol template related outputs, filter stage 1 "Juggernaut" trigger to humans and reset targetnames.
 modify:
 {
 	match:
@@ -116,9 +107,9 @@ modify:
 		"OnSpawn" "stage_x_crane_breakableRunScriptCodefunction InputUse() { if (activator.GetTeam() == 3) return true; return false; }1"
 		"OnSpawn" "stage_x_crane_crateRunScriptCodefunction InputUse() { if (activator.GetTeam() == 3) return true; return false; }1"
 		"OnSpawn" "game_playerdieRunScriptCode_ <- delegate { function _get(strKey) { return strKey; } } : {};1"
+		"OnSpawn" "player,AddOutput,targetname ,,1"
 	}
 }
-
 // Fix killing people with stage 2 first big door.
 modify:
 {
@@ -132,7 +123,6 @@ modify:
 		"dmg" "1"
 	}
 }
-
 // Fix stage 2 last vent entrance being breakable early.
 modify:
 {
@@ -146,7 +136,6 @@ modify:
 		"OnStartTouch" "stage_2_escape_vent,SetHealth,100,10,1"
 	}
 }
-
 modify:
 {
 	match:
@@ -159,7 +148,6 @@ modify:
 		"health" "0"
 	}
 }
-
 // Prevent the "Portal Gun" skip.
 modify:
 {
@@ -173,7 +161,6 @@ modify:
 		"origin" "-1004 13248 -8512"
 	}
 }
-
 modify:
 {
 	match:
@@ -186,7 +173,6 @@ modify:
 		"origin" "-1088 13248 -8520"
 	}
 }
-
 // Fix stage 2 last vent fall breaking despite second room being "Mutator Test".
 modify:
 {
@@ -200,7 +186,6 @@ modify:
 		"OnCase03" "stage_2_end_trigger,AddOutput,OnTrigger stage_2_vent_breakable:Break:::1,,1"
 	}
 }
-
 modify:
 {
 	match:
@@ -213,7 +198,6 @@ modify:
 		"OnStartTouch" "stage_2_vent_breakableBreak0-1"
 	}
 }
-
 // Reduce volume of "Mech" minigun sound.
 modify:
 {
@@ -227,7 +211,6 @@ modify:
 		"health" "3"
 	}
 }
-
 // Fix stage 4 nuke pit teleport being setup wrong.
 modify:
 {
@@ -245,7 +228,6 @@ modify:
 		"target" "stages_teleport_destination"
 	}
 }
-
 // Fix stage 4 nuke pad being broken showing the wrong message, being able to be damaged multiple times and not resulting in a round end.
 modify:
 {
@@ -265,14 +247,12 @@ modify:
 		"OnDamaged" "map1roundend1,EndRound_TerroristsWin,7,,1"
 	}
 }
-
 add:
 {
 	"classname" "game_round_end"
 	"targetname" "map1roundend1"
 	"OnRoundEnded" "map1roundend1,Kill,,,1"
 }
-
 // Fix the new truck model used in stage 5 not covering the side like in the original.
 modify:
 {
@@ -286,7 +266,6 @@ modify:
 		"origin" "3904 -3440 12480"
 	}
 }
-
 // Prevent explosions from triggering repeat killer.
 modify:
 {
@@ -297,8 +276,8 @@ modify:
 	}
 	insert:
 	{
-		"OnSpawn" "Spawn_Explosion_Damage,AddOutput,classname norepeatkiller1,,-1"
-		"OnSpawn" "Spawn_Explosion_Damage_All,AddOutput,classname norepeatkiller1,,-1"
+		"OnSpawn" "Spawn_Explosion_Damage,AddOutput,classname norepeatkiller1,,1"
+		"OnSpawn" "Spawn_Explosion_Damage_All,AddOutput,classname norepeatkiller1,,1"
 	}
 }
 
@@ -311,8 +290,8 @@ modify:
 	}
 	insert:
 	{
-		"OnSpawn" "Spawn_Explosion_Small_Damage,AddOutput,classname norepeatkiller1,,-1"
-		"OnSpawn" "Spawn_Explosion_Small_Damage_H,AddOutput,classname norepeatkiller1,,-1"
+		"OnSpawn" "Spawn_Explosion_Small_Damage,AddOutput,classname norepeatkiller1,,1"
+		"OnSpawn" "Spawn_Explosion_Small_Damage_H,AddOutput,classname norepeatkiller1,,1"
 	}
 }
 
@@ -336,7 +315,6 @@ modify:
 		"OnTrigger" "Tank_Cannon,Color,64 64 64,.01,1"
 	}
 }
-
 // Prevent camping zombie spawns.
 // Add filters that prevent all damage but nuke.
 add:
@@ -345,21 +323,18 @@ add:
 	"targetname" "map1nukefilter1"
 	"filtername" "Nuke_Kill_Trigger"
 }
-
 add:
 {
 	"classname" "filter_activator_name"
 	"targetname" "map1nukefilter2"
 	"filtername" "Kill_All_Trigger"
 }
-
 add:
 {
 	"classname" "filter_activator_name"
 	"targetname" "map1nukefilter3"
 	"filtername" "stage_3_nuke"
 }
-
 add:
 {
 	"classname" "filter_multi"
@@ -369,7 +344,6 @@ add:
 	"Filter02" "map1nukefilter2"
 	"Filter03" "map1nukefilter3"
 }
-
 // Stage 1
 add:
 {
@@ -382,7 +356,6 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
-
 add:
 {
 	"classname" "trigger_multiple"
@@ -395,7 +368,6 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
-
 add:
 {
 	"classname" "trigger_multiple"
@@ -408,7 +380,6 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
-
 add:
 {
 	"classname" "trigger_multiple"
@@ -421,7 +392,6 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
-
 // Stage 2
 add:
 {
@@ -435,7 +405,6 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
-
 add:
 {
 	"classname" "trigger_multiple"
@@ -448,7 +417,6 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
-
 add:
 {
 	"classname" "trigger_multiple"
@@ -461,7 +429,6 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
-
 // Stage 3
 add:
 {
@@ -474,7 +441,6 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
-
 add:
 {
 	"classname" "trigger_multiple"
@@ -487,7 +453,6 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
-
 add:
 {
 	"classname" "trigger_multiple"
@@ -499,7 +464,6 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
-
 // Stage 4
 add:
 {
@@ -513,7 +477,6 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
-
 add:
 {
 	"classname" "trigger_multiple"
@@ -526,7 +489,6 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
-
 add:
 {
 	"classname" "trigger_multiple"
@@ -538,7 +500,6 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
-
 add:
 {
 	"classname" "trigger_multiple"
@@ -550,7 +511,6 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
-
 // Implement the unused zombie teleport in extreme stage 1.
 modify:
 {
@@ -564,7 +524,6 @@ modify:
 		"OnFullyOpen" "stage_positioner_teleport,InValue,11,5,1"
 	}
 }
-
 // Implement the unused zombie teleport in extreme stage 3.
 modify:
 {
@@ -578,7 +537,6 @@ modify:
 		"OnTrigger" "stage_positioner_teleport,InValue,32,15,1"
 	}
 }
-
 // Fix viewcontrols being laggy for "Alex Mercer" and "Mech".
 // Delete the old system used for viewcontrols.
 filter:
@@ -586,27 +544,22 @@ filter:
 	"classname" "logic_measure_movement"
 	"targetname" "Zombie_Item_Boss_Measure"
 }
-
 filter:
 {
 	"classname" "info_teleport_destination"
 	"targetname" "Zombie_Item_Boss_Cam_Pos_2"
 }
-
 filter:
 {
 	"classname" "logic_measure_movement"
 	"targetname" "Human_Item_Mech_Measure"
 }
-
 filter:
 {
 	"classname" "info_teleport_destination"
 	"targetname" "Human_Item_Mech_Cam_Pos_2"
 }
-
 // Add the new system where we spawn the viewcontrols using preserved templates and spawn them parented.
-
 modify:
 {
 	match:
@@ -619,7 +572,6 @@ modify:
 		"parentname" "Zombie_Item_Boss_Cam_Pos"
 	}
 }
-
 modify:
 {
 	match:
@@ -632,21 +584,18 @@ modify:
 		"parentname" "Human_Item_Mech_Knife"
 	}
 }
-
 add:
 {
 	"classname" "point_template"
 	"targetname" "map1viewcontroltemplate1"
 	"Template01" "Zombie_Item_Boss_Cam"
 }
-
 add:
 {
 	"classname" "point_template"
 	"targetname" "map1viewcontroltemplate2"
 	"Template01" "Human_Item_Mech_Cam"
 }
-
 modify:
 {
 	match:
@@ -661,8 +610,7 @@ modify:
 		"OnUser2" "map1viewcontroltemplate2,AddOutput,targetname map1viewcontrolpreservedtemplate2,,1"
 	}
 }
-
-// Give players empty targetname instead of one called "none" and prevent viewmodel from being glitched out.
+// When someone dies, give them empty targetname instead of one called "none" and prevent viewmodel from being glitched out.
 modify:
 {
 	match:

--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -68,20 +68,8 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "!activator,AddOutput,targetname ,,-1"
-		"OnStartTouch" "!activator,AddOutput,gravity 1,,-1"
-		"OnStartTouch" "!activator,AddOutput,OnUser3 !self:AddOutput:health 1200::1,,-1"
-		"OnStartTouch" "!activator,AddOutput,rendermode 0,,-1"
-		"OnStartTouch" "!activator,AddOutput,gravity 1,,-1"
-		"OnStartTouch" "!activator,AddOutput,renderfx 0,,-1"
-		"OnStartTouch" "!activator,SetDamageFilter,,,-1"
-		"OnStartTouch" "!activator,ClearContext,,,-1"
-		"OnStartTouch" "teleporter_main_counter,Add,1,,-1"
-		"OnStartTouch" "Global_Speed_suppress,ModifySpeed,1,,-1"
 		"OnStartTouch" "stage_end_explosion_working,Trigger,,540,1"
-		"OnStartTouch" "stage_5_top_teleport_counter,Add,1,,-1"
 		"OnStartTouch" "Z_Items_Filter,TestActivator,,,-1"
-		"OnUser1" "!activator,AddOutput,OnUser3 !self:AddOutput:health 10000:.1:1,,-1"
 	}
 }
 
@@ -94,7 +82,35 @@ modify:
 	}
 	insert:
 	{
-		"OnPass" "teleporter_main_trigger_positioner,FireUser1,,,-1"
+		"OnPass" "!activator,AddOutput,targetname ,,-1"
+		"OnPass" "!activator,AddOutput,gravity 1,,-1"
+		"OnPass" "!activator,AddOutput,OnUser3 !self:AddOutput:health 1200::1,.01,-1"
+		"OnPass" "!activator,AddOutput,rendermode 0,,-1"
+		"OnPass" "!activator,AddOutput,gravity 1,,-1"
+		"OnPass" "!activator,AddOutput,renderfx 0,,-1"
+		"OnPass" "!activator,SetDamageFilter,,,-1"
+		"OnPass" "!activator,ClearContext,,,-1"
+		"OnPass" "teleporter_main_counter,Add,1,,-1"
+		"OnPass" "Global_Speed_suppress,ModifySpeed,1,,-1"
+		"OnPass" "stage_5_top_teleport_counter,Add,1,,-1"
+		"OnUser1" "!activator,AddOutput,OnUser3 !self:AddOutput:health 10000::1,,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "/Extreme_Stage_[1-4]/"
+	}
+	delete:
+	{
+		"OnTrigger" "teleporter_main_trigger_positionerAddOutputOnStartTouch !self:FireUser1::0:00-1"
+	}
+	insert:
+	{
+		"OnTrigger" "Z_Items_Filter,AddOutput,OnPass !self:FireUser1:::-1,,-1"
 	}
 }
 

--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -70,7 +70,7 @@ modify:
 	{
 		"OnStartTouch" "!activator,AddOutput,targetname ,,-1"
 		"OnStartTouch" "!activator,AddOutput,gravity 1,,-1"
-		"OnStartTouch" "!activator,AddOutput,OnUser3 !self:AddOutput:health 1200::1,0,-1"
+		"OnStartTouch" "!activator,AddOutput,OnUser3 !self:AddOutput:health 1200::1,,-1"
 		"OnStartTouch" "!activator,AddOutput,rendermode 0,,-1"
 		"OnStartTouch" "!activator,AddOutput,gravity 1,,-1"
 		"OnStartTouch" "!activator,AddOutput,renderfx 0,,-1"
@@ -163,20 +163,6 @@ modify:
 		"OnSpawn" "stage_x_crane_crateRunScriptCodefunction InputUse() { if (activator.GetTeam() == 3) return true; return false; }1"
 		"OnSpawn" "game_playerdieRunScriptCode_ <- delegate { function _get(strKey) { return strKey; } } : {};1"
 		"OnSpawn" "player,AddOutput,targetname ,,1"
-	}
-}
-
-// Fix killing people with stage 2 first big door.
-modify:
-{
-	match:
-	{
-		"classname" "func_door"
-		"targetname" "stage_x_second_door"
-	}
-	replace:
-	{
-		"dmg" "1"
 	}
 }
 

--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -13,6 +13,7 @@ modify:
 		"OnUser1" "Mode_Extreme_CompareCompare0.06-1"
 	}
 }
+
 ;fix early triggering nuke on stage 4
 modify:
 {
@@ -26,6 +27,7 @@ modify:
 		"OnStartTouch" "stage_4_trigger_end,Enable,0,-1"
 	}
 }
+
 modify:
 {
 	match:
@@ -38,6 +40,7 @@ modify:
 		"StartDisabled" "1"
 	}
 }
+
 ;Fix possible skip with tank on Stage4
 add:
 {
@@ -46,6 +49,7 @@ add:
 	"model" "*142"
 	"rendermode" "10"
 }
+
 // Rest of the changes are made by "Berke" "STEAM_1:0:95142811", version 1.
 // Remove the message related to checkpoints in warmup round since this version doesn't have them.
 modify:
@@ -60,6 +64,7 @@ modify:
 		"OnTrigger" "Global_GameText_AnnouncementAddOutputmessage CHECKPOINT REACHED MEANS STAGE WONT REPEAT WHEN IT ENDS5-1"
 	}
 }
+
 // Add a prop to get out of a stuck spot near tank spawn on extreme stage 1.
 add:
 {
@@ -70,6 +75,7 @@ add:
 	"model" "models/props/props_crates/wooden_crate_64x64.mdl"
 	"solid" "6"
 }
+
 add:
 {
 	"classname" "prop_dynamic"
@@ -78,6 +84,7 @@ add:
 	"model" "models/props/props_crates/wooden_crate_64x64.mdl"
 	"solid" "6"
 }
+
 add:
 {
 	"classname" "prop_dynamic"
@@ -87,6 +94,7 @@ add:
 	"model" "models/props/de_nuke/crate_large.mdl"
 	"solid" "6"
 }
+
 // Add viewcontrol template related outputs, filter stage 1 "Juggernaut" trigger to humans and reset targetnames.
 modify:
 {
@@ -110,6 +118,7 @@ modify:
 		"OnSpawn" "player,AddOutput,targetname ,,1"
 	}
 }
+
 // Fix killing people with stage 2 first big door.
 modify:
 {
@@ -123,6 +132,7 @@ modify:
 		"dmg" "1"
 	}
 }
+
 // Fix stage 2 last vent entrance being breakable early.
 modify:
 {
@@ -136,6 +146,7 @@ modify:
 		"OnStartTouch" "stage_2_escape_vent,SetHealth,100,10,1"
 	}
 }
+
 modify:
 {
 	match:
@@ -148,6 +159,7 @@ modify:
 		"health" "0"
 	}
 }
+
 // Prevent the "Portal Gun" skip.
 modify:
 {
@@ -161,6 +173,7 @@ modify:
 		"origin" "-1004 13248 -8512"
 	}
 }
+
 modify:
 {
 	match:
@@ -173,6 +186,7 @@ modify:
 		"origin" "-1088 13248 -8520"
 	}
 }
+
 // Fix stage 2 last vent fall breaking despite second room being "Mutator Test".
 modify:
 {
@@ -186,6 +200,7 @@ modify:
 		"OnCase03" "stage_2_end_trigger,AddOutput,OnTrigger stage_2_vent_breakable:Break:::1,,1"
 	}
 }
+
 modify:
 {
 	match:
@@ -198,6 +213,7 @@ modify:
 		"OnStartTouch" "stage_2_vent_breakableBreak0-1"
 	}
 }
+
 // Reduce volume of "Mech" minigun sound.
 modify:
 {
@@ -211,6 +227,7 @@ modify:
 		"health" "3"
 	}
 }
+
 // Fix stage 4 nuke pit teleport being setup wrong.
 modify:
 {
@@ -228,6 +245,7 @@ modify:
 		"target" "stages_teleport_destination"
 	}
 }
+
 // Fix stage 4 nuke pad being broken showing the wrong message, being able to be damaged multiple times and not resulting in a round end.
 modify:
 {
@@ -247,12 +265,14 @@ modify:
 		"OnDamaged" "map1roundend1,EndRound_TerroristsWin,7,,1"
 	}
 }
+
 add:
 {
 	"classname" "game_round_end"
 	"targetname" "map1roundend1"
 	"OnRoundEnded" "map1roundend1,Kill,,,1"
 }
+
 // Fix the new truck model used in stage 5 not covering the side like in the original.
 modify:
 {
@@ -266,6 +286,7 @@ modify:
 		"origin" "3904 -3440 12480"
 	}
 }
+
 // Prevent explosions from triggering repeat killer.
 modify:
 {
@@ -315,6 +336,7 @@ modify:
 		"OnTrigger" "Tank_Cannon,Color,64 64 64,.01,1"
 	}
 }
+
 // Prevent camping zombie spawns.
 // Add filters that prevent all damage but nuke.
 add:
@@ -323,18 +345,21 @@ add:
 	"targetname" "map1nukefilter1"
 	"filtername" "Nuke_Kill_Trigger"
 }
+
 add:
 {
 	"classname" "filter_activator_name"
 	"targetname" "map1nukefilter2"
 	"filtername" "Kill_All_Trigger"
 }
+
 add:
 {
 	"classname" "filter_activator_name"
 	"targetname" "map1nukefilter3"
 	"filtername" "stage_3_nuke"
 }
+
 add:
 {
 	"classname" "filter_multi"
@@ -344,6 +369,7 @@ add:
 	"Filter02" "map1nukefilter2"
 	"Filter03" "map1nukefilter3"
 }
+
 // Stage 1
 add:
 {
@@ -356,6 +382,7 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
+
 add:
 {
 	"classname" "trigger_multiple"
@@ -368,6 +395,7 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
+
 add:
 {
 	"classname" "trigger_multiple"
@@ -380,6 +408,7 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
+
 add:
 {
 	"classname" "trigger_multiple"
@@ -392,6 +421,7 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
+
 // Stage 2
 add:
 {
@@ -405,6 +435,7 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
+
 add:
 {
 	"classname" "trigger_multiple"
@@ -417,6 +448,7 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
+
 add:
 {
 	"classname" "trigger_multiple"
@@ -429,6 +461,7 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
+
 // Stage 3
 add:
 {
@@ -441,6 +474,7 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
+
 add:
 {
 	"classname" "trigger_multiple"
@@ -453,6 +487,7 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
+
 add:
 {
 	"classname" "trigger_multiple"
@@ -464,6 +499,7 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
+
 // Stage 4
 add:
 {
@@ -477,6 +513,7 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
+
 add:
 {
 	"classname" "trigger_multiple"
@@ -489,6 +526,7 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
+
 add:
 {
 	"classname" "trigger_multiple"
@@ -500,6 +538,7 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
+
 add:
 {
 	"classname" "trigger_multiple"
@@ -511,6 +550,7 @@ add:
 	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
+
 // Implement the unused zombie teleport in extreme stage 1.
 modify:
 {
@@ -524,6 +564,7 @@ modify:
 		"OnFullyOpen" "stage_positioner_teleport,InValue,11,5,1"
 	}
 }
+
 // Implement the unused zombie teleport in extreme stage 3.
 modify:
 {
@@ -537,6 +578,7 @@ modify:
 		"OnTrigger" "stage_positioner_teleport,InValue,32,15,1"
 	}
 }
+
 // Fix viewcontrols being laggy for "Alex Mercer" and "Mech".
 // Delete the old system used for viewcontrols.
 filter:
@@ -544,21 +586,25 @@ filter:
 	"classname" "logic_measure_movement"
 	"targetname" "Zombie_Item_Boss_Measure"
 }
+
 filter:
 {
 	"classname" "info_teleport_destination"
 	"targetname" "Zombie_Item_Boss_Cam_Pos_2"
 }
+
 filter:
 {
 	"classname" "logic_measure_movement"
 	"targetname" "Human_Item_Mech_Measure"
 }
+
 filter:
 {
 	"classname" "info_teleport_destination"
 	"targetname" "Human_Item_Mech_Cam_Pos_2"
 }
+
 // Add the new system where we spawn the viewcontrols using preserved templates and spawn them parented.
 modify:
 {
@@ -572,6 +618,7 @@ modify:
 		"parentname" "Zombie_Item_Boss_Cam_Pos"
 	}
 }
+
 modify:
 {
 	match:
@@ -584,18 +631,21 @@ modify:
 		"parentname" "Human_Item_Mech_Knife"
 	}
 }
+
 add:
 {
 	"classname" "point_template"
 	"targetname" "map1viewcontroltemplate1"
 	"Template01" "Zombie_Item_Boss_Cam"
 }
+
 add:
 {
 	"classname" "point_template"
 	"targetname" "map1viewcontroltemplate2"
 	"Template01" "Human_Item_Mech_Cam"
 }
+
 modify:
 {
 	match:
@@ -610,6 +660,7 @@ modify:
 		"OnUser2" "map1viewcontroltemplate2,AddOutput,targetname map1viewcontrolpreservedtemplate2,,1"
 	}
 }
+
 // When someone dies, give them empty targetname instead of one called "none" and prevent viewmodel from being glitched out.
 modify:
 {

--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -96,7 +96,7 @@ add:
 	"solid" "6"
 }
 
-// Add viewcontrol template related outputs and filter stage 1 "Juggernaut" trigger to humans.
+// Add viewcontrol template related outputs, filter stage 1 "Juggernaut" trigger to humans and reset targetnames.
 modify:
 {
 	match:
@@ -116,6 +116,7 @@ modify:
 		"OnSpawn" "stage_x_crane_breakableRunScriptCodefunction InputUse() { if (activator.GetTeam() == 3) return true; return false; }1"
 		"OnSpawn" "stage_x_crane_crateRunScriptCodefunction InputUse() { if (activator.GetTeam() == 3) return true; return false; }1"
 		"OnSpawn" "game_playerdieRunScriptCode_ <- delegate { function _get(strKey) { return strKey; } } : {};1"
+		"OnSpawn" "player,AddOutput,targetname ,,1"
 	}
 }
 
@@ -662,7 +663,7 @@ modify:
 	}
 }
 
-// Give players empty targetname instead of one called "none" and prevent viewmodel from being glitched out.
+// When someone dies, give them empty targetname instead of one called "none" and prevent viewmodel from being glitched out.
 modify:
 {
 	match:

--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -96,7 +96,7 @@ add:
 	"solid" "6"
 }
 
-// Add viewcontrol template related outputs, filter stage 1 "Juggernaut" trigger to humans and reset targetnames.
+// Add viewcontrol template related outputs and filter stage 1 "Juggernaut" trigger to humans.
 modify:
 {
 	match:
@@ -116,7 +116,6 @@ modify:
 		"OnSpawn" "stage_x_crane_breakableRunScriptCodefunction InputUse() { if (activator.GetTeam() == 3) return true; return false; }1"
 		"OnSpawn" "stage_x_crane_crateRunScriptCodefunction InputUse() { if (activator.GetTeam() == 3) return true; return false; }1"
 		"OnSpawn" "game_playerdieRunScriptCode_ <- delegate { function _get(strKey) { return strKey; } } : {};1"
-		"OnSpawn" "player,AddOutput,targetname ,,1"
 	}
 }
 
@@ -298,8 +297,8 @@ modify:
 	}
 	insert:
 	{
-		"OnSpawn" "Spawn_Explosion_Damage,AddOutput,classname norepeatkiller1,,1"
-		"OnSpawn" "Spawn_Explosion_Damage_All,AddOutput,classname norepeatkiller1,,1"
+		"OnSpawn" "Spawn_Explosion_Damage,AddOutput,classname norepeatkiller1,,-1"
+		"OnSpawn" "Spawn_Explosion_Damage_All,AddOutput,classname norepeatkiller1,,-1"
 	}
 }
 
@@ -312,8 +311,8 @@ modify:
 	}
 	insert:
 	{
-		"OnSpawn" "Spawn_Explosion_Small_Damage,AddOutput,classname norepeatkiller1,,1"
-		"OnSpawn" "Spawn_Explosion_Small_Damage_H,AddOutput,classname norepeatkiller1,,1"
+		"OnSpawn" "Spawn_Explosion_Small_Damage,AddOutput,classname norepeatkiller1,,-1"
+		"OnSpawn" "Spawn_Explosion_Small_Damage_H,AddOutput,classname norepeatkiller1,,-1"
 	}
 }
 
@@ -663,7 +662,7 @@ modify:
 	}
 }
 
-// When someone dies, give them empty targetname instead of one called "none" and prevent viewmodel from being glitched out.
+// Give players empty targetname instead of one called "none" and prevent viewmodel from being glitched out.
 modify:
 {
 	match:
@@ -679,7 +678,7 @@ modify:
 	{
 		"OnUse" "!activator,AddOutput,targetname ,,-1"
 		"OnUse" "!selfRunScriptCodeif (activator.IsValid() && (activator.GetName() == _.zombie_boss || activator.GetName() == _.human_mech)) EntFireByHandle(self, _.FireUser1, ' '.tochar(), 0, activator, null);-1"
-		"OnUser1" "v_cam1,Disable,,,1"
-		"OnUser1" "v_cam1,Enable,,,1"
+		"OnUser1" "Map_End_Camera,RemovePlayer,,,1"
+		"OnUser1" "Map_End_Camera,AddPlayer,,,1"
 	}
 }

--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -298,8 +298,8 @@ modify:
 	}
 	insert:
 	{
-		"OnSpawn" "Spawn_Explosion_Damage,AddOutput,classname norepeatkiller1,,-1"
-		"OnSpawn" "Spawn_Explosion_Damage_All,AddOutput,classname norepeatkiller1,,-1"
+		"OnSpawn" "Spawn_Explosion_Damage,AddOutput,classname norepeatkiller1,,1"
+		"OnSpawn" "Spawn_Explosion_Damage_All,AddOutput,classname norepeatkiller1,,1"
 	}
 }
 
@@ -312,8 +312,8 @@ modify:
 	}
 	insert:
 	{
-		"OnSpawn" "Spawn_Explosion_Small_Damage,AddOutput,classname norepeatkiller1,,-1"
-		"OnSpawn" "Spawn_Explosion_Small_Damage_H,AddOutput,classname norepeatkiller1,,-1"
+		"OnSpawn" "Spawn_Explosion_Small_Damage,AddOutput,classname norepeatkiller1,,1"
+		"OnSpawn" "Spawn_Explosion_Small_Damage_H,AddOutput,classname norepeatkiller1,,1"
 	}
 }
 

--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -49,3 +49,636 @@ add:
 	"model" "*142"
 	"rendermode" "10"
 }
+
+// Rest of the changes are made by "Berke" "STEAM_1:0:95142811", version 1.
+
+// Remove the message related to checkpoints in warmup round since this version doesn't have them.
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Stage_Start_Stage_Warmup"
+	}
+	delete:
+	{
+		"OnTrigger" "Global_GameText_AnnouncementAddOutputmessage CHECKPOINT REACHED MEANS STAGE WONT REPEAT WHEN IT ENDS5-1"
+	}
+}
+
+// Add a prop to get out of a stuck spot near tank spawn on extreme stage 1.
+add:
+{
+	"classname" "prop_dynamic"
+	"targetname" "stage_1_stuff1"
+	"origin" "2368 320 -13680"
+	"angles" "0 -15 0"
+	"model" "models/props/props_crates/wooden_crate_64x64.mdl"
+	"solid" "6"
+}
+
+add:
+{
+	"classname" "prop_dynamic"
+	"targetname" "stage_1_stuff1"
+	"origin" "2368 320 -13608"
+	"model" "models/props/props_crates/wooden_crate_64x64.mdl"
+	"solid" "6"
+}
+
+add:
+{
+	"classname" "prop_dynamic"
+	"targetname" "stage_1_stuff1"
+	"origin" "2384 224 -13680"
+	"angles" "-10 0 0"
+	"model" "models/props/de_nuke/crate_large.mdl"
+	"solid" "6"
+}
+
+// Add viewcontrol template related outputs and filter stage 1 "Juggernaut" trigger to humans.
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Auto"
+	}
+	replace:
+	{
+		"spawnflags" "1"
+	}
+	insert:
+	{
+		"OnSpawn" "map1viewcontrolpreservedtemplate*,ForceSpawn,,.01,1"
+		"OnSpawn" "map1viewcontroltemplate*,Kill,,.01,1"
+		"OnSpawn" "worldspawn_brush_target,FireUser2,,,1"
+		"OnSpawn" "stage_x_crane_breakableRunScriptCodefunction InputUse() { if (activator.GetTeam() == 3) return true; return false; }1"
+		"OnSpawn" "stage_x_crane_crateRunScriptCodefunction InputUse() { if (activator.GetTeam() == 3) return true; return false; }1"
+		"OnSpawn" "game_playerdieRunScriptCode_ <- delegate { function _get(strKey) { return strKey; } } : {};1"
+	}
+}
+
+// Fix killing people with stage 2 first big door.
+modify:
+{
+	match:
+	{
+		"classname" "func_door"
+		"targetname" "stage_x_second_door"
+	}
+	replace:
+	{
+		"dmg" "1"
+	}
+}
+
+// Fix stage 2 last vent entrance being breakable early.
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "stage_2_teleport_2"
+	}
+	insert:
+	{
+		"OnStartTouch" "stage_2_escape_vent,SetHealth,100,10,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_breakable"
+		"targetname" "stage_2_escape_vent"
+	}
+	replace:
+	{
+		"health" "0"
+	}
+}
+
+// Prevent the "Portal Gun" skip.
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "Weapon_PortalGun_UI"
+	}
+	replace:
+	{
+		"origin" "-1004 13248 -8512"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "env_entity_maker"
+		"targetname" "Weapon_PortalGun_Projectile_Spawner"
+	}
+	replace:
+	{
+		"origin" "-1088 13248 -8520"
+	}
+}
+
+// Fix stage 2 last vent fall breaking despite second room being "Mutator Test".
+modify:
+{
+	match:
+	{
+		"classname" "logic_case"
+		"targetname" "stage_2_open_random_relay"
+	}
+	insert:
+	{
+		"OnCase03" "stage_2_end_trigger,AddOutput,OnTrigger stage_2_vent_breakable:Break:::1,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "stage_2_end_trigger"
+	}
+	delete:
+	{
+		"OnStartTouch" "stage_2_vent_breakableBreak0-1"
+	}
+}
+
+// Reduce volume of "Mech" minigun sound.
+modify:
+{
+	match:
+	{
+		"classname" "ambient_generic"
+		"targetname" "Human_Item_Mech_Sound_Minigun"
+	}
+	replace:
+	{
+		"health" "3"
+	}
+}
+
+// Fix stage 4 nuke pit teleport being setup wrong.
+modify:
+{
+	match:
+	{
+		"classname" "trigger_teleport"
+		"targetname" "stage_4_trigger_pad"
+	}
+	delete:
+	{
+		"landmark" "stages_teleport_destination"
+	}
+	insert:
+	{
+		"target" "stages_teleport_destination"
+	}
+}
+
+// Fix stage 4 nuke pad being broken showing the wrong message, being able to be damaged multiple times and not resulting in a round end.
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "stage_4_end_button_protection"
+	}
+	delete:
+	{
+		"OnDamaged" "Global_GameText_AnnouncementRunScriptCodesetMessage(3)0-1"
+	}
+	insert:
+	{
+		"OnDamaged" "!self,Kill,,,1"
+		"OnDamaged" "Global_GameText_AnnouncementRunScriptCodesetMessage(33);1"
+		"OnDamaged" "map1roundend1,EndRound_TerroristsWin,7,,1"
+	}
+}
+
+add:
+{
+	"classname" "game_round_end"
+	"targetname" "map1roundend1"
+	"OnRoundEnded" "map1roundend1,Kill,,,1"
+}
+
+// Fix the new truck model used in stage 5 not covering the side like in the original.
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic_override"
+		"targetname" "stage_5_megatrontruck"
+	}
+	replace:
+	{
+		"origin" "3904 -3440 12480"
+	}
+}
+
+// Prevent explosions from triggering repeat killer.
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Spawn_Explosion_Logic"
+	}
+	insert:
+	{
+		"OnSpawn" "Spawn_Explosion_Damage,AddOutput,classname norepeatkiller1,,-1"
+		"OnSpawn" "Spawn_Explosion_Damage_All,AddOutput,classname norepeatkiller1,,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Spawn_Explosion_Small_Logic"
+	}
+	insert:
+	{
+		"OnSpawn" "Spawn_Explosion_Small_Damage,AddOutput,classname norepeatkiller1,,-1"
+		"OnSpawn" "Spawn_Explosion_Small_Damage_H,AddOutput,classname norepeatkiller1,,-1"
+	}
+}
+
+// When a zombie tank is broken, don't make it disappear but make it non-solid and darken it.
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "_human_item_tank_health_drivver_zombiekill"
+	}
+	delete:
+	{
+		"OnTrigger" "v_model1Break0-1"
+	}
+	insert:
+	{
+		"OnTrigger" "v_model1,AddOutput,solid 0,,1"
+		"OnTrigger" "v_button1,Kill,,,1"
+		"OnTrigger" "v_model1,Color,64 64 64,.01,1"
+		"OnTrigger" "Tank_Cannon,Color,64 64 64,.01,1"
+	}
+}
+
+// Prevent camping zombie spawns.
+// Add filters that prevent all damage but nuke.
+add:
+{
+	"classname" "filter_activator_name"
+	"targetname" "map1nukefilter1"
+	"filtername" "Nuke_Kill_Trigger"
+}
+
+add:
+{
+	"classname" "filter_activator_name"
+	"targetname" "map1nukefilter2"
+	"filtername" "Kill_All_Trigger"
+}
+
+add:
+{
+	"classname" "filter_activator_name"
+	"targetname" "map1nukefilter3"
+	"filtername" "stage_3_nuke"
+}
+
+add:
+{
+	"classname" "filter_multi"
+	"targetname" "map1mainnukefilter1"
+	"FilterType" "1"
+	"Filter01" "map1nukefilter1"
+	"Filter02" "map1nukefilter2"
+	"Filter03" "map1nukefilter3"
+}
+
+// Stage 1
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_1_stuff1"
+	"origin" "1672 -464 -13632"
+	"model" "*584"
+	"spawnflags" "1"
+	"filtername" "team_filter_zombies"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+}
+
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_1_stuff1"
+	"origin" "6392 224 -13632"
+	"angles" "0 90 0"
+	"model" "*584"
+	"spawnflags" "1"
+	"filtername" "team_filter_zombies"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+}
+
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_1_stuff1"
+	"origin" "12184 -10384 -13632"
+	"angles" "0 90 0"
+	"model" "*584"
+	"spawnflags" "1"
+	"filtername" "team_filter_zombies"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+}
+
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_1_stuff1"
+	"origin" "3856 -9368 -12848"
+	"angles" "0 90 0"
+	"model" "*584"
+	"spawnflags" "1"
+	"filtername" "team_filter_zombies"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+}
+
+// Stage 2
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_2_stuff1"
+	"origin" "3920 768 -7376"
+	"angles" "0 90 0"
+	"model" "*584"
+	"spawnflags" "1"
+	"filtername" "team_filter_zombies"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+}
+
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_2_stuff1"
+	"origin" "-1048 3656 -7632"
+	"angles" "0 90 0"
+	"model" "*584"
+	"spawnflags" "1"
+	"filtername" "team_filter_zombies"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+}
+
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_2_stuff1"
+	"origin" "-1296 6048 -8032"
+	"angles" "0 90 0"
+	"model" "*584"
+	"spawnflags" "1"
+	"filtername" "team_filter_zombies"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+}
+
+// Stage 3
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_3_stuff1"
+	"origin" "-296 6392 -560"
+	"model" "*584"
+	"spawnflags" "1"
+	"filtername" "team_filter_zombies"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+}
+
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_3_stuff1"
+	"origin" "6640 5224 832"
+	"angles" "0 90 0"
+	"model" "*584"
+	"spawnflags" "1"
+	"filtername" "team_filter_zombies"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+}
+
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_3_stuff1"
+	"origin" "8000 3880 1216"
+	"model" "*584"
+	"spawnflags" "1"
+	"filtername" "team_filter_zombies"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+}
+
+// Stage 4
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_4_stuff1"
+	"origin" "5968 7952 3376"
+	"angles" "0 90 0"
+	"model" "*584"
+	"spawnflags" "1"
+	"filtername" "team_filter_zombies"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+}
+
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_4_stuff1"
+	"origin" "176 -800 3376"
+	"angles" "0 90 0"
+	"model" "*584"
+	"spawnflags" "1"
+	"filtername" "team_filter_zombies"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+}
+
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_4_stuff1"
+	"origin" "-11072 -10488 3376"
+	"model" "*584"
+	"spawnflags" "1"
+	"filtername" "team_filter_zombies"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+}
+
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_4_stuff1"
+	"origin" "9608 -7704 3376"
+	"model" "*584"
+	"spawnflags" "1"
+	"filtername" "team_filter_zombies"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+}
+
+// Implement the unused zombie teleport in extreme stage 1.
+modify:
+{
+	match:
+	{
+		"classname" "func_movelinear"
+		"targetname" "stage_x_camp_door"
+	}
+	insert:
+	{
+		"OnFullyOpen" "stage_positioner_teleport,InValue,11,5,1"
+	}
+}
+
+// Implement the unused zombie teleport in extreme stage 3.
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "stage_3_tests_relay_2"
+	}
+	insert:
+	{
+		"OnTrigger" "stage_positioner_teleport,InValue,32,15,1"
+	}
+}
+
+// Fix viewcontrols being laggy for "Alex Mercer" and "Mech".
+// Delete the old system used for viewcontrols.
+filter:
+{
+	"classname" "logic_measure_movement"
+	"targetname" "Zombie_Item_Boss_Measure"
+}
+
+filter:
+{
+	"classname" "info_teleport_destination"
+	"targetname" "Zombie_Item_Boss_Cam_Pos_2"
+}
+
+filter:
+{
+	"classname" "logic_measure_movement"
+	"targetname" "Human_Item_Mech_Measure"
+}
+
+filter:
+{
+	"classname" "info_teleport_destination"
+	"targetname" "Human_Item_Mech_Cam_Pos_2"
+}
+
+// Add the new system where we spawn the viewcontrols using preserved templates and spawn them parented.
+
+modify:
+{
+	match:
+	{
+		"classname" "point_viewcontrol"
+		"targetname" "Zombie_Item_Boss_Cam"
+	}
+	insert:
+	{
+		"parentname" "Zombie_Item_Boss_Cam_Pos"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_viewcontrol"
+		"targetname" "Human_Item_Mech_Cam"
+	}
+	insert:
+	{
+		"parentname" "Human_Item_Mech_Knife"
+	}
+}
+
+add:
+{
+	"classname" "point_template"
+	"targetname" "map1viewcontroltemplate1"
+	"Template01" "Zombie_Item_Boss_Cam"
+}
+
+add:
+{
+	"classname" "point_template"
+	"targetname" "map1viewcontroltemplate2"
+	"Template01" "Human_Item_Mech_Cam"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "info_target"
+		"targetname" "worldspawn_brush_target"
+	}
+	insert:
+	{
+		"OnUser2" "map1viewcontrolpreservedtemplate*,AddOutput,classname info_ladder,,-1"
+		"OnUser2" "map1viewcontroltemplate1,AddOutput,targetname map1viewcontrolpreservedtemplate1,,1"
+		"OnUser2" "map1viewcontroltemplate2,AddOutput,targetname map1viewcontrolpreservedtemplate2,,1"
+	}
+}
+
+// Give players empty targetname instead of one called "none" and prevent viewmodel from being glitched out.
+modify:
+{
+	match:
+	{
+		"classname" "trigger_brush"
+		"targetname" "game_playerdie"
+	}
+	delete:
+	{
+		"OnUse" "!activatorAddOutputtargetname none0-1"
+	}
+	insert:
+	{
+		"OnUse" "!activator,AddOutput,targetname ,,-1"
+		"OnUse" "!selfRunScriptCodeif (activator.IsValid() && (activator.GetName() == _.zombie_boss || activator.GetName() == _.human_mech)) EntFireByHandle(self, _.FireUser1, ' '.tochar(), 0, activator, null);-1"
+		"OnUser1" "v_cam1,Disable,,,1"
+		"OnUser1" "v_cam1,Enable,,,1"
+	}
+}

--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -561,7 +561,7 @@ modify:
 	}
 	insert:
 	{
-		"OnFullyOpen" "stage_positioner_teleport,InValue,11,5,1"
+		"OnFullyOpen" "stage_positioner_teleport,InValue,11,,1"
 	}
 }
 
@@ -571,11 +571,11 @@ modify:
 	match:
 	{
 		"classname" "logic_relay"
-		"targetname" "stage_3_tests_relay_2"
+		"targetname" "stage_3_tests_relay_1"
 	}
 	insert:
 	{
-		"OnTrigger" "stage_positioner_teleport,InValue,32,15,1"
+		"OnTrigger" "stage_positioner_teleport,InValue,32,,1"
 	}
 }
 

--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -109,8 +109,8 @@ modify:
 	}
 	insert:
 	{
-		"OnSpawn" "map1viewcontrolpreservedtemplate*,ForceSpawn,,.01,1"
-		"OnSpawn" "map1viewcontroltemplate*,Kill,,.01,1"
+		"OnSpawn" "map1viewcontrolpreservedtemplate1,ForceSpawn,,.01,1"
+		"OnSpawn" "map1viewcontroltemplate1,Kill,,.01,1"
 		"OnSpawn" "worldspawn_brush_target,FireUser2,,,1"
 		"OnSpawn" "stage_x_crane_breakableRunScriptCodefunction InputUse() { if (activator.GetTeam() == 3) return true; return false; }1"
 		"OnSpawn" "stage_x_crane_crateRunScriptCodefunction InputUse() { if (activator.GetTeam() == 3) return true; return false; }1"
@@ -605,7 +605,7 @@ filter:
 	"targetname" "Human_Item_Mech_Cam_Pos_2"
 }
 
-// Add the new system where we spawn the viewcontrols using preserved templates and spawn them parented.
+// Add the new system where we spawn the viewcontrols using a preserved template and spawn them parented.
 modify:
 {
 	match:
@@ -637,13 +637,7 @@ add:
 	"classname" "point_template"
 	"targetname" "map1viewcontroltemplate1"
 	"Template01" "Zombie_Item_Boss_Cam"
-}
-
-add:
-{
-	"classname" "point_template"
-	"targetname" "map1viewcontroltemplate2"
-	"Template01" "Human_Item_Mech_Cam"
+	"Template02" "Human_Item_Mech_Cam"
 }
 
 modify:
@@ -655,9 +649,8 @@ modify:
 	}
 	insert:
 	{
-		"OnUser2" "map1viewcontrolpreservedtemplate*,AddOutput,classname info_ladder,,-1"
+		"OnUser2" "map1viewcontrolpreservedtemplate1,AddOutput,classname info_ladder,,1"
 		"OnUser2" "map1viewcontroltemplate1,AddOutput,targetname map1viewcontrolpreservedtemplate1,,1"
-		"OnUser2" "map1viewcontroltemplate2,AddOutput,targetname map1viewcontrolpreservedtemplate2,,1"
 	}
 }
 


### PR DESCRIPTION
-Fixed some messages.
-Fixed some stuck spots.
-Fixed griefing with stage 2 big door.
-Fixed some exploits.
-Reduced "Mech" minigun sound.
-Fixed zombies breaking the nuke on stage 4 not ending the round.
-When Tank is destroyed with zombie in it doesn't make the prop disappear anymore.
-Fixed "Alex Mercer" and "Mech" viewcontrols being laggy.
-Added 2 zombie teleports which were left unused on extreme stage 1 and extreme stage 3.
-Fixed zombies being able to trigger the "Juggernaut" event at stage 1.
-Fixed "Portal Gun" skip and camping at all zombie teleports on all stages with permission from Hichatu.