### PR TITLE
Add bioluminescent stripper

### DIFF
--- a/stripper/ze_bioluminescent_k1.cfg
+++ b/stripper/ze_bioluminescent_k1.cfg
@@ -1,0 +1,56 @@
+;stripper by koen (STEAM_1:1:114921174)
+
+;fix zombies not being teleported away after zm attack during stage 3 boss fight
+modify:
+{
+	match:
+	{
+		"classname" "func_movelinear"
+		"targetname" "stage3_zm_platform"
+	}
+	delete:
+	{
+		"OnFullyOpen" "stage3_boss_att9_zm_tpDisable0.551"
+		"OnFullyOpen" "s3_boss_att_tp_cageDisable7.541"
+	}
+	insert:
+	{
+		"OnFullyOpen" "stage3_boss_att9_zm_tpDisable1.551"
+		"OnFullyOpen" "s3_boss_att_tp_cageDisable8.541"
+	}
+}
+
+;buff stage 2 ending health and change trigger type to multiple
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "s2_once_win"
+	}
+	replace:
+	{
+		"classname" "trigger_multiple"
+	}
+	delete:
+	{
+		"OnStartTouch" "!activatorSetHealth1000-1"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activatorAddOutputhealth 1500-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_movelinear"
+		"targetname" "s2_lift03"
+	}
+	insert:
+	{
+		"OnFullyClosed" "s2_set_hpDisable28.51"
+	}
+}

--- a/stripper/ze_bioluminescent_k1.cfg
+++ b/stripper/ze_bioluminescent_k1.cfg
@@ -26,7 +26,7 @@ modify:
 	match:
 	{
 		"classname" "trigger_once"
-		"targetname" "s2_once_win"
+		"targetname" "s2_set_hp"
 	}
 	replace:
 	{


### PR DESCRIPTION
This **should** hopefully be the last changes I need to make for the map. 

-> Fix a rare bug where during stage 3 boss fight zm attack if a player were to be infected as zombies were teleported away, they don't get teleported away
-> Increased default health for stage 2 ending minigame to 150 hp
-> Changed set hp trigger to a trigger_multiple instead of relying on a trigger_once