### PR TITLE
Update dreamin stripper

### DIFF
--- a/musicname/ze_totemo_roka_v1.cfg
+++ b/musicname/ze_totemo_roka_v1.cfg
@@ -2,7 +2,7 @@
 {
 	"Braz Gonsalves - Raga Rock.mp3"			"The Braz Gonslaves - Raga Rock (1970 India)"
 	"Floyd Lawson & The Heart of Stone - K Gee.mp3"			"Floyd Lawson & The Heart of Stone - K Gee"
-	"Jungle Fire - Firewalker.mp3"			"Jungle Fire - "Firewalker" - Latin Funk 45"
+	"Jungle Fire - Firewalker.mp3"			"Jungle Fire - Firewalker"
 	"The Qualitons - Kekfeny.mp3"			"The Qualitons - Kekfeny"
 	"Trio Valore - Return of the Iron Monkey.mp3"			"Trio Valore - Return of the Iron Monkey [Record Kicks]"
 }

--- a/stripper/ze_dreamin_v3_3.cfg
+++ b/stripper/ze_dreamin_v3_3.cfg
@@ -1,3 +1,46 @@
+;prevent humans from being knifed at the end of rtv stage
+add:
+{
+	"classname" "filter_activator_team"
+	"origin" "2 2 2"
+	"targetname" "no_zombies"
+	"Negated" "1"
+	"filterteam" "2"
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "rtv_last"
+		"classname" "trigger_teleport"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activatorSetDamageFilterno_zombies0-1"
+	}
+}
+
+;remove boss health game_text
+filter:
+{
+	"classname" "game_text"
+	"targetname" "bosshp_text"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "st2_start"
+	}
+	delete:
+	{
+		"OnTrigger" "st2_hitboxRunScriptCodecheck()0-1"
+	}
+}
+
 ;st3 boss pattern lower difficulty
 modify:
 {


### PR DESCRIPTION
The goal of this stripper change is to address two issues:

-> Make humans that reach the final room during the RTV stage immune from zombie infection. Currently, there's a very small gap at the very left side that zombies can manage to knife humans.
-> Disable boss health `game_text` during stage 2 boss from appearing by filtering the entity itself and removing the script code output. The `game_text` health display is completely unnecessary as we already have bhud plugin, and the display causes `game_text` flickering as well.