### PR TITLE
Several Stripper Updates

### DIFF
--- a/stripper/ze_dreamin_v3_3.cfg
+++ b/stripper/ze_dreamin_v3_3.cfg
@@ -21,23 +21,17 @@ modify:
 	}
 }
 
-;remove boss health game_text
-filter:
-{
-	"classname" "game_text"
-	"targetname" "bosshp_text"
-}
-
+;change boss health game_text holdtime to prevent flickering
 modify:
 {
 	match:
 	{
-		"classname" "logic_relay"
-		"targetname" "st2_start"
+		"classname" "game_text"
+		"targetname" "bosshp_text"
 	}
-	delete:
+	replace:
 	{
-		"OnTrigger" "st2_hitboxRunScriptCodecheck()0-1"
+		"holdtime" "0.1"
 	}
 }
 

--- a/stripper/ze_dreamin_v3_3.cfg
+++ b/stripper/ze_dreamin_v3_3.cfg
@@ -1,3 +1,46 @@
+;prevent humans from being knifed at the end of rtv stage
+add:
+{
+	"classname" "filter_activator_team"
+	"origin" "2 2 2"
+	"targetname" "no_zombies"
+	"Negated" "1"
+	"filterteam" "2"
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "rtv_last"
+		"classname" "trigger_teleport"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activatorSetDamageFilterno_zombies0-1"
+	}
+}
+
+;remove boss health game_text
+filter:
+{
+	"classname" "game_text"
+	"targetname" "bosshp_text"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "st2_start"
+	}
+	delete:
+	{
+		"OnTrigger" "st2_hitboxRunScriptCodecheck()0-1"
+	}
+}
+
 ;st3 boss pattern lower difficulty
 modify:
 {

--- a/stripper/ze_huggy_wuggy_chap4_halloween_rus4.cfg
+++ b/stripper/ze_huggy_wuggy_chap4_halloween_rus4.cfg
@@ -1,0 +1,17 @@
+;prevent zombies getting boosted into next room by teleporting them away and moving the trigger a bit back
+modify:
+{
+	match:
+	{
+		"classname" "trigger_push"
+		"targetname" "push_protect_1"
+	}
+	replace:
+	{
+		"origin" "2668 9592 -1920"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activatorAddOutputorigin -24 5632 26080-1"
+	}
+}

--- a/stripper/ze_huggy_wuggy_chap4_halloween_rus4.cfg
+++ b/stripper/ze_huggy_wuggy_chap4_halloween_rus4.cfg
@@ -8,10 +8,13 @@ modify:
 	}
 	replace:
 	{
+		"classname" "trigger_teleport"
 		"origin" "2668 9592 -1920"
+		"spawnflags" "4097"
 	}
 	insert:
 	{
-		"OnStartTouch" "!activatorAddOutputorigin -24 5632 26080-1"
+		"target" "tp_dest_10_t"
+		"UseLandmarkAngles" "1"
 	}
 }

--- a/stripper/ze_surf_happy_b7.cfg
+++ b/stripper/ze_surf_happy_b7.cfg
@@ -1,19 +1,3 @@
-;prevent humans from delaying at the final island by giving 30 seconds to kill zombies
-modify:
-{
-	match:
-	{
-		"classname" "trigger_once"
-		"hammerid" "117385"
-	}
-	insert:
-	{
-		"OnStartTouch" "cmdCommandsay ** You have 30 seconds to kill all remaining zombies! **801"
-		"OnStartTouch" "cmdCommandsay ** You took too long to kill zombies! Slaying! **1101"
-		"OnStartTouch" "playerRunScriptCodeforeach(k,_ in{SetHealth=0}){if(self.GetTeam()==3&&self.GetHealth()>0)EntFireByHandle(self, k,(0).tostring(),0,null,null)}1111""
-	}
-}
-
 ;translate the map
 ;############################ THIS CHANGE WILL NOT WORK WITHOUT HAVING ###################################
 ;############################ csgo/scripts/vscripts/gfl/happy_patched.nut ################################

--- a/stripper/ze_surf_happy_b7.cfg
+++ b/stripper/ze_surf_happy_b7.cfg
@@ -1,3 +1,20 @@
+;prevent humans from delaying at the final island by giving 30 seconds to kill zombies
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"hammerid" "117385"
+	}
+	insert:
+	{
+		"OnStartTouch" "cmdCommandsay ** You have 30 seconds to kill all remaining zombies! **801"
+		"OnStartTouch" "cmdCommandsay ** You took too long to kill zombies! Slaying! **1101"
+		"OnStartTouch" "playerRunScriptCodeforeach(k,_ in{SetHealth=0}){if(self.GetTeam()==3&&self.GetHealth()>0)EntFireByHandle(self, k,(0).tostring(),0,null,null)}1111""
+	}
+}
+
+
 ;translate the map
 ;############################ THIS CHANGE WILL NOT WORK WITHOUT HAVING ###################################
 ;############################ csgo/scripts/vscripts/gfl/happy_patched.nut ################################

--- a/stripper/ze_surf_happy_b7.cfg
+++ b/stripper/ze_surf_happy_b7.cfg
@@ -14,7 +14,6 @@ modify:
 	}
 }
 
-
 ;translate the map
 ;############################ THIS CHANGE WILL NOT WORK WITHOUT HAVING ###################################
 ;############################ csgo/scripts/vscripts/gfl/happy_patched.nut ################################


### PR DESCRIPTION
ze_dreamin_v3_3.cfg
-> Shortened stage 2 boss health `game_text` hold time to `0.1` to minimize flickering
-> Make humans who reach the end on RTV stage to be immune from zombie infection. There happens to be a small gap at the side of the barrier where zombies could infect humans through the wall, which some trolls intentionally abused in order to either delay rounds or kill humans

ze_huggy_wuggy_chap4_halloween_rus4.cfg
-> At the stairs part where humans run to the opposite side, make the `trigger_push` at the end of the hallway teleport zombies back to the teleport room as instructed by Lardy on [discord](https://discord.com/channels/223673175571955712/420095739562295296/1102528379116343396)