### PR TITLE
Update stripper for escape together

### DIFF
--- a/stripper/ze_escape_together_v1_xx.cfg
+++ b/stripper/ze_escape_together_v1_xx.cfg
@@ -1,31 +1,31 @@
-;stripper for ze_escape_together_v1_xx made by Dominikk
-;version #3
+;stripper for ze_escape_together_v1_xx made by Dominikk (STEAM_1:1:116509469)
+;version #4
 ;fix the doors where it didn't kill players
 modify:
 {
-	match:
-	{
+    match:
+    {
 		"classname" "func_door"
 		"targetname" "end_door"
-	}
-	replace:
-	{
+    }
+    replace:
+    {
 		"forceclosed" "1"
 		"dmg" "99999"
-	}
+    }
 }
 modify:
 {
-	match:
-	{
+    match:
+    {
 		"classname" "func_door"
 		"targetname" "doorend"
-	}
-	replace:
-	{
+    }
+    replace:
+    {
 		"forceclosed" "1"
 		"dmg" "99999"
-	}
+    }
 }
 
 ;fix weird teleport text (remove) and change the teleport time to 05
@@ -39,8 +39,8 @@ modify:
 	delete:
 	{
 		"OnStartTouch" "servercommandsCommandsay [ ZM TP ]151"
-		"OnStartTouch" "teleport4Enable151"
-	}
+    	"OnStartTouch" "teleport4Enable151"
+    }
 	insert:
 	{
 		"OnStartTouch" "teleport4Enable51"
@@ -58,11 +58,45 @@ modify:
 	delete:
 	{
 		"OnStartTouch" "servercommandsCommandsay [ AFK TP in 5s ]51"
-		"OnStartTouch" "trigger_afk_uwuEnable101"
-	}
+    	"OnStartTouch" "trigger_afk_uwuEnable101"
+    }
 	insert:
 	{
 		"OnStartTouch" "servercommandsCommandsay [ AFK TP in 5s ]01"
-		"OnStartTouch" "trigger_afk_uwuEnable51"
+    	"OnStartTouch" "trigger_afk_uwuEnable51"
 	}
+}
+
+;nerf zm teleport where people died while over defending
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"hammerid" "671123"
+	}
+	delete:
+	{
+		"OnStartTouch" "servercommandsCommandsay [ AFK TP ]251"
+    	"OnStartTouch" "teleport10Enable251"
+    }
+	insert:
+	{
+		"OnStartTouch" "servercommandsCommandsay [ AFK TP ]351"
+    	"OnStartTouch" "teleport10Enable351"
+	}
+}
+
+;fix trigger_hurt that people could extend the round by jumping into the void
+modify:
+{
+    match:
+    {
+		"classname" "trigger_hurt"
+		"targetname" "hurt_r"
+    }
+    replace:
+    {
+		"damage" "1000"
+    }
 }


### PR DESCRIPTION
- nerf zm teleport where people died while over defending
- fix trigger_hurt that people could extend the round by jumping into the void