### PR TITLE
Prevent triple boost early trig

### DIFF
--- a/stripper/ze_rizomata_va2.cfg
+++ b/stripper/ze_rizomata_va2.cfg
@@ -1,3 +1,34 @@
+;prevent early trigger on stage 4 from triple boost
+;dont prevent triple boost cuz its fun
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"hammerid" "1650321"
+	}
+	replace:
+	{
+		"StartDisabled" "1"
+	}
+	insert:
+	{
+		"targetname" "trigggerytrig"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "4_door3"
+	}
+	insert:
+	{
+		"OnFullyOpen" "trigggerytrigEnable50-1"
+	}
+}
+
 ;prevent early trigger on stage 1 by bugging through displacement
 modify:
 {


### PR DESCRIPTION
Delay the next trigger being enabled until its possible to get past the tp/reach it normally.
Takes about 60s to reach the trigger with bhopping, and about 40s to clear the tp spot with no bhopping.