### PR TITLE
Update sandstorm stripper

### DIFF
--- a/stripper/ze_sandstorm_go_v1_5x3.cfg
+++ b/stripper/ze_sandstorm_go_v1_5x3.cfg
@@ -1,3 +1,40 @@
+;fix missing grenade explosion sound
+modify:
+{
+	match:
+	{
+		"classname" "ambient_generic"
+		"targetname" "Nade_Sound"
+	}
+	replace:
+	{
+		"Message" "weapons/hegrenade/explode4.wav"
+	}
+}
+
+;fix fire not slowing zombies
+add:
+{
+	"classname" "logic_relay"
+	"targetname" "Slowdown_Patch"
+	"spawnflags" "2"
+	"OnTrigger" "!activatorRunScriptCodeforeach(v,_ in {SetHealth=0}){EntFireByHandle(self,v,(self.GetHealth()-1).tostring(),0.0,null,null);}0-1"
+	"OnTrigger" "!activatorRunScriptCodeforeach(v,_ in {SetHealth=0}){EntFireByHandle(self,v,(self.GetHealth()+1).tostring(),0.0,null,null);}0.1-1"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "fire_tr"
+	}
+	insert:
+	{
+		"OnHurtPlayer" "Slowdown_PatchTrigger0-1"
+	}
+}
+
 ;Fix Heal burning human for the entire of Heal's lifetime which could cause 1 hp players to die
 modify:
 {


### PR DESCRIPTION
Updated stripper/ze_sandstorm_go_v1_5x3.cfg
-> Replace missing grenade sound that was causing the server to lag whenever players threw nades at the boss
-> Fix fire not slowing zombies down like intended on css with IgniteLifetime