### PR TITLE
Last Man Standing p3 Fixes and stripper cleanup

### DIFF
--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -78,11 +78,8 @@ add:
 	"origin" "-1088 13304 -8516"
 	"classname" "trigger_multiple"
 	"filtername" "Weapon_PortalGun_FixFilter_2"
-	connections
-	{
-		"OnStartTouch" "!activatorAddContextplayer_portal_1:10-1"
-		"OnStartTouch" "Weapon_PortalGun_EnterPortalSoundFireUser10-1"
-	}
+	"OnStartTouch" "!activatorAddContextplayer_portal_1:10-1"
+	"OnStartTouch" "Weapon_PortalGun_EnterPortalSoundFireUser10-1"
 }
 add:
 {
@@ -95,11 +92,8 @@ add:
 	"origin" "-1088 13352 -8516"
 	"classname" "trigger_multiple"
 	"filtername" "Weapon_PortalGun_FixFilter_1"
-	connections
-	{
-		"OnStartTouch" "!activatorAddContextplayer_portal_2:10-1"
-		"OnStartTouch" "Weapon_PortalGun_EnterPortalSoundFireUser10-1"
-	}
+	"OnStartTouch" "!activatorAddContextplayer_portal_2:10-1"
+	"OnStartTouch" "Weapon_PortalGun_EnterPortalSoundFireUser10-1"
 }
 add:
 {

--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -59,9 +59,437 @@ add:
 	"rendermode" "10"
 }
 
-// Rest of the changes are made by "Berke" "STEAM_1:0:95142811", version 1.
+;fix portal gun repeatedly teleporting bug
+modify:
+{
+	match:
+	{
+		"targetname" "Weapon_PortalGun_Portal_1_Phys"
+		"classname" "func_physbox_multiplayer"
+	}
+	insert:
+	{
+		"OnUser1" "Weapon_PortalGun_Portal_1_TriggerKill0-1"
+		"OnUser2" "Weapon_PortalGun_Portal_1_TriggerClearParent1.5-1"
+	}
+}
 
-// Fix spawn trigger not resetting players.
+modify:
+{
+	match:
+	{
+		"targetname" "Weapon_PortalGun_Portal_2_Phys"
+		"classname" "func_physbox_multiplayer"
+	}
+	insert:
+	{
+		"OnUser1" "Weapon_PortalGun_Portal_2_TriggerKill0-1"
+		"OnUser2" "Weapon_PortalGun_Portal_2_TriggerClearParent1.5-1"
+	}
+}
+
+add:
+{
+	"model" "*86"
+	"wait" "1"
+	"targetname" "Weapon_PortalGun_Portal_1_Trigger"
+	"StartDisabled" "1"
+	"spawnflags" "1"
+	"parentname" "Weapon_PortalGun_Portal_1_Teleport"
+	"origin" "-1088 13304 -8516"
+	"classname" "trigger_multiple"
+	"filtername" "Weapon_PortalGun_FixFilter_2"
+	"OnStartTouch" "!activatorAddContextplayer_portal_1:10-1"
+	"OnStartTouch" "Weapon_PortalGun_EnterPortalSoundFireUser10-1"
+}
+
+add:
+{
+	"model" "*89"
+	"wait" "1"
+	"targetname" "Weapon_PortalGun_Portal_2_Trigger"
+	"StartDisabled" "1"
+	"spawnflags" "1"
+	"parentname" "Weapon_PortalGun_Portal_2_Teleport"
+	"origin" "-1088 13352 -8516"
+	"classname" "trigger_multiple"
+	"filtername" "Weapon_PortalGun_FixFilter_1"
+	"OnStartTouch" "!activatorAddContextplayer_portal_2:10-1"
+	"OnStartTouch" "Weapon_PortalGun_EnterPortalSoundFireUser10-1"
+}
+
+add:
+{
+	"targetname" "Weapon_PortalGun_FixFilter_1_2"
+	"ResponseContext" "player_portal_1"
+	"Negated" "0"
+	"classname" "filter_activator_context"
+}
+
+add:
+{
+	"targetname" "Weapon_PortalGun_FixFilter_2_2"
+	"ResponseContext" "player_portal_2"
+	"Negated" "0"
+	"classname" "filter_activator_context"
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "Weapon_PortalGun_Portal_1_Teleport"
+		"classname" "trigger_teleport"
+	}
+	delete:
+	{
+		"OnEndTouch" "Weapon_PortalGun_EnterPortalSoundFireUser10-1"
+		"OnStartTouch" "!activatorAddContextplayer_portal_1:10-1"
+		"OnEndTouch" "!activatorRemoveContextplayer_portal_20-1"
+	}
+	replace:
+	{
+		"filtername" "Weapon_PortalGun_FixFilter_1_2"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "Weapon_PortalGun_Portal_2_Teleport"
+		"classname" "trigger_teleport"
+	}
+	delete:
+	{
+		"OnEndTouch" "Weapon_PortalGun_EnterPortalSoundFireUser10-1"
+		"OnEndTouch" "!activatorRemoveContextplayer_portal_10-1"
+		"OnStartTouch" "!activatorAddContextplayer_portal_2:10-1"
+	}
+	replace:
+	{
+		"filtername" "Weapon_PortalGun_FixFilter_2_2"
+	}
+}
+
+; open doors to prevent ZMs being locked out on Solo ending
+modify: 
+{
+    match:
+    {
+        "classname" "logic_relay"
+        "targetname" "stage_5_core_destroyed"
+    }
+    insert:
+    {
+        "OnTrigger" "stage_5_top_door_*Open01"
+    }
+}
+; Fix stage 2 last vent entrance being breakable early.
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "stage_2_teleport_2"
+	}
+	insert:
+	{
+		"OnStartTouch" "stage_2_escape_ventSetHealth10051"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_breakable"
+		"targetname" "stage_2_escape_vent"
+	}
+	replace:
+	{
+		"health" "0"
+	}
+}
+
+; Avoid delay on stage 5
+modify:
+{
+	match:
+	{
+		"classname" "math_counter"
+		"targetname" "stage_5_lower_counter_energy"
+	}
+	insert:
+	{
+		"OnHitMax" "stage5_antidelayTrigger01"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "filter_activator_team"
+		"targetname" "stage_5_button_filter"
+	}
+	insert:
+	{
+		"OnPass" "stage5_antidelayCancelPending01"
+	}
+}
+
+add:
+{
+	"classname" "logic_relay"
+	"spawnflags" "0"
+	"StartDisabled" "0"
+	"targetname" "stage5_antidelay"
+	"OnTrigger" "Global_GameText_AnnouncementFireUser361"
+	"OnTrigger" "Global_GameText_AnnouncementAddOutputmessage ** ACTIVATE THE ELEVATOR QUICKLY! (1/3) **61"
+	"OnTrigger" "Global_GameText_AnnouncementFireUser3161"
+	"OnTrigger" "Global_GameText_AnnouncementAddOutputmessage ** ACTIVATE THE ELEVATOR QUICKLY! (2/3) **161"
+	"OnTrigger" "Global_GameText_AnnouncementFireUser3261"
+	"OnTrigger" "Global_GameText_AnnouncementAddOutputmessage ** LAST WARNING! ACTIVATE THE ELEVATOR QUICKLY! (3/3) **261"
+	"OnTrigger" "map1roundend1EndRound_TerroristsWin7361"
+}
+
+add:
+{
+	"classname" "game_round_end"
+	"targetname" "map1roundend1"
+	"OnRoundEnded" "map1roundend1,Kill,,,1"
+}
+
+; Fix zms able to surf and stop stage 2 from being completed (only really doable with high AA but just incase)
+add:
+{
+	"targetname" "team_filter_stage2water_human"
+	"Negated" "Allow entities that match criteria"
+	"filterteam" "3"
+	"classname" "filter_activator_team"
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "stage_2_hurt_water"
+	}
+	replace:
+	{
+		"filtername" "team_filter_stage2water_human"
+	}
+}
+modify:
+{
+	match:
+	{
+		"targetname" "stage_2_end_trigger"
+	}
+	insert:
+	{
+		"OnStartTouch" "team_filter_stage2water_humanKill01"
+		"OnStartTouch" "stage_2_hurt_waterAddOutputdamage 500001"
+		"OnStartTouch" "stage_2_hurt_waterAddOutputdamagecap 500001"
+	}
+}
+
+; make this unblockable (players can get stuck but at least this wont be griefable)
+modify:
+{
+	match:
+	{
+		"targetname" "stage_x_reward_vehicle_with_weapons"
+		"classname" "func_tracktrain"
+	}
+	replace:
+	{
+		"dmg" "5"
+	}
+}
+
+; stage 5 lower delay on the buttons on top
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "stage_5_end_button_blue"
+	}
+	replace:
+	{
+		"wait" "0.1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "stage_5_end_button_red"
+	}
+	replace:
+	{
+		"wait" "0.1"
+	}
+}
+
+; Stage 4 Nuke breaking will now not cause map to be in limbo (avoid delay) hopefully too incase it for some reason breaks
+; This will also fix the issues resulting of stage 4 being extremely open which let predator, freezer and jumper to trigger the round end button since whoever touched this before decided that was a good idea
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "stage_4_end_button_protection"
+	}
+	insert:
+	{
+		"OnDamaged" "stage4_nuke_brokeEnable01"
+	}
+}
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stage_x_ultralistk_path_8"
+	}
+	insert:
+	{
+		"OnPass" "stage4_nuke_brokeTrigger01"
+	}
+}
+
+add:
+{
+	"classname" "logic_relay"
+	"spawnflags" "1"
+	"StartDisabled" "1"
+	"targetname" "stage4_nuke_broke"
+	"OnTrigger" "stage_nuke_inmuzer1Enable101"
+	"OnTrigger" "stage_nuke_inmuzer2Enable101"
+	"OnTrigger" "stage_nuke_inmuzer1Disable10.031"
+	"OnTrigger" "stage_nuke_inmuzer2Disable10.031"
+	"OnTrigger" "Global_GameText_AnnouncementAddOutputmessage ** THE NUKE FAILED! **21"
+	"OnTrigger" "Global_GameText_AnnouncementFireUser331"
+	"OnTrigger" "Global_GameText_AnnouncementAddOutputmessage ** THE ULTRALISK IS STILL ALIVE HOPE WE DONT HAVE TO MEET HIM AGAIN... **81"
+	"OnTrigger" "Global_GameText_AnnouncementFireUser391"
+	"OnTrigger" "Fix_IssueForceSpawn10.51"
+}
+
+; nerf antlion
+; this was done due to it being OP as fck if you know what to do
+modify:
+{
+	match:
+	{
+		"classname" "logic_compare"
+		"targetname" "Zombie_Item_Antlion_Dig_Relay"
+	}
+	delete:
+	{
+		"OnEqualTo" "Global_SpeedModifySpeed1.151.25-1"
+	}
+	insert:
+	{
+		"OnEqualTo" "Global_SpeedModifySpeed0.51.25-1"
+	}
+}
+
+; move vortigaunt stage 1 to let you get past a lot easier with tank
+modify:
+{
+	match:
+	{
+		"targetname" "Extreme_stage_1"
+		"classname" "logic_relay"
+		"hammerid" "7668954"
+	}
+	delete:
+	{
+		"OnTrigger" "Zombie_Item_Vortigaunt_TemplateAddOutputorigin 7886 2884 -136620-1"
+	}
+	insert:
+	{
+		"OnTrigger" "Zombie_Item_Vortigaunt_TemplateAddOutputorigin 7886 3108 -136620-1"
+	}
+}	
+
+; fix boost on stage 5 with core
+modify:
+{
+	match:
+	{
+		"targetname" "stage_5_core_hit_push"
+		"classname" "trigger_teleport"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activatorRunScriptCodeself.SetVelocity(Vector());0-1"
+	}
+}
+
+; OPTIONAL REMOVE SPEED FOR ZMS AS THEY TP TO AVOID HAVING INCIDENTS WHERE ZMS FALL FASTER THAN THE HUMAN DUE TO SOURCE ENGINE PHYSICS
+modify:
+{
+	match:
+	{
+		"targetname" "stage_5_last_man_trigger_core_end"
+		"classname" "trigger_multiple"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activatorRunScriptCodeself.SetVelocity(Vector());0-1"
+	}
+}	
+
+; fix the british guy adding some skybox making heli shit itself
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stage_x_end_helicopter_track_7"
+	}
+	replace:
+	{
+		"origin" "-5952 -9235 5256"
+	}
+}
+
+; Stage 3 Make zombies unable to survive and delay untill zms are slayed
+modify:
+{
+	match:
+	{
+		"hammerid" "5643492"
+		"targetname" "stage_nuke_inmuzer1"
+	}
+	insert:
+	{
+		"filtername" "team_filter_humans"
+	}
+}
+
+; move tank stage 2 to the v6_1 one
+modify:
+{
+	match:
+	{
+		"targetname" "Zombie_Item_Tank_Spawner"
+		"classname" "env_entity_maker"
+	}
+	replace:
+	{
+		"origin" "4848 -10200 -7248"
+	}
+}
+; Rest of the changes are made by "Berke" "STEAM_1:0:95142811", version 1.
+
+; Fix spawn trigger not resetting players.
 filter:
 {
 	"classname" "trigger_multiple"
@@ -123,7 +551,7 @@ modify:
 	}
 }
 
-// Remove the message related to checkpoints in warmup round since this version doesn't have them.
+; Remove the message related to checkpoints in warmup round since this version doesn't have them.
 modify:
 {
 	match:
@@ -137,7 +565,7 @@ modify:
 	}
 }
 
-// Add a prop to get out of a stuck spot near tank spawn on extreme stage 1.
+; Add a prop to get out of a stuck spot near tank spawn on extreme stage 1.
 add:
 {
 	"classname" "prop_dynamic"
@@ -167,7 +595,7 @@ add:
 	"solid" "6"
 }
 
-// Add viewcontrol template related outputs, filter stage 1 "Juggernaut" trigger to humans and reset targetnames.
+; Add viewcontrol template related outputs, filter stage 1 "Juggernaut" trigger to humans and reset targetnames.
 modify:
 {
 	match:
@@ -191,7 +619,7 @@ modify:
 	}
 }
 
-// Fix stage 2 last vent entrance being breakable early.
+; Fix stage 2 last vent entrance being breakable early.
 modify:
 {
 	match:
@@ -218,34 +646,8 @@ modify:
 	}
 }
 
-// Optional: Prevent the "Portal Gun" skip.
-//modify:
-//{
-//	match:
-//	{
-//		"classname" "func_button"
-//		"targetname" "Weapon_PortalGun_UI"
-//	}
-//	replace:
-//	{
-//		"origin" "-1004 13248 -8512"
-//	}
-//}
 
-//modify:
-//{
-//	match:
-//	{
-//		"classname" "env_entity_maker"
-// 		"targetname" "Weapon_PortalGun_Projectile_Spawner"
-//	}
-//	replace:
-//	{
-//		"origin" "-1088 13248 -8520"
-//	}
-//}
-
-// Fix stage 2 last vent fall breaking despite second room being "Mutator Test".
+; Fix stage 2 last vent fall breaking despite second room being "Mutator Test".
 modify:
 {
 	match:
@@ -272,7 +674,7 @@ modify:
 	}
 }
 
-// Reduce volume of "Mech" minigun sound.
+; Reduce volume of "Mech" minigun sound.
 modify:
 {
 	match:
@@ -286,7 +688,7 @@ modify:
 	}
 }
 
-// Fix stage 4 nuke pit teleport being setup wrong.
+; Fix stage 4 nuke pit teleport being setup wrong.
 modify:
 {
 	match:
@@ -304,7 +706,7 @@ modify:
 	}
 }
 
-// Fix stage 4 nuke pad being broken showing the wrong message, being able to be damaged multiple times and not resulting in a round end.
+; Fix stage 4 nuke pad being broken showing the wrong message, being able to be damaged multiple times and not resulting in a round end.
 modify:
 {
 	match:
@@ -318,20 +720,12 @@ modify:
 	}
 	insert:
 	{
-		"OnDamaged" "!self,Kill,,,1"
 		"OnDamaged" "Global_GameText_AnnouncementRunScriptCodesetMessage(33);1"
-		"OnDamaged" "map1roundend1,EndRound_TerroristsWin,7,,1"
 	}
 }
 
-add:
-{
-	"classname" "game_round_end"
-	"targetname" "map1roundend1"
-	"OnRoundEnded" "map1roundend1,Kill,,,1"
-}
 
-// Fix the new truck model used in stage 5 not covering the side like in the original.
+; Fix the new truck model used in stage 5 not covering the side like in the original.
 modify:
 {
 	match:
@@ -345,7 +739,7 @@ modify:
 	}
 }
 
-// Prevent explosions from triggering repeat killer.
+; Prevent explosions from triggering repeat killer.
 modify:
 {
 	match:
@@ -374,7 +768,7 @@ modify:
 	}
 }
 
-// When a zombie tank is broken, don't make it disappear but make it non-solid and darken it.
+; When a zombie tank is broken, don't make it disappear but make it non-solid and darken it.
 modify:
 {
 	match:
@@ -395,8 +789,8 @@ modify:
 	}
 }
 
-// Prevent camping zombie spawns.
-// Add filters that prevent all damage but nuke.
+; Prevent camping zombie spawns.
+; Add filters that prevent all damage but nuke.
 add:
 {
 	"classname" "filter_activator_name"
@@ -428,7 +822,7 @@ add:
 	"Filter03" "map1nukefilter3"
 }
 
-// Stage 1
+; Stage 1
 add:
 {
 	"classname" "trigger_multiple"
@@ -480,7 +874,7 @@ add:
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
 
-// Stage 2
+; Stage 2
 add:
 {
 	"classname" "trigger_multiple"
@@ -520,7 +914,7 @@ add:
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
 
-// Stage 3
+; Stage 3
 add:
 {
 	"classname" "trigger_multiple"
@@ -558,7 +952,7 @@ add:
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
 
-// Stage 4
+; Stage 4
 add:
 {
 	"classname" "trigger_multiple"
@@ -609,7 +1003,7 @@ add:
 	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
 }
 
-// Implement the unused zombie teleport in extreme stage 1.
+; Implement the unused zombie teleport in extreme stage 1.
 modify:
 {
 	match:
@@ -623,7 +1017,7 @@ modify:
 	}
 }
 
-// Implement the unused zombie teleport in extreme stage 3.
+; Implement the unused zombie teleport in extreme stage 3.
 modify:
 {
 	match:
@@ -637,8 +1031,8 @@ modify:
 	}
 }
 
-// Fix viewcontrols being laggy for "Alex Mercer" and "Mech".
-// Delete the old system used for viewcontrols.
+; Fix viewcontrols being laggy for "Alex Mercer" and "Mech".
+; Delete the old system used for viewcontrols.
 filter:
 {
 	"classname" "logic_measure_movement"
@@ -663,7 +1057,7 @@ filter:
 	"targetname" "Human_Item_Mech_Cam_Pos_2"
 }
 
-// Add the new system where we spawn the viewcontrols using a preserved template and spawn them parented.
+; Add the new system where we spawn the viewcontrols using a preserved template and spawn them parented.
 modify:
 {
 	match:
@@ -712,7 +1106,7 @@ modify:
 	}
 }
 
-// When someone dies, give them empty targetname instead of one called "none" and prevent viewmodel from being glitched out.
+; When someone dies, give them empty targetname instead of one called "none" and prevent viewmodel from being glitched out.
 modify:
 {
 	match:
@@ -731,4 +1125,443 @@ modify:
 		"OnUser1" "Map_End_Camera,RemovePlayer,,,1"
 		"OnUser1" "Map_End_Camera,AddPlayer,,,1"
 	}
+}
+
+; BELOW IS OPTIONAL
+; JUST ADDS SONG LYRICS
+; Song lyrics ex4&ex5 done by koen (https:;github.com/notkoen)
+; ex3 done by iszaar
+modify:
+{
+	match:
+	{
+		"targetname" "Music_Selector_Ex"
+		"classname" "logic_case"
+	}
+	insert:
+	{
+		"OnCase11" "stage_10_start_relayTrigger0.21"
+		"OnCase11" "stage_10_top_1_relayEnable0.21"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "stage_5_button_filter"
+		"classname" "filter_activator_team"
+	}
+	insert:
+	{
+		"OnPass" "stage_10_start_relayCancelPending6.201"
+		"OnPass" "stage_10_top_1_relayTrigger11.11"
+		"OnPass" "ex5_music_textAddOutputmessage  6.001"
+		"OnPass" "ex5_music_textDisplay6.101"
+		"OnPass" "ex5_music_text2AddOutputmessage  6.001"
+		"OnPass" "ex5_music_text2Display6.101"
+		"OnPass" "stage_10_start_relaykill7.101"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "stage_5_top_relay_core_working"
+		"classname" "logic_relay"
+	}
+	insert:
+	{
+		"OnTrigger" "ex5_music_textAddOutputmessage  1.001"
+		"OnTrigger" "ex5_music_textDisplay1.101"
+		"OnTrigger" "stage_10_top_1_relayCancelPending7.00-1"
+		"OnTrigger" "stage_10_top_1_relaykill7.10-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "stage_5_core_destroyed"
+		"classname" "logic_relay"
+	}
+	insert:
+	{
+		"OnTrigger" "ex5_music_textAddOutputmessage  1.001"
+		"OnTrigger" "ex5_music_textDisplay1.101"
+		"OnTrigger" "stage_10_top_1_relayCancelPending7.00-1"
+		"OnTrigger" "stage_10_top_1_relaykill7.10-1"
+	}
+}
+modify:
+{
+	match:
+	{
+		"hammerid" "9345860"
+	}
+	insert:
+	{
+		"OnCase07" "music_master_ambient_ex3_relayEnable0.11"
+		"OnCase07" "music_master_ambient_ex3_relayTrigger0.21"
+		"OnCase10" "music_master_ambient_ex4_relayEnable0.11"
+		"OnCase10" "music_master_ambient_ex4_relayTrigger0.21"
+	}
+}
+add:
+{
+	"classname" "game_text"
+	"origin" "-5701.34 -723.98 -15159.97"
+	"y" "0.5"
+	"x" "0.02"
+	"targetname" "ex5_music_text"
+	"spawnflags" "1"
+	"message" ""
+	"holdtime" "66"
+	"fxtime" "1.5"
+	"fadeout" "0.1"
+	"fadein" "0.3"
+	"effect" "0"
+	"color2" "255 255 255"
+	"color" "255 255 255"
+	"channel" "4"
+}
+add:
+{
+	"origin" "-5701.34 -723.98 -15159.98"
+	"targetname" "stage_10_start_relay"
+	"StartDisabled" "0"
+	"spawnflags" "0"
+	"classname" "logic_relay"
+	"OnTrigger" "ex5_music_textAddOutputmessage Madeon - Finale (Netsky Remix)20.001"
+	"OnTrigger" "ex5_music_textDisplay20.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Your last chance23.001"
+	"OnTrigger" "ex5_music_textDisplay23.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Last Summer26.001"
+	"OnTrigger" "ex5_music_textDisplay26.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Your last dance29.001"
+	"OnTrigger" "ex5_music_textDisplay29.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage To beat to your own drummer31.001"
+	"OnTrigger" "ex5_music_textDisplay31.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Go out fighting35.001"
+	"OnTrigger" "ex5_music_textDisplay35.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Go out young37.001"
+	"OnTrigger" "ex5_music_textDisplay37.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage A flash of lightning40.001"
+	"OnTrigger" "ex5_music_textDisplay40.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Eclipse the sun43.001"
+	"OnTrigger" "ex5_music_textDisplay43.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Your last chance45.001"
+	"OnTrigger" "ex5_music_textDisplay45.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Last Summer49.001"
+	"OnTrigger" "ex5_music_textDisplay49.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Your last dance51.001"
+	"OnTrigger" "ex5_music_textDisplay51.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage To beat to your own drummer54.001"
+	"OnTrigger" "ex5_music_textDisplay54.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Go out fighting57.001"
+	"OnTrigger" "ex5_music_textDisplay57.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Go out young60.001"
+	"OnTrigger" "ex5_music_textDisplay60.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage A flash of lightning62.001"
+	"OnTrigger" "ex5_music_textDisplay62.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Eclipse the sun65.001"
+	"OnTrigger" "ex5_music_textDisplay65.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Brace yourself brace yourself67.001"
+	"OnTrigger" "ex5_music_textDisplay67.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Brace yourself for the grand finale87.001"
+	"OnTrigger" "ex5_music_textDisplay87.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Whoa oh~~~91.001"
+	"OnTrigger" "ex5_music_textDisplay91.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Brace yourself for the grand finale131.001"
+	"OnTrigger" "ex5_music_textDisplay131.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Your last chance156.001"
+	"OnTrigger" "ex5_music_textDisplay156.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Last Summer159.001"
+	"OnTrigger" "ex5_music_textDisplay159.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Your last dance162.001"
+	"OnTrigger" "ex5_music_textDisplay162.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage To beat to your own drummer164.001"
+	"OnTrigger" "ex5_music_textDisplay164.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Go out fighting168.001"
+	"OnTrigger" "ex5_music_textDisplay168.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Go out young171.001"
+	"OnTrigger" "ex5_music_textDisplay171.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage A flash of lightning173.001"
+	"OnTrigger" "ex5_music_textDisplay173.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Eclipse the sun176.001"
+	"OnTrigger" "ex5_music_textDisplay176.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Brace yourself brace yourself178.001"
+	"OnTrigger" "ex5_music_textDisplay178.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Brace yourself for the grand finale198.001"
+	"OnTrigger" "ex5_music_textDisplay198.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Whoa oh~~~202.001"
+	"OnTrigger" "ex5_music_textDisplay202.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Brace yourself for the grand finale242.001"
+	"OnTrigger" "ex5_music_textDisplay242.101"
+}
+add:
+{
+	"origin" "-5701.34 -723.98 -15159.98"
+	"targetname" "stage_10_top_1_relay"
+	"StartDisabled" "1"
+	"spawnflags" "0"
+	"classname" "logic_relay"
+	"OnTrigger" "ex5_music_textAddOutputmessage Pendulum - Witchcraft Vs Watercolour0.001"
+	"OnTrigger" "ex5_music_textDisplay0.101"
+	"OnTrigger" "ex5_music_textAddOutputcolor 255 0 00.201"
+	"OnTrigger" "ex5_music_textAddOutputmessage It's in your eyes a color fade-out6.001"
+	"OnTrigger" "ex5_music_textDisplay6.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Looks like a new transition12.001"
+	"OnTrigger" "ex5_music_textDisplay12.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Is starting up and shaking your ground17.001"
+	"OnTrigger" "ex5_music_textDisplay17.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Turning your head to see a new day calling22.001"
+	"OnTrigger" "ex5_music_textDisplay22.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Does it feel like a head to lean on29.001"
+	"OnTrigger" "ex5_music_textDisplay29.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage A snapshot from where you were born35.001"
+	"OnTrigger" "ex5_music_textDisplay35.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage I'm looking for your hand in the rough40.001"
+	"OnTrigger" "ex5_music_textDisplay40.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage You're caught in the wire44.001"
+	"OnTrigger" "ex5_music_textDisplay44.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Well I'll lift you out47.001"
+	"OnTrigger" "ex5_music_textDisplay47.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage When I'm falling down51.001"
+	"OnTrigger" "ex5_music_textDisplay51.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Will you pick me up again56.001"
+	"OnTrigger" "ex5_music_textDisplay56.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage When I'm too far gone62.001"
+	"OnTrigger" "ex5_music_textDisplay62.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Dead in the eyes of my friends67.001"
+	"OnTrigger" "ex5_music_textDisplay67.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Will you take me out of here73.001"
+	"OnTrigger" "ex5_music_textDisplay73.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage When I'm staring down the barrel75.001"
+	"OnTrigger" "ex5_music_textDisplay75.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage When I'm blinded by the lights78.001"
+	"OnTrigger" "ex5_music_textDisplay78.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage When I cannot see your face81.001"
+	"OnTrigger" "ex5_music_textDisplay81.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Take me out of here84.001"
+	"OnTrigger" "ex5_music_textDisplay84.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Take me out of here87.001"
+	"OnTrigger" "ex5_music_textDisplay87.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Take me out of here90.001"
+	"OnTrigger" "ex5_music_textDisplay90.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Take me out of here93.001"
+	"OnTrigger" "ex5_music_textDisplay93.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Leaning on the action94.001"
+	"OnTrigger" "ex5_music_textDisplay94.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Caught in a cellphone's rays97.001"
+	"OnTrigger" "ex5_music_textDisplay97.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Bleeding on the sofa99.001"
+	"OnTrigger" "ex5_music_textDisplay99.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Staring at the wayside102.001"
+	"OnTrigger" "ex5_music_textDisplay102.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage He's coming and she knows it104.001"
+	"OnTrigger" "ex5_music_textDisplay104.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Even if she knows why108.001"
+	"OnTrigger" "ex5_music_textDisplay108.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Footsteps in the hallway110.001"
+	"OnTrigger" "ex5_music_textDisplay110.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Girl you haven't got time113.001"
+	"OnTrigger" "ex5_music_textDisplay113.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage All I believe115.001"
+	"OnTrigger" "ex5_music_textDisplay115.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage And all I've known118.001"
+	"OnTrigger" "ex5_music_textDisplay118.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Are being taken from me120.001"
+	"OnTrigger" "ex5_music_textDisplay120.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Can't get home124.001"
+	"OnTrigger" "ex5_music_textDisplay124.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Led to a world126.001"
+	"OnTrigger" "ex5_music_textDisplay126.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Where worlds collide129.001"
+	"OnTrigger" "ex5_music_textDisplay129.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Let the fear collapse bring no surprise132.001"
+	"OnTrigger" "ex5_music_textDisplay132.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Take me out of here137.001"
+	"OnTrigger" "ex5_music_textDisplay137.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Feed the fire break your vision159.001"
+	"OnTrigger" "ex5_music_textDisplay159.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Throw your fists up come on with me159.001"
+	"OnTrigger" "ex5_music_textDisplay159.101"
+}
+
+add:
+{
+	"origin" "-5701.34 -723.98 -15159.98"
+	"targetname" "music_master_ambient_ex4_relay"
+	"StartDisabled" "1"
+	"spawnflags" "0"
+	"classname" "logic_relay"	
+	"OnTrigger" "ex5_music_textAddOutputmessage Linkin Park - The Catalyst (Pendulum Remix)0.001"
+	"OnTrigger" "ex5_music_textDisplay0.101"
+	"OnTrigger" "ex5_music_textAddOutputcolor 255 255 2550.201"
+	"OnTrigger" "ex5_music_textAddOutputmessage Like memories in cold decay2.501"
+	"OnTrigger" "ex5_music_textDisplay2.601"
+	"OnTrigger" "ex5_music_textAddOutputmessage Transmissions echoing away5.001"
+	"OnTrigger" "ex5_music_textDisplay5.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Far from the world of you and I7.501"
+	"OnTrigger" "ex5_music_textDisplay7.601"
+	"OnTrigger" "ex5_music_textAddOutputmessage Where oceans bleed into the sky11.001"
+	"OnTrigger" "ex5_music_textDisplay11.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage God save us everyone41.001"
+	"OnTrigger" "ex5_music_textDisplay41.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Will we burn inside the fires of a thousand suns43.001"
+	"OnTrigger" "ex5_music_textDisplay43.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage For the sins of our hands46.001"
+	"OnTrigger" "ex5_music_textDisplay46.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage The sins of our tongue47.001"
+	"OnTrigger" "ex5_music_textDisplay47.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage The sins of our fathers48.001"
+	"OnTrigger" "ex5_music_textDisplay48.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage The sins of our young49.001"
+	"OnTrigger" "ex5_music_textDisplay49.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage No51.001"
+	"OnTrigger" "ex5_music_textDisplay51.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage God save us everyone52.001"
+	"OnTrigger" "ex5_music_textDisplay52.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Will we burn inside the fires of a thousand suns54.001"
+	"OnTrigger" "ex5_music_textDisplay54.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage For the sins of our hands57.001"
+	"OnTrigger" "ex5_music_textDisplay57.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage The sins of our tongue58.001"
+	"OnTrigger" "ex5_music_textDisplay58.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage The sins of our fathers59.001"
+	"OnTrigger" "ex5_music_textDisplay59.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage The sins of our young61.001"
+	"OnTrigger" "ex5_music_textDisplay61.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage No63.001"
+	"OnTrigger" "ex5_music_textDisplay63.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage And when I close my eyes tonight64.001"
+	"OnTrigger" "ex5_music_textDisplay64.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage To symphonies of blinding light66.001"
+	"OnTrigger" "ex5_music_textDisplay66.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Like memories in cold decay74.501"
+	"OnTrigger" "ex5_music_textDisplay74.601"
+	"OnTrigger" "ex5_music_textAddOutputmessage Transmissions echoing away77.001"
+	"OnTrigger" "ex5_music_textDisplay77.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Far from the world of you and I80.001"
+	"OnTrigger" "ex5_music_textDisplay80.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Where oceans bleed into the sky83.001"
+	"OnTrigger" "ex5_music_textDisplay83.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Like memories in cold decay107.001"
+	"OnTrigger" "ex5_music_textDisplay107.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Transmissions echoing away110.001"
+	"OnTrigger" "ex5_music_textDisplay110.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Far from the world of you and I113.001"
+	"OnTrigger" "ex5_music_textDisplay113.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Where oceans bleed into the sky116.001"
+	"OnTrigger" "ex5_music_textDisplay116.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Lift me up130.001"
+	"OnTrigger" "ex5_music_textDisplay130.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage Let me go133.501"
+	"OnTrigger" "ex5_music_textDisplay133.601"
+	"OnTrigger" "ex5_music_textAddOutputmessage Lift me up! Let me go!136.501"
+	"OnTrigger" "ex5_music_textDisplay136.601"
+}
+
+add:
+{
+	"origin" "-5701.34 -723.98 -15159.98"
+	"targetname" "music_master_ambient_ex3_relay"
+	"StartDisabled" "1"
+	"spawnflags" "0"
+	"classname" "logic_relay"
+	"OnTrigger" "ex5_music_textAddOutputcolor 255 55 001"
+	"OnTrigger" "ex5_music_textAddOutputholdtime 1001"
+	"OnTrigger" "ex5_music_textAddOutputmessage Pendulum feat. In Flames - Self vs Self0.001"
+	"OnTrigger" "ex5_music_textDisplay0.101"
+	"OnTrigger" "ex5_music_textAddOutputmessage If I struggle a lifetime2.661"
+	"OnTrigger" "ex5_music_textDisplay661"
+	"OnTrigger" "ex5_music_textAddOutputmessage What would my body be?691"
+	"OnTrigger" "ex5_music_textDisplay69.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage An empty shell721"
+	"OnTrigger" "ex5_music_textDisplay72.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage On which a demon fed741"
+	"OnTrigger" "ex5_music_textDisplay74.51"
+	"OnTrigger" "ex5_music_textAddOutputmessage Could be a heavy burden771"
+	"OnTrigger" "ex5_music_textDisplay77.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage To stay true to your words791"
+	"OnTrigger" "ex5_music_textDisplay79.51"
+	"OnTrigger" "ex5_music_textAddOutputmessage Speak up831"
+	"OnTrigger" "ex5_music_textDisplay83.51"
+	"OnTrigger" "ex5_music_textAddOutputmessage I wanna silence everything851"
+	"OnTrigger" "ex5_music_textDisplay85.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage If I got no plan891"
+	"OnTrigger" "ex5_music_textDisplay89.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage Doesn't mean that I get what I want for free941"
+	"OnTrigger" "ex5_music_textDisplay94.51"
+	"OnTrigger" "ex5_music_textAddOutputmessage If I got no meaning1001"
+	"OnTrigger" "ex5_music_textDisplay100.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage Would you force me to a place where I make sense1051"
+	"OnTrigger" "ex5_music_textDisplay105.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage Cause nothing lasts forever...!1101"
+	"OnTrigger" "ex5_music_textDisplay110.11"
+	"OnTrigger" "ex5_music_textAddOutputcolor 255 0 01151"
+	"OnTrigger" "ex5_music_textAddOutputmessage How do I get home?1151"
+	"OnTrigger" "ex5_music_textDisplay115.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage Everything revolves around me1181"
+	"OnTrigger" "ex5_music_textDisplay118.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage If I can't find myself?1201"
+	"OnTrigger" "ex5_music_textDisplay120.51"
+	"OnTrigger" "ex5_music_textAddOutputmessage If so Its so completely fake1231"
+	"OnTrigger" "ex5_music_textDisplay123.51"
+	"OnTrigger" "ex5_music_textAddOutputmessage How do I get home?1261"
+	"OnTrigger" "ex5_music_textDisplay126.51"
+	"OnTrigger" "ex5_music_textAddOutputmessage Everything revolves around me1291"
+	"OnTrigger" "ex5_music_textDisplay129.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage If even you can't help?1311"
+	"OnTrigger" "ex5_music_textDisplay131.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage Dark nights on my soul1361"
+	"OnTrigger" "ex5_music_textDisplay136.11"
+	"OnTrigger" "ex5_music_textAddOutputcolor 255 55 01601"
+	"OnTrigger" "ex5_music_textAddOutputmessage I deny failure1611"
+	"OnTrigger" "ex5_music_textDisplay161.51"
+	"OnTrigger" "ex5_music_textAddOutputmessage I ignite1631"
+	"OnTrigger" "ex5_music_textDisplay163.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage Woe is on my misery1651"
+	"OnTrigger" "ex5_music_textDisplay165.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage She wins all their eyes1681"
+	"OnTrigger" "ex5_music_textDisplay168.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage Realise what defies our fate1701"
+	"OnTrigger" "ex5_music_textDisplay170.51"
+	"OnTrigger" "ex5_music_textAddOutputmessage This is not me this is me1731"
+	"OnTrigger" "ex5_music_textDisplay173.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage So if I struggle a lifetime1761"
+	"OnTrigger" "ex5_music_textDisplay176.51"
+	"OnTrigger" "ex5_music_textAddOutputmessage What good would that do?1791"
+	"OnTrigger" "ex5_music_textDisplay179.11"
+	"OnTrigger" "ex5_music_textAddOutputcolor 255 0 01821"
+	"OnTrigger" "ex5_music_textAddOutputmessage If I got a plan1821"
+	"OnTrigger" "ex5_music_textDisplay182.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage Doesn't have to stop the feeling inside1881"
+	"OnTrigger" "ex5_music_textDisplay188.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage If I do make sense1931"
+	"OnTrigger" "ex5_music_textDisplay193.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage Would you drag me down?1991"
+	"OnTrigger" "ex5_music_textDisplay199.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage Cause nothing lasts forever...!2031"
+	"OnTrigger" "ex5_music_textDisplay203.51"
+	"OnTrigger" "ex5_music_textAddOutputcolor 255 0 002311"
+	"OnTrigger" "ex5_music_textAddOutputmessage How do I get home?2311"
+	"OnTrigger" "ex5_music_textDisplay231.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage Everything revolves around me2341"
+	"OnTrigger" "ex5_music_textDisplay234.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage If I can't find myself?2361"
+	"OnTrigger" "ex5_music_textDisplay236.51"
+	"OnTrigger" "ex5_music_textAddOutputmessage If so Its so completely fake2401"
+	"OnTrigger" "ex5_music_textDisplay240.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage How do I get home?2421"
+	"OnTrigger" "ex5_music_textDisplay242.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage Everything revolves around me2451"
+	"OnTrigger" "ex5_music_textDisplay245.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage If even you can't help?2471"
+	"OnTrigger" "ex5_music_textDisplay247.11"
+	"OnTrigger" "ex5_music_textAddOutputmessage Dark nights on my soul2511"
+	"OnTrigger" "ex5_music_textDisplay251.51"
 }

--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -1,3 +1,7 @@
+; - - - - - - - - - - - - - - - - - - - - - - - 
+; 				  ze Last Man Standing
+; 				 Map version p3 (CS:GO)
+; - - - - - - - - - - - - - - - - - - - - - - -
 ;start at extreme
 modify:
 {
@@ -14,49 +18,26 @@ modify:
 	}
 }
 
-;fix early triggering nuke on stage 4
-modify:
-{
-	match:
-	{
-		"classname" "trigger_once"
-		"targetname" "stage_4_part_5_trigger"
-	}
-	insert:
-	{
-		"OnStartTouch" "stage_4_trigger_end,Enable,0,-1"
-	}
-}
+; - - - - - - - - - - - - - - - - - - - - - - -
+; Random authors/Hichatu fixes
+; - - - - - - - - - - - - - - - - - - - - - - -
 
-modify:
-{
-	match:
-	{
-		"classname" "trigger_once"
-		"targetname" "stage_4_trigger_end"
-	}
-	replace:
-	{
-		"StartDisabled" "1"
-	}
-}
-
-;Fix possible skip with tank on Stage4
+;Fix possible skip with tank on Stage 4
 add:
 {
-	"classname" "func_brush"
-	"origin" "3640 972 3467"
-	"model" "*142"
-	"rendermode" "10"
+    "classname" "func_brush"
+    "origin" "3640 972 3467"
+    "model" "*142"
+    "rendermode" "10"
 }
-
 ;fix stage1 skip after bridge
+;stage_1_wall_way2
 add:
 {
-	"classname" "func_brush"
-	"origin" "5176 -9963.06 -12740"
-	"model" "*675"
-	"rendermode" "10"
+    "classname" "func_brush"
+    "origin" "5176 -9963.06 -12740"
+    "model" "*675"
+    "rendermode" "10"
 }
 
 ;fix portal gun repeatedly teleporting bug
@@ -73,7 +54,6 @@ modify:
 		"OnUser2" "Weapon_PortalGun_Portal_1_TriggerClearParent1.5-1"
 	}
 }
-
 modify:
 {
 	match:
@@ -87,7 +67,6 @@ modify:
 		"OnUser2" "Weapon_PortalGun_Portal_2_TriggerClearParent1.5-1"
 	}
 }
-
 add:
 {
 	"model" "*86"
@@ -99,10 +78,12 @@ add:
 	"origin" "-1088 13304 -8516"
 	"classname" "trigger_multiple"
 	"filtername" "Weapon_PortalGun_FixFilter_2"
-	"OnStartTouch" "!activatorAddContextplayer_portal_1:10-1"
-	"OnStartTouch" "Weapon_PortalGun_EnterPortalSoundFireUser10-1"
+	connections
+	{
+		"OnStartTouch" "!activatorAddContextplayer_portal_1:10-1"
+		"OnStartTouch" "Weapon_PortalGun_EnterPortalSoundFireUser10-1"
+	}
 }
-
 add:
 {
 	"model" "*89"
@@ -114,10 +95,12 @@ add:
 	"origin" "-1088 13352 -8516"
 	"classname" "trigger_multiple"
 	"filtername" "Weapon_PortalGun_FixFilter_1"
-	"OnStartTouch" "!activatorAddContextplayer_portal_2:10-1"
-	"OnStartTouch" "Weapon_PortalGun_EnterPortalSoundFireUser10-1"
+	connections
+	{
+		"OnStartTouch" "!activatorAddContextplayer_portal_2:10-1"
+		"OnStartTouch" "Weapon_PortalGun_EnterPortalSoundFireUser10-1"
+	}
 }
-
 add:
 {
 	"targetname" "Weapon_PortalGun_FixFilter_1_2"
@@ -125,7 +108,6 @@ add:
 	"Negated" "0"
 	"classname" "filter_activator_context"
 }
-
 add:
 {
 	"targetname" "Weapon_PortalGun_FixFilter_2_2"
@@ -133,7 +115,6 @@ add:
 	"Negated" "0"
 	"classname" "filter_activator_context"
 }
-
 modify:
 {
 	match:
@@ -152,7 +133,6 @@ modify:
 		"filtername" "Weapon_PortalGun_FixFilter_1_2"
 	}
 }
-
 modify:
 {
 	match:
@@ -172,6 +152,37 @@ modify:
 	}
 }
 
+;fix early triggering nuke on stage 4
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "stage_4_part_5_trigger"
+	}
+	insert:
+	{
+		"OnStartTouch" "stage_4_trigger_end,Enable,20,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "stage_4_trigger_end"
+	}
+	replace:
+	{
+		"StartDisabled" "1"
+	}
+}
+
+
+; - - - - - - - - - - - - - - - - - - - - - - -
+; 	Changes done by iszaar
+; - - - - - - - - - - - - - - - - - - - - - - -
 ; open doors to prevent ZMs being locked out on Solo ending
 modify: 
 {
@@ -184,6 +195,23 @@ modify:
     {
         "OnTrigger" "stage_5_top_door_*Open01"
     }
+}
+;make ultralisk come faster on event hes not killed
+modify: 
+{
+    match:
+    {
+		"targetname" "stage5_things"
+		"classname" "point_template"
+    }
+    delete:
+    {
+        "OnEntitySpawned" "stage_5_lower_ultraliskTrigger120-1"
+    }
+	insert:
+	{
+		"OnEntitySpawned" "stage_5_lower_ultraliskTrigger100-1"
+	}
 }
 ; Fix stage 2 last vent entrance being breakable early.
 modify:
@@ -265,7 +293,6 @@ add:
 add:
 {
 	"targetname" "team_filter_stage2water_human"
-	"Negated" "Allow entities that match criteria"
 	"filterteam" "3"
 	"classname" "filter_activator_team"
 }
@@ -337,7 +364,7 @@ modify:
 }
 
 ; Stage 4 Nuke breaking will now not cause map to be in limbo (avoid delay) hopefully too incase it for some reason breaks
-; This will also fix the issues resulting of stage 4 being extremely open which let predator, freezer and jumper to trigger the round end button since whoever touched this before decided that was a good idea
+; This will also fix the issues resulting of stage 4 being extremely open which let predator, freezer and jumper to trigger the round end button since whoever touched this map before decided that was a good idea
 modify:
 {
 	match:
@@ -487,7 +514,11 @@ modify:
 		"origin" "4848 -10200 -7248"
 	}
 }
-; Rest of the changes are made by "Berke" "STEAM_1:0:95142811", version 1.
+
+
+; - - - - - - - - - - - - - - - - - - - - - - -
+;	Berke fixes
+; - - - - - - - - - - - - - - - - - - - - - - -
 
 ; Fix spawn trigger not resetting players.
 filter:
@@ -523,7 +554,6 @@ modify:
 		"OnPass" "!activator,AddOutput,gravity 1,,-1"
 		"OnPass" "!activator,AddOutput,OnUser3 !self:AddOutput:health 1200::1,.01,-1"
 		"OnPass" "!activator,AddOutput,rendermode 0,,-1"
-		"OnPass" "!activator,AddOutput,gravity 1,,-1"
 		"OnPass" "!activator,AddOutput,renderfx 0,,-1"
 		"OnPass" "!activator,SetDamageFilter,,,-1"
 		"OnPass" "!activator,ClearContext,,,-1"
@@ -565,7 +595,7 @@ modify:
 	}
 }
 
-; Add a prop to get out of a stuck spot near tank spawn on extreme stage 1.
+; Add props to get out of a stuck spot near tank spawn on extreme stage 1.
 add:
 {
 	"classname" "prop_dynamic"
@@ -595,7 +625,7 @@ add:
 	"solid" "6"
 }
 
-; Add viewcontrol template related outputs, filter stage 1 "Juggernaut" trigger to humans and reset targetnames.
+; Add viewcontrol template related outputs, filter stage 1 "Juggernaut" trigger to humans, reset targetnames and prevent viewmodel from being glitched out.
 modify:
 {
 	match:
@@ -603,12 +633,9 @@ modify:
 		"classname" "logic_relay"
 		"targetname" "Auto"
 	}
-	replace:
-	{
-		"spawnflags" "1"
-	}
 	insert:
 	{
+		"OnSpawn" "!self,Kill,,.01,1"
 		"OnSpawn" "map1viewcontrolpreservedtemplate1,ForceSpawn,,.01,1"
 		"OnSpawn" "map1viewcontroltemplate1,Kill,,.01,1"
 		"OnSpawn" "worldspawn_brush_target,FireUser2,,,1"
@@ -616,6 +643,10 @@ modify:
 		"OnSpawn" "stage_x_crane_crateRunScriptCodefunction InputUse() { if (activator.GetTeam() == 3) return true; return false; }1"
 		"OnSpawn" "game_playerdieRunScriptCode_ <- delegate { function _get(strKey) { return strKey; } } : {};1"
 		"OnSpawn" "player,AddOutput,targetname ,,1"
+		"OnSpawn" "playerRunScriptCodeif (self.GetName() == _.zombie_boss || self.GetName() == _.human_mech) EntFireByHandle(caller, _.FireUser1, ' '.tochar(), 0, self, null);1"
+		"OnSpawn" "!selfRunScriptCode_ <- delegate { function _get(strKey) { return strKey; } } : {};1"
+		"OnUser1" "Map_End_Camera,RemovePlayer,,,1"
+		"OnUser1" "Map_End_Camera,AddPlayer,,,1"
 	}
 }
 
@@ -646,6 +677,32 @@ modify:
 	}
 }
 
+; Optional: Prevent the "Portal Gun" skip.
+;modify:
+;{
+;	match:
+;	{
+;		"classname" "func_button"
+;		"targetname" "Weapon_PortalGun_UI"
+;	}
+;	replace:
+;	{
+;		"origin" "-1004 13248 -8512"
+;	}
+;}
+
+;modify:
+;{
+;	match:
+;	{
+;		"classname" "env_entity_maker"
+; 		"targetname" "Weapon_PortalGun_Projectile_Spawner"
+;	}
+;	replace:
+;	{
+;		"origin" "-1088 13248 -8520"
+;	}
+;}
 
 ; Fix stage 2 last vent fall breaking despite second room being "Mutator Test".
 modify:
@@ -720,10 +777,10 @@ modify:
 	}
 	insert:
 	{
+		"OnDamaged" "!self,Kill,,,1"
 		"OnDamaged" "Global_GameText_AnnouncementRunScriptCodesetMessage(33);1"
 	}
 }
-
 
 ; Fix the new truck model used in stage 5 not covering the side like in the original.
 modify:
@@ -831,8 +888,8 @@ add:
 	"model" "*584"
 	"spawnflags" "1"
 	"filtername" "team_filter_zombies"
-	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
-	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,.01,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,.01,-1"
 }
 
 add:
@@ -844,8 +901,8 @@ add:
 	"model" "*584"
 	"spawnflags" "1"
 	"filtername" "team_filter_zombies"
-	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
-	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,.01,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,.01,-1"
 }
 
 add:
@@ -857,8 +914,8 @@ add:
 	"model" "*584"
 	"spawnflags" "1"
 	"filtername" "team_filter_zombies"
-	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
-	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,.01,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,.01,-1"
 }
 
 add:
@@ -870,8 +927,8 @@ add:
 	"model" "*584"
 	"spawnflags" "1"
 	"filtername" "team_filter_zombies"
-	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
-	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,.01,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,.01,-1"
 }
 
 ; Stage 2
@@ -884,8 +941,8 @@ add:
 	"model" "*584"
 	"spawnflags" "1"
 	"filtername" "team_filter_zombies"
-	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
-	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,.01,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,.01,-1"
 }
 
 add:
@@ -897,8 +954,8 @@ add:
 	"model" "*584"
 	"spawnflags" "1"
 	"filtername" "team_filter_zombies"
-	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
-	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,.01,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,.01,-1"
 }
 
 add:
@@ -910,8 +967,8 @@ add:
 	"model" "*584"
 	"spawnflags" "1"
 	"filtername" "team_filter_zombies"
-	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
-	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,.01,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,.01,-1"
 }
 
 ; Stage 3
@@ -923,8 +980,8 @@ add:
 	"model" "*584"
 	"spawnflags" "1"
 	"filtername" "team_filter_zombies"
-	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
-	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,.01,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,.01,-1"
 }
 
 add:
@@ -936,8 +993,8 @@ add:
 	"model" "*584"
 	"spawnflags" "1"
 	"filtername" "team_filter_zombies"
-	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
-	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,.01,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,.01,-1"
 }
 
 add:
@@ -948,8 +1005,8 @@ add:
 	"model" "*584"
 	"spawnflags" "1"
 	"filtername" "team_filter_zombies"
-	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
-	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,.01,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,.01,-1"
 }
 
 ; Stage 4
@@ -962,8 +1019,8 @@ add:
 	"model" "*584"
 	"spawnflags" "1"
 	"filtername" "team_filter_zombies"
-	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
-	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,.01,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,.01,-1"
 }
 
 add:
@@ -975,8 +1032,8 @@ add:
 	"model" "*584"
 	"spawnflags" "1"
 	"filtername" "team_filter_zombies"
-	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
-	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,.01,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,.01,-1"
 }
 
 add:
@@ -987,8 +1044,8 @@ add:
 	"model" "*584"
 	"spawnflags" "1"
 	"filtername" "team_filter_zombies"
-	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
-	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,.01,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,.01,-1"
 }
 
 add:
@@ -999,8 +1056,8 @@ add:
 	"model" "*584"
 	"spawnflags" "1"
 	"filtername" "team_filter_zombies"
-	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,,-1"
-	"OnEndTouch" "!activator,SetDamageFilter,,,-1"
+	"OnStartTouch" "!activator,SetDamageFilter,map1mainnukefilter1,.01,-1"
+	"OnEndTouch" "!activator,SetDamageFilter,,.01,-1"
 }
 
 ; Implement the unused zombie teleport in extreme stage 1.
@@ -1127,441 +1184,17 @@ modify:
 	}
 }
 
-; BELOW IS OPTIONAL
-; JUST ADDS SONG LYRICS
-; Song lyrics ex4&ex5 done by koen (https:;github.com/notkoen)
-; ex3 done by iszaar
+; Make trigger of extreme stage 3 third test room bigger to prevent zombies avoiding it by staying just next to the room.
 modify:
 {
 	match:
 	{
-		"targetname" "Music_Selector_Ex"
-		"classname" "logic_case"
+		"classname" "trigger_multiple"
+		"targetname" "stage_3_tests_main_5"
 	}
-	insert:
+	replace:
 	{
-		"OnCase11" "stage_10_start_relayTrigger0.21"
-		"OnCase11" "stage_10_top_1_relayEnable0.21"
+		"model" "*279"
+		"origin" "5025.78 5771.83 968"
 	}
-}
-
-modify:
-{
-	match:
-	{
-		"targetname" "stage_5_button_filter"
-		"classname" "filter_activator_team"
-	}
-	insert:
-	{
-		"OnPass" "stage_10_start_relayCancelPending6.201"
-		"OnPass" "stage_10_top_1_relayTrigger11.11"
-		"OnPass" "ex5_music_textAddOutputmessage  6.001"
-		"OnPass" "ex5_music_textDisplay6.101"
-		"OnPass" "ex5_music_text2AddOutputmessage  6.001"
-		"OnPass" "ex5_music_text2Display6.101"
-		"OnPass" "stage_10_start_relaykill7.101"
-	}
-}
-
-modify:
-{
-	match:
-	{
-		"targetname" "stage_5_top_relay_core_working"
-		"classname" "logic_relay"
-	}
-	insert:
-	{
-		"OnTrigger" "ex5_music_textAddOutputmessage  1.001"
-		"OnTrigger" "ex5_music_textDisplay1.101"
-		"OnTrigger" "stage_10_top_1_relayCancelPending7.00-1"
-		"OnTrigger" "stage_10_top_1_relaykill7.10-1"
-	}
-}
-
-modify:
-{
-	match:
-	{
-		"targetname" "stage_5_core_destroyed"
-		"classname" "logic_relay"
-	}
-	insert:
-	{
-		"OnTrigger" "ex5_music_textAddOutputmessage  1.001"
-		"OnTrigger" "ex5_music_textDisplay1.101"
-		"OnTrigger" "stage_10_top_1_relayCancelPending7.00-1"
-		"OnTrigger" "stage_10_top_1_relaykill7.10-1"
-	}
-}
-modify:
-{
-	match:
-	{
-		"hammerid" "9345860"
-	}
-	insert:
-	{
-		"OnCase07" "music_master_ambient_ex3_relayEnable0.11"
-		"OnCase07" "music_master_ambient_ex3_relayTrigger0.21"
-		"OnCase10" "music_master_ambient_ex4_relayEnable0.11"
-		"OnCase10" "music_master_ambient_ex4_relayTrigger0.21"
-	}
-}
-add:
-{
-	"classname" "game_text"
-	"origin" "-5701.34 -723.98 -15159.97"
-	"y" "0.5"
-	"x" "0.02"
-	"targetname" "ex5_music_text"
-	"spawnflags" "1"
-	"message" ""
-	"holdtime" "66"
-	"fxtime" "1.5"
-	"fadeout" "0.1"
-	"fadein" "0.3"
-	"effect" "0"
-	"color2" "255 255 255"
-	"color" "255 255 255"
-	"channel" "4"
-}
-add:
-{
-	"origin" "-5701.34 -723.98 -15159.98"
-	"targetname" "stage_10_start_relay"
-	"StartDisabled" "0"
-	"spawnflags" "0"
-	"classname" "logic_relay"
-	"OnTrigger" "ex5_music_textAddOutputmessage Madeon - Finale (Netsky Remix)20.001"
-	"OnTrigger" "ex5_music_textDisplay20.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Your last chance23.001"
-	"OnTrigger" "ex5_music_textDisplay23.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Last Summer26.001"
-	"OnTrigger" "ex5_music_textDisplay26.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Your last dance29.001"
-	"OnTrigger" "ex5_music_textDisplay29.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage To beat to your own drummer31.001"
-	"OnTrigger" "ex5_music_textDisplay31.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Go out fighting35.001"
-	"OnTrigger" "ex5_music_textDisplay35.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Go out young37.001"
-	"OnTrigger" "ex5_music_textDisplay37.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage A flash of lightning40.001"
-	"OnTrigger" "ex5_music_textDisplay40.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Eclipse the sun43.001"
-	"OnTrigger" "ex5_music_textDisplay43.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Your last chance45.001"
-	"OnTrigger" "ex5_music_textDisplay45.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Last Summer49.001"
-	"OnTrigger" "ex5_music_textDisplay49.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Your last dance51.001"
-	"OnTrigger" "ex5_music_textDisplay51.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage To beat to your own drummer54.001"
-	"OnTrigger" "ex5_music_textDisplay54.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Go out fighting57.001"
-	"OnTrigger" "ex5_music_textDisplay57.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Go out young60.001"
-	"OnTrigger" "ex5_music_textDisplay60.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage A flash of lightning62.001"
-	"OnTrigger" "ex5_music_textDisplay62.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Eclipse the sun65.001"
-	"OnTrigger" "ex5_music_textDisplay65.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Brace yourself brace yourself67.001"
-	"OnTrigger" "ex5_music_textDisplay67.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Brace yourself for the grand finale87.001"
-	"OnTrigger" "ex5_music_textDisplay87.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Whoa oh~~~91.001"
-	"OnTrigger" "ex5_music_textDisplay91.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Brace yourself for the grand finale131.001"
-	"OnTrigger" "ex5_music_textDisplay131.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Your last chance156.001"
-	"OnTrigger" "ex5_music_textDisplay156.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Last Summer159.001"
-	"OnTrigger" "ex5_music_textDisplay159.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Your last dance162.001"
-	"OnTrigger" "ex5_music_textDisplay162.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage To beat to your own drummer164.001"
-	"OnTrigger" "ex5_music_textDisplay164.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Go out fighting168.001"
-	"OnTrigger" "ex5_music_textDisplay168.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Go out young171.001"
-	"OnTrigger" "ex5_music_textDisplay171.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage A flash of lightning173.001"
-	"OnTrigger" "ex5_music_textDisplay173.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Eclipse the sun176.001"
-	"OnTrigger" "ex5_music_textDisplay176.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Brace yourself brace yourself178.001"
-	"OnTrigger" "ex5_music_textDisplay178.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Brace yourself for the grand finale198.001"
-	"OnTrigger" "ex5_music_textDisplay198.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Whoa oh~~~202.001"
-	"OnTrigger" "ex5_music_textDisplay202.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Brace yourself for the grand finale242.001"
-	"OnTrigger" "ex5_music_textDisplay242.101"
-}
-add:
-{
-	"origin" "-5701.34 -723.98 -15159.98"
-	"targetname" "stage_10_top_1_relay"
-	"StartDisabled" "1"
-	"spawnflags" "0"
-	"classname" "logic_relay"
-	"OnTrigger" "ex5_music_textAddOutputmessage Pendulum - Witchcraft Vs Watercolour0.001"
-	"OnTrigger" "ex5_music_textDisplay0.101"
-	"OnTrigger" "ex5_music_textAddOutputcolor 255 0 00.201"
-	"OnTrigger" "ex5_music_textAddOutputmessage It's in your eyes a color fade-out6.001"
-	"OnTrigger" "ex5_music_textDisplay6.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Looks like a new transition12.001"
-	"OnTrigger" "ex5_music_textDisplay12.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Is starting up and shaking your ground17.001"
-	"OnTrigger" "ex5_music_textDisplay17.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Turning your head to see a new day calling22.001"
-	"OnTrigger" "ex5_music_textDisplay22.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Does it feel like a head to lean on29.001"
-	"OnTrigger" "ex5_music_textDisplay29.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage A snapshot from where you were born35.001"
-	"OnTrigger" "ex5_music_textDisplay35.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage I'm looking for your hand in the rough40.001"
-	"OnTrigger" "ex5_music_textDisplay40.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage You're caught in the wire44.001"
-	"OnTrigger" "ex5_music_textDisplay44.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Well I'll lift you out47.001"
-	"OnTrigger" "ex5_music_textDisplay47.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage When I'm falling down51.001"
-	"OnTrigger" "ex5_music_textDisplay51.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Will you pick me up again56.001"
-	"OnTrigger" "ex5_music_textDisplay56.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage When I'm too far gone62.001"
-	"OnTrigger" "ex5_music_textDisplay62.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Dead in the eyes of my friends67.001"
-	"OnTrigger" "ex5_music_textDisplay67.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Will you take me out of here73.001"
-	"OnTrigger" "ex5_music_textDisplay73.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage When I'm staring down the barrel75.001"
-	"OnTrigger" "ex5_music_textDisplay75.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage When I'm blinded by the lights78.001"
-	"OnTrigger" "ex5_music_textDisplay78.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage When I cannot see your face81.001"
-	"OnTrigger" "ex5_music_textDisplay81.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Take me out of here84.001"
-	"OnTrigger" "ex5_music_textDisplay84.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Take me out of here87.001"
-	"OnTrigger" "ex5_music_textDisplay87.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Take me out of here90.001"
-	"OnTrigger" "ex5_music_textDisplay90.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Take me out of here93.001"
-	"OnTrigger" "ex5_music_textDisplay93.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Leaning on the action94.001"
-	"OnTrigger" "ex5_music_textDisplay94.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Caught in a cellphone's rays97.001"
-	"OnTrigger" "ex5_music_textDisplay97.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Bleeding on the sofa99.001"
-	"OnTrigger" "ex5_music_textDisplay99.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Staring at the wayside102.001"
-	"OnTrigger" "ex5_music_textDisplay102.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage He's coming and she knows it104.001"
-	"OnTrigger" "ex5_music_textDisplay104.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Even if she knows why108.001"
-	"OnTrigger" "ex5_music_textDisplay108.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Footsteps in the hallway110.001"
-	"OnTrigger" "ex5_music_textDisplay110.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Girl you haven't got time113.001"
-	"OnTrigger" "ex5_music_textDisplay113.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage All I believe115.001"
-	"OnTrigger" "ex5_music_textDisplay115.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage And all I've known118.001"
-	"OnTrigger" "ex5_music_textDisplay118.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Are being taken from me120.001"
-	"OnTrigger" "ex5_music_textDisplay120.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Can't get home124.001"
-	"OnTrigger" "ex5_music_textDisplay124.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Led to a world126.001"
-	"OnTrigger" "ex5_music_textDisplay126.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Where worlds collide129.001"
-	"OnTrigger" "ex5_music_textDisplay129.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Let the fear collapse bring no surprise132.001"
-	"OnTrigger" "ex5_music_textDisplay132.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Take me out of here137.001"
-	"OnTrigger" "ex5_music_textDisplay137.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Feed the fire break your vision159.001"
-	"OnTrigger" "ex5_music_textDisplay159.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Throw your fists up come on with me159.001"
-	"OnTrigger" "ex5_music_textDisplay159.101"
-}
-
-add:
-{
-	"origin" "-5701.34 -723.98 -15159.98"
-	"targetname" "music_master_ambient_ex4_relay"
-	"StartDisabled" "1"
-	"spawnflags" "0"
-	"classname" "logic_relay"	
-	"OnTrigger" "ex5_music_textAddOutputmessage Linkin Park - The Catalyst (Pendulum Remix)0.001"
-	"OnTrigger" "ex5_music_textDisplay0.101"
-	"OnTrigger" "ex5_music_textAddOutputcolor 255 255 2550.201"
-	"OnTrigger" "ex5_music_textAddOutputmessage Like memories in cold decay2.501"
-	"OnTrigger" "ex5_music_textDisplay2.601"
-	"OnTrigger" "ex5_music_textAddOutputmessage Transmissions echoing away5.001"
-	"OnTrigger" "ex5_music_textDisplay5.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Far from the world of you and I7.501"
-	"OnTrigger" "ex5_music_textDisplay7.601"
-	"OnTrigger" "ex5_music_textAddOutputmessage Where oceans bleed into the sky11.001"
-	"OnTrigger" "ex5_music_textDisplay11.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage God save us everyone41.001"
-	"OnTrigger" "ex5_music_textDisplay41.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Will we burn inside the fires of a thousand suns43.001"
-	"OnTrigger" "ex5_music_textDisplay43.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage For the sins of our hands46.001"
-	"OnTrigger" "ex5_music_textDisplay46.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage The sins of our tongue47.001"
-	"OnTrigger" "ex5_music_textDisplay47.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage The sins of our fathers48.001"
-	"OnTrigger" "ex5_music_textDisplay48.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage The sins of our young49.001"
-	"OnTrigger" "ex5_music_textDisplay49.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage No51.001"
-	"OnTrigger" "ex5_music_textDisplay51.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage God save us everyone52.001"
-	"OnTrigger" "ex5_music_textDisplay52.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Will we burn inside the fires of a thousand suns54.001"
-	"OnTrigger" "ex5_music_textDisplay54.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage For the sins of our hands57.001"
-	"OnTrigger" "ex5_music_textDisplay57.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage The sins of our tongue58.001"
-	"OnTrigger" "ex5_music_textDisplay58.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage The sins of our fathers59.001"
-	"OnTrigger" "ex5_music_textDisplay59.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage The sins of our young61.001"
-	"OnTrigger" "ex5_music_textDisplay61.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage No63.001"
-	"OnTrigger" "ex5_music_textDisplay63.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage And when I close my eyes tonight64.001"
-	"OnTrigger" "ex5_music_textDisplay64.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage To symphonies of blinding light66.001"
-	"OnTrigger" "ex5_music_textDisplay66.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Like memories in cold decay74.501"
-	"OnTrigger" "ex5_music_textDisplay74.601"
-	"OnTrigger" "ex5_music_textAddOutputmessage Transmissions echoing away77.001"
-	"OnTrigger" "ex5_music_textDisplay77.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Far from the world of you and I80.001"
-	"OnTrigger" "ex5_music_textDisplay80.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Where oceans bleed into the sky83.001"
-	"OnTrigger" "ex5_music_textDisplay83.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Like memories in cold decay107.001"
-	"OnTrigger" "ex5_music_textDisplay107.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Transmissions echoing away110.001"
-	"OnTrigger" "ex5_music_textDisplay110.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Far from the world of you and I113.001"
-	"OnTrigger" "ex5_music_textDisplay113.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Where oceans bleed into the sky116.001"
-	"OnTrigger" "ex5_music_textDisplay116.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Lift me up130.001"
-	"OnTrigger" "ex5_music_textDisplay130.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage Let me go133.501"
-	"OnTrigger" "ex5_music_textDisplay133.601"
-	"OnTrigger" "ex5_music_textAddOutputmessage Lift me up! Let me go!136.501"
-	"OnTrigger" "ex5_music_textDisplay136.601"
-}
-
-add:
-{
-	"origin" "-5701.34 -723.98 -15159.98"
-	"targetname" "music_master_ambient_ex3_relay"
-	"StartDisabled" "1"
-	"spawnflags" "0"
-	"classname" "logic_relay"
-	"OnTrigger" "ex5_music_textAddOutputcolor 255 55 001"
-	"OnTrigger" "ex5_music_textAddOutputholdtime 1001"
-	"OnTrigger" "ex5_music_textAddOutputmessage Pendulum feat. In Flames - Self vs Self0.001"
-	"OnTrigger" "ex5_music_textDisplay0.101"
-	"OnTrigger" "ex5_music_textAddOutputmessage If I struggle a lifetime2.661"
-	"OnTrigger" "ex5_music_textDisplay661"
-	"OnTrigger" "ex5_music_textAddOutputmessage What would my body be?691"
-	"OnTrigger" "ex5_music_textDisplay69.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage An empty shell721"
-	"OnTrigger" "ex5_music_textDisplay72.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage On which a demon fed741"
-	"OnTrigger" "ex5_music_textDisplay74.51"
-	"OnTrigger" "ex5_music_textAddOutputmessage Could be a heavy burden771"
-	"OnTrigger" "ex5_music_textDisplay77.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage To stay true to your words791"
-	"OnTrigger" "ex5_music_textDisplay79.51"
-	"OnTrigger" "ex5_music_textAddOutputmessage Speak up831"
-	"OnTrigger" "ex5_music_textDisplay83.51"
-	"OnTrigger" "ex5_music_textAddOutputmessage I wanna silence everything851"
-	"OnTrigger" "ex5_music_textDisplay85.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage If I got no plan891"
-	"OnTrigger" "ex5_music_textDisplay89.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage Doesn't mean that I get what I want for free941"
-	"OnTrigger" "ex5_music_textDisplay94.51"
-	"OnTrigger" "ex5_music_textAddOutputmessage If I got no meaning1001"
-	"OnTrigger" "ex5_music_textDisplay100.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage Would you force me to a place where I make sense1051"
-	"OnTrigger" "ex5_music_textDisplay105.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage Cause nothing lasts forever...!1101"
-	"OnTrigger" "ex5_music_textDisplay110.11"
-	"OnTrigger" "ex5_music_textAddOutputcolor 255 0 01151"
-	"OnTrigger" "ex5_music_textAddOutputmessage How do I get home?1151"
-	"OnTrigger" "ex5_music_textDisplay115.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage Everything revolves around me1181"
-	"OnTrigger" "ex5_music_textDisplay118.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage If I can't find myself?1201"
-	"OnTrigger" "ex5_music_textDisplay120.51"
-	"OnTrigger" "ex5_music_textAddOutputmessage If so Its so completely fake1231"
-	"OnTrigger" "ex5_music_textDisplay123.51"
-	"OnTrigger" "ex5_music_textAddOutputmessage How do I get home?1261"
-	"OnTrigger" "ex5_music_textDisplay126.51"
-	"OnTrigger" "ex5_music_textAddOutputmessage Everything revolves around me1291"
-	"OnTrigger" "ex5_music_textDisplay129.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage If even you can't help?1311"
-	"OnTrigger" "ex5_music_textDisplay131.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage Dark nights on my soul1361"
-	"OnTrigger" "ex5_music_textDisplay136.11"
-	"OnTrigger" "ex5_music_textAddOutputcolor 255 55 01601"
-	"OnTrigger" "ex5_music_textAddOutputmessage I deny failure1611"
-	"OnTrigger" "ex5_music_textDisplay161.51"
-	"OnTrigger" "ex5_music_textAddOutputmessage I ignite1631"
-	"OnTrigger" "ex5_music_textDisplay163.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage Woe is on my misery1651"
-	"OnTrigger" "ex5_music_textDisplay165.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage She wins all their eyes1681"
-	"OnTrigger" "ex5_music_textDisplay168.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage Realise what defies our fate1701"
-	"OnTrigger" "ex5_music_textDisplay170.51"
-	"OnTrigger" "ex5_music_textAddOutputmessage This is not me this is me1731"
-	"OnTrigger" "ex5_music_textDisplay173.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage So if I struggle a lifetime1761"
-	"OnTrigger" "ex5_music_textDisplay176.51"
-	"OnTrigger" "ex5_music_textAddOutputmessage What good would that do?1791"
-	"OnTrigger" "ex5_music_textDisplay179.11"
-	"OnTrigger" "ex5_music_textAddOutputcolor 255 0 01821"
-	"OnTrigger" "ex5_music_textAddOutputmessage If I got a plan1821"
-	"OnTrigger" "ex5_music_textDisplay182.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage Doesn't have to stop the feeling inside1881"
-	"OnTrigger" "ex5_music_textDisplay188.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage If I do make sense1931"
-	"OnTrigger" "ex5_music_textDisplay193.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage Would you drag me down?1991"
-	"OnTrigger" "ex5_music_textDisplay199.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage Cause nothing lasts forever...!2031"
-	"OnTrigger" "ex5_music_textDisplay203.51"
-	"OnTrigger" "ex5_music_textAddOutputcolor 255 0 002311"
-	"OnTrigger" "ex5_music_textAddOutputmessage How do I get home?2311"
-	"OnTrigger" "ex5_music_textDisplay231.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage Everything revolves around me2341"
-	"OnTrigger" "ex5_music_textDisplay234.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage If I can't find myself?2361"
-	"OnTrigger" "ex5_music_textDisplay236.51"
-	"OnTrigger" "ex5_music_textAddOutputmessage If so Its so completely fake2401"
-	"OnTrigger" "ex5_music_textDisplay240.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage How do I get home?2421"
-	"OnTrigger" "ex5_music_textDisplay242.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage Everything revolves around me2451"
-	"OnTrigger" "ex5_music_textDisplay245.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage If even you can't help?2471"
-	"OnTrigger" "ex5_music_textDisplay247.11"
-	"OnTrigger" "ex5_music_textAddOutputmessage Dark nights on my soul2511"
-	"OnTrigger" "ex5_music_textDisplay251.51"
 }


### PR DESCRIPTION
Stage 1Ex: Adjusted Vortigaunt to avoid it blocking tank
Stage 2: Adjusted Tank to v6 location
Stage 2: Fixed Water skip on last part
Stage 2: Portal is now more predictable
Stage 2: Fix early triggering vent (big problem)
Stage 3: Added filtername to nuke immunizer which should prevent round delays (if no admins)
Stage 4: Applied proper ending for stage 4 nuke break as it was supposed to in Hannibals notes.
Stage 4: Heli wont now go into skybox (porter issue)
Stage 5: Added anti delay
Stage 5: The Item Truck has now blockdmg to discourage blocking it
Stage 5: Fixes some boost due to freezer and minigun + core hit push making zms fly up
Stage 5 OPTIONAL: Make zms reset speed to fix an exploit for zms where they would get more speed than the last man in blue ending

ZM Items: Antlion Nerfed to 0.55 instead of 1.15 for Digging underground attack

Optional: Added song lyrics for Stage 3 Bossfight, Stage 4 Ending and Stage 5 Start & Core Defense