### PR TITLE
Update tenkinoko welkin stripper

### DIFF
--- a/stripper/ze_tenkinoko_welkin_v1_6f.cfg
+++ b/stripper/ze_tenkinoko_welkin_v1_6f.cfg
@@ -1,4 +1,4 @@
-;disable admin room push that gets players stuck if they wish to press another button
+;rework mapper's method for making only one person press admin room button
 modify:
 {
 	match:

--- a/stripper/ze_tenkinoko_welkin_v1_6f.cfg
+++ b/stripper/ze_tenkinoko_welkin_v1_6f.cfg
@@ -1,3 +1,17 @@
+;lock all admin room buttons after setting stage
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "/^admin_stage/"
+	}
+	insert:
+	{
+		"OnPressed" "admin_stage*Lock0.02-1"
+	}
+}
+
 ;Make Frozen Tomb activation button less frustrating to press
 modify:
 {

--- a/stripper/ze_tenkinoko_welkin_v1_6f.cfg
+++ b/stripper/ze_tenkinoko_welkin_v1_6f.cfg
@@ -1,4 +1,4 @@
-;lock all admin room buttons after setting stage
+;disable admin room push that gets players stuck if they wish to press another button
 modify:
 {
 	match:
@@ -6,9 +6,9 @@ modify:
 		"classname" "func_button"
 		"targetname" "/^admin_stage/"
 	}
-	insert:
+	delete:
 	{
-		"OnPressed" "admin_stage*Lock0.02-1"
+		"OnPressed" "admin_pushEnable0-1"
 	}
 }
 

--- a/stripper/ze_tenkinoko_welkin_v1_6f.cfg
+++ b/stripper/ze_tenkinoko_welkin_v1_6f.cfg
@@ -10,6 +10,10 @@ modify:
 	{
 		"OnPressed" "admin_pushEnable0-1"
 	}
+	insert:
+	{
+		"OnPressed" "admin_stage*Lock0-1"
+	}
 }
 
 ;Make Frozen Tomb activation button less frustrating to press


### PR DESCRIPTION
ze_tenkinoko_welkin_v1_6f.cfg
-> Lock admin room buttons after one button is pressed. This makes it so if people win "LeisureTime" stage, only one button can be pressed instead of someone intentionally repeatedly pressing the other buttons, or to prevent the scenario where you accidentally get pushed and press other buttons as well like [this](https://cdn.discordapp.com/attachments/512551721952608266/1104975757995950241/Counter-Strike__Global_Offensive_-_Direct3D_9_2023-05-07_23-37-34.mp4)