### PR TITLE
Update several strippers

### DIFF
--- a/stripper/ze_ffxii_westersand_v8zeta1_b5k.cfg
+++ b/stripper/ze_ffxii_westersand_v8zeta1_b5k.cfg
@@ -1,3 +1,57 @@
+;fix dragon boost
+modify:
+{
+	match:
+	{
+		"targetname" "Warmup_Fly_Push"
+		"classname" "trigger_multiple"
+	}
+	delete:
+	{
+		"OnStartTouch" "!activatorAddOutputbasevelocity 0 -2100 15000-1"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activatorRunScriptCode{local vel=self.GetVelocity();self.SetVelocity(Vector(vel.x,vel.y-2100,vel.z+1500))}0-1"
+	}
+}
+
+;make electro and fire slow zombies like in css
+add:
+{
+	"classname" "logic_relay"
+	"targetname" "Slowdown_Patch"
+	"spawnflags" "2"
+	"OnTrigger" "!activatorRunScriptCodeforeach(v,_ in {SetHealth=0}){EntFireByHandle(self,v,(self.GetHealth()-1).tostring(),0.0,null,null);}0-1"
+	"OnTrigger" "!activatorRunScriptCodeforeach(v,_ in {SetHealth=0}){EntFireByHandle(self,v,(self.GetHealth()+1).tostring(),0.0,null,null);}0.1-1"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Staff_Electro_Trigger"
+	}
+	insert:
+	{
+		"OnHurtPlayer" "Slowdown_PatchTrigger0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Staff_Fire_Trigger"
+	}
+	insert:
+	{
+		"OnHurtPlayer" "Slowdown_PatchTrigger0-1"
+	}
+}
+
 ;fix zombie heal text not updating
 modify:
 {

--- a/stripper/ze_ffxii_westersand_v8zeta1_b5k.cfg
+++ b/stripper/ze_ffxii_westersand_v8zeta1_b5k.cfg
@@ -1,3 +1,279 @@
+;fix zombie heal text not updating
+modify:
+{
+	match:
+	{
+		"classname" "logic_case"
+		"targetname" "Knife_Heal_Hud_Hints"
+	}
+	delete:
+	{
+		"OnCase01" "Knife_Heal_HudHintRunScriptCodetext(16);01"
+		"OnCase02" "Knife_Heal_HudHintRunScriptCodetext(17);01"
+		"OnCase03" "Knife_Heal_HudHintRunScriptCodetext(18);01"
+	}
+	insert:
+	{
+		"OnCase01" "Knife_Heal_HudHintRunScriptCodetext(16);0-1"
+		"OnCase02" "Knife_Heal_HudHintRunScriptCodetext(17);0-1"
+		"OnCase03" "Knife_Heal_HudHintRunScriptCodetext(18);0-1"
+	}
+}
+
+;clear contexts at round start
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "playerClearContext0-1"
+	}
+}
+
+;fix zombies being able to pick up multiple zombie items
+add:
+{
+	"targetname" "zmItemFilter_context"
+	"ResponseContext" "zmItem_test"
+	"Negated" "1"
+	"classname" "filter_activator_context"
+}
+
+add:
+{
+	"targetname" "zmItem_block"
+	"Negated" "0"
+	"filtertype" "0"
+	"Filter03" "Filter_None"
+	"Filter02" "Filter_Team_Zombies"
+	"Filter01" "zmItemFilter_context"
+	"classname" "filter_multi"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Knife_Lure_Knife"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "!activator,AddContext,zmItem_test:1,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Knife_Blind_Knife"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "!activator,AddContext,zmItem_test:1,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Knife_Warp_Knife"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "!activator,AddContext,zmItem_test:1,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Knife_Invis_Knife"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "!activator,AddContext,zmItem_test:1,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Knife_Shield_Knife"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "!activator,AddContext,zmItem_test:1,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Knife_Heal_Knife"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "!activator,AddContext,zmItem_test:1,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Knife_Fire_Knife"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "!activator,AddContext,zmItem_test:1,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Knife_Frost_Knife"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "!activator,AddContext,zmItem_test:1,0,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "Knife_Warp_Stripper"
+	}
+	replace:
+	{
+		"filtername" "zmItem_block"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "Knife_Warp_Stripper"
+	}
+	replace:
+	{
+		"filtername" "zmItem_block"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "Knife_Lure_Stripper"
+	}
+	replace:
+	{
+		"filtername" "zmItem_block"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "Knife_Heal_Stripper"
+	}
+	replace:
+	{
+		"filtername" "zmItem_block"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "Knife_Invis_Stripper"
+	}
+	replace:
+	{
+		"filtername" "zmItem_block"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "Knife_Blind_Stripper"
+	}
+	replace:
+	{
+		"filtername" "zmItem_block"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "Knife_Shield_Stripper"
+	}
+	replace:
+	{
+		"filtername" "zmItem_block"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "Knife_Fire_Stripper"
+	}
+	replace:
+	{
+		"filtername" "zmItem_block"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "Knife_Frost_Stripper"
+	}
+	replace:
+	{
+		"filtername" "zmItem_block"
+	}
+}
+
 ;tp angles
 modify:
 {
@@ -61,6 +337,7 @@ modify:
 		"start_active" "0"
 	}
 }
+
 modify:
 {
 	match:
@@ -73,6 +350,7 @@ modify:
 		"start_active" "0"
 	}
 }
+
 modify:
 {
 	match:
@@ -95,6 +373,7 @@ modify:
 		"OnNewGame" "Staff_Heal_ParticleStart10.71"
 	}
 }
+
 modify:
 {
 	match:
@@ -122,6 +401,7 @@ modify:
 		"OnCase08" "Knife_Fire_Particle_1Start0.7-1"
 	}
 }
+
 modify:
 {
 	match:
@@ -137,6 +417,7 @@ modify:
 		"OnCase02" "Staff_Holy_ParticleStart11.31"
 	}
 }
+
 modify:
 {
 	match:
@@ -152,6 +433,7 @@ modify:
 		"OnEntitySpawned" "Vulcano_PartStart0.21"
 	}
 }
+
 modify:
 {
 	match:
@@ -169,6 +451,7 @@ modify:
 		"OnUser1" "!selfKill1.271"
 	}
 }
+
 modify:
 {
 	match:

--- a/stripper/ze_madara_temple_v1fix_csgo.cfg
+++ b/stripper/ze_madara_temple_v1fix_csgo.cfg
@@ -1,3 +1,26 @@
+;fix lightning not slowing zombies like in css
+add:
+{
+	"classname" "logic_relay"
+	"targetname" "Slowdown_Patch"
+	"spawnflags" "2"
+	"OnTrigger" "!activatorRunScriptCodeforeach(v,_ in {SetHealth=0}){EntFireByHandle(self,v,(self.GetHealth()-1).tostring(),0.0,null,null);}0-1"
+	"OnTrigger" "!activatorRunScriptCodeforeach(v,_ in {SetHealth=0}){EntFireByHandle(self,v,(self.GetHealth()+1).tostring(),0.0,null,null);}0.1-1"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "lightning_hurt"
+	}
+	insert:
+	{
+		"OnHurtPlayer" "Slowdown_PatchTrigger0-1"
+	}
+}
+
 ;fix tp avoidance spot below bridge in first area
 add:
 {


### PR DESCRIPTION
Updated stripper/ze_ffxii_westersand_v8_zeta1_b5k.cfg
-> Fix zombie heal mode selection text not updating
-> Fix zombies being able to pick up multiple items
-> Fix electro and fire not slowing zombies down like in CSS
-> Fix dragon push not working during warmup/zm mode

Updated stripper/ze_mdara_temple_v1fix_csgo.cfg
-> Added speedmod patch for lightning item not slowing zombies as it does on css