### PR TITLE
Update minas tirith stripper

### DIFF
--- a/stripper/ze_lotr_minas_tirith_p5.cfg
+++ b/stripper/ze_lotr_minas_tirith_p5.cfg
@@ -1,3 +1,17 @@
+;rework nuke on stages 4/8 so people using glitch spots are also killed
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "stage_4_end_of_all_things"
+	}
+	insert:
+	{
+		"OnTrigger" "playerRunScriptCodelocal pos=self.GetOrigin();foreach(k,_ in{SetHealth=0}){if(self.GetTeam()==3&&pos.z< -2000&&!(pos.x>4810&&pos.y> -363&&pos.x<6210&&pos.y< -42))EntFireByHandle(self,k,(0).tostring(),0,null,null)}5.4-1"
+	}
+}
+
 ;fix stuff on perm player entities persisting when switching teams to suicide
 add:
 {

--- a/stripper/ze_lotr_minas_tirith_p5.cfg
+++ b/stripper/ze_lotr_minas_tirith_p5.cfg
@@ -4,11 +4,11 @@ modify:
 	match:
 	{
 		"classname" "logic_relay"
-		"targetname" "stage_4_end_of_all_things"
+		"targetname" "stage_4_relay_3"
 	}
 	insert:
 	{
-		"OnTrigger" "playerRunScriptCodelocal pos=self.GetOrigin();foreach(k,_ in{SetHealth=0}){if(self.GetTeam()==3&&pos.z< -2000&&!(pos.x>4810&&pos.y> -363&&pos.x<6210&&pos.y< -42))EntFireByHandle(self,k,(0).tostring(),0,null,null)}5.4-1"
+		"OnTrigger" "playerRunScriptCodelocal pos=self.GetOrigin();foreach(k,_ in{SetHealth=0}){if(self.GetTeam()==3&&pos.z< -2000&&!(pos.x>4810&&pos.y> -363&&pos.x<6210&&pos.y< -42))EntFireByHandle(self,k,(0).tostring(),0,null,null)}89.5-1"
 	}
 }
 

--- a/stripper/ze_lotr_minas_tirith_p5.cfg
+++ b/stripper/ze_lotr_minas_tirith_p5.cfg
@@ -8,7 +8,7 @@ modify:
 	}
 	insert:
 	{
-		"OnTrigger" "playerRunScriptCodelocal pos=self.GetOrigin();foreach(k,_ in{SetHealth=0}){if(self.GetTeam()==3&&pos.z< -2000&&!(pos.x>4810&&pos.y> -363&&pos.x<6210&&pos.y< -42))EntFireByHandle(self,k,(0).tostring(),0,null,null)}89.5-1"
+		"OnTrigger" "playerRunScriptCodelocal pos=self.GetOrigin();foreach(k,_ in{SetHealth=0}){if(self.GetTeam()==3&&pos.z< -2000&&!(pos.x>4810&&pos.y> -363&&pos.x<6210&&pos.y< -42))EntFireByHandle(self,k,(0).tostring(),0,null,null)}90-1"
 	}
 }
 


### PR DESCRIPTION
This pull request aims to fix several exploit spots that allow people to easily get wins while not intended by the mapper. Initially, this aimed to patch the cliffhanger spot at the front, but a conversation with Console revealed that many other spots exist that people exploit to try to survive.

Tested locally with both normal and extreme stage 4.

-> Implemented a nutless script 0.1 seconds before the actual nuke to slay people below a certain Z-level

Many thanks to @Frozen-H2O and Potti for help related to nutless scripting.