### PR TITLE
Fix rizomata stage 1 early trigger

### DIFF
--- a/stripper/ze_rizomata_va2.cfg
+++ b/stripper/ze_rizomata_va2.cfg
@@ -1,3 +1,16 @@
+;prevent early trigger on stage 1 by bugging through displacement
+modify:
+{
+	match:
+	{
+		"targetname" "1_rockbreak1"
+	}
+	insert:
+	{
+		"OnBreak" "des2Addoutputorigin -5608 -12504 -1406820-1"
+	}
+}
+
 ;prevent ground going back down after killing lvl 2 boss
 modify:
 {
@@ -178,6 +191,7 @@ modify:
 }
 
 ;fix some bad spawns on level 1
+;start stage1 des2 at the same pos as des1 to prevent early triggers
 modify:
 {
 	match:
@@ -188,10 +202,12 @@ modify:
 	delete:
 	{
 		"OnCase01" "des1AddOutputorigin -15296 -12872 -1509001"
+		"OnCase01" "des2AddOutputorigin -5608 -12504 -1406801"
 	}
 	insert:
 	{
 		"OnCase01" "des1AddOutputorigin -15206 -12872 -1509001"
+		"OnCase01" "des2AddOutputorigin -15206 -12872 -1509001"
 	}
 }
 


### PR DESCRIPTION
Displacement bug near spawn makes it possible to reach the tp below, teleporting outside the cave very early and could be used to ruin a round. 20 seconds after wall breaks is about how long it takes to reach tp position with just running.