### PR TITLE
Updated atix apoc/biohazard manor stripper

### DIFF
--- a/stripper/ze_atix_apocalypse_p3.cfg
+++ b/stripper/ze_atix_apocalypse_p3.cfg
@@ -1,3 +1,198 @@
+;Prevent players from opening a door from outside, door is only supposed to be opened from inside, truck escape route yet again...
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"hammerid" "20311"
+	}
+	replace:
+	{
+		"origin" "710.5 -1433.01 413.01"
+	}
+}
+
+;Lock buttons that close the inner doors on truck escape route while said doors are opening. Trolls/idiots keep E spamming them causing the doors to be stuck in an opening/closing loop locking out slow players.
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"hammerid" "20160"
+	}
+	replace:
+	{
+		"targetname" "truck_but_close1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"hammerid" "20168"
+	}
+	replace:
+	{
+		"targetname" "truck_but_close2"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"hammerid" "20192"
+	}
+	replace:
+	{
+		"targetname" "truck_but_close3"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"hammerid" "20200"
+	}
+	replace:
+	{
+		"targetname" "truck_but_close4"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"hammerid" "20128"
+	}
+	replace:
+	{
+		"targetname" "truck_but_open1"
+	}
+	insert:
+	{
+		"OnPressed" "truck_but_close1,Lock,,0,-1"
+		"OnPressed" "!self,Lock,,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"hammerid" "20176"
+	}
+	replace:
+	{
+		"targetname" "truck_but_open2"
+	}
+	insert:
+	{
+		"OnPressed" "truck_but_close2,Lock,,0,-1"
+		"OnPressed" "!self,Lock,,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"hammerid" "20184"
+	}
+	replace:
+	{
+		"targetname" "truck_but_open3"
+	}
+	insert:
+	{
+		"OnPressed" "truck_but_close3,Lock,,0,-1"
+		"OnPressed" "!self,Lock,,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"hammerid" "20208"
+	}
+	replace:
+	{
+		"targetname" "truck_but_open4"
+	}
+	insert:
+	{
+		"OnPressed" "truck_but_close4,Lock,,0,-1"
+		"OnPressed" "!self,Lock,,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "lastdoor1"
+		"classname" "func_door"
+	}
+	insert:
+	{
+		"OnFullyOpen" "truck_but_close1,Unlock,,0.5,-1"
+		"OnFullyOpen" "truck_but_open1,Unlock,,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "lastdoor2"
+		"classname" "func_door"
+	}
+	insert:
+	{
+		"OnFullyOpen" "truck_but_close2,Unlock,,0.5,-1"
+		"OnFullyOpen" "truck_but_open2,Unlock,,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "lastdoor3"
+		"classname" "func_door"
+	}
+	insert:
+	{
+		"OnFullyOpen" "truck_but_close3,Unlock,,0.5,-1"
+		"OnFullyOpen" "truck_but_open3,Unlock,,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "lastdoor4"
+		"classname" "func_door"
+	}
+	insert:
+	{
+		"OnFullyOpen" "truck_but_close4,Unlock,,0.5,-1"
+		"OnFullyOpen" "truck_but_open4,Unlock,,0,-1"
+	}
+}
+
 ;Force final doors on truck route to open no matter what because trolls/idiots keep E spamming them
 modify:
 {
@@ -108,10 +303,10 @@ add:
 	"classname" "trigger_push"
 	"targetname" "TrainPush"
 	"StartDisabled" "1"
-	"speed" "600"
+	"speed" "800"
 	"spawnflags" "1"
 	"pushdir" "0 180 0"
-	"origin" "3115.5 -1121.5 218"
+	"origin" "2992 -2008 151"
 	"filtername" "Zombies"
 	"alternateticksfix" "0"
 }
@@ -121,7 +316,20 @@ add:
 	"classname" "trigger_push"
 	"targetname" "TrainPush2"
 	"StartDisabled" "1"
-	"speed" "600"
+	"speed" "800"
+	"spawnflags" "1"
+	"pushdir" "0 180 0"
+	"origin" "2992 -336 151"
+	"filtername" "Zombies"
+	"alternateticksfix" "0"
+}
+
+add:
+{
+	"classname" "trigger_push"
+	"targetname" "TrainPush3"
+	"StartDisabled" "1"
+	"speed" "800"
 	"spawnflags" "1"
 	"pushdir" "0 180 0"
 	"origin" "-250 -144 -263.5"
@@ -139,11 +347,14 @@ modify:
 	insert:
 	{
 		"OnSpawn" "TrainPush,AddOutput,solid 2,0.5,1"
-		"OnSpawn" "TrainPush,AddOutput,mins -111.5 -1115.5 -145,1,1"
-		"OnSpawn" "TrainPush,AddOutput,maxs 111.5 1115.5 145,1,1"
+		"OnSpawn" "TrainPush,AddOutput,mins -176 -232 -153,1,1"
+		"OnSpawn" "TrainPush,AddOutput,maxs 176 232 153,1,1"
 		"OnSpawn" "TrainPush2,AddOutput,solid 2,0.5,1"
-		"OnSpawn" "TrainPush2,AddOutput,mins -22 -81 -69.5,1,1"
-		"OnSpawn" "TrainPush2,AddOutput,maxs 22 81 69.5,1,1"
+		"OnSpawn" "TrainPush2,AddOutput,mins -176 -256 -153,1,1"
+		"OnSpawn" "TrainPush2,AddOutput,maxs 176 256 153,1,1"
+		"OnSpawn" "TrainPush3,AddOutput,solid 2,0.5,1"
+		"OnSpawn" "TrainPush3,AddOutput,mins -44 -81 -69.5,1,1"
+		"OnSpawn" "TrainPush3,AddOutput,maxs 44 81 69.5,1,1"
 	}
 }
 
@@ -160,6 +371,8 @@ modify:
 		"OnTrigger" "TrainPush,Disable,,19.5,1"
 		"OnTrigger" "TrainPush2,Enable,,9.5,1"
 		"OnTrigger" "TrainPush2,Disable,,19.5,1"
+		"OnTrigger" "TrainPush3,Enable,,9.5,1"
+		"OnTrigger" "TrainPush3,Disable,,19.5,1"
 	}
 }
 

--- a/stripper/ze_biohazard_manor_004_p4.cfg
+++ b/stripper/ze_biohazard_manor_004_p4.cfg
@@ -126,6 +126,11 @@ modify:
 		"OnFullyOpen" "p_49,Open,,0.00,1"
 		"OnFullyOpen" "p_49,Lock,,0.02,1"
 		"OnFullyOpen" "door_zom_shut2,Kill,,0.00,1"
+		"OnFullyOpen" "p_33,Open,,0.00,1"
+		"OnFullyOpen" "p_33,Lock,,0.02,1"
+		"OnFullyOpen" "p_32,Open,,0.00,1"
+		"OnFullyOpen" "p_32,Lock,,0.02,1"		
+		"OnFullyOpen" "door_zom_shut1,Kill,,0,1"
 	}
 }
 


### PR DESCRIPTION
Notable changes:

Atix Apocalypse
- Truck Route: Fixed more door stuff that can be exploited by trolls/idiots
- Train Route: Redone the anti-camp push and increased push force

Biohazard Manor
- Fixing another potential soft-lock caused by a door being closed permanently (same as initial door fix)