### PR TITLE
Update escapetheworld stripper

### DIFF
--- a/stripper/ze_escapetheworld_a33.cfg
+++ b/stripper/ze_escapetheworld_a33.cfg
@@ -1,3 +1,21 @@
+;Change fade timing for stage 3 ending
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stg3_final_path3"
+	}
+	delete:
+	{
+		"OnPass" "stg3_fade_endFade131"
+	}
+	insert:
+	{
+		"OnPass" "stg3_fade_endFade15.81"
+	}
+}
+
 ;Fix glitch to skip/bypass the boss
 add:
 {

--- a/stripper/ze_escapetheworld_a33.cfg
+++ b/stripper/ze_escapetheworld_a33.cfg
@@ -12,7 +12,7 @@ modify:
 	}
 	insert:
 	{
-		"OnPass" "stg3_fade_endFade15.81"
+		"OnPass" "stg3_fade_endFade15.51"
 	}
 }
 


### PR DESCRIPTION
The stage 3 gear-dodging ending has a fade that makes it impossible to see and dodge/react to the final few gears, essentially making it near impossible and RNG-reliant. The aim of this PR is to delay the fade slightly so that it matches both the teleport and the color correction being disabled while making it possible to see the ending.

[Video](https://youtu.be/qeN0n22ebuc) for context. You can see how the screen fade occurs before the gears finish, making it near impossible to win unless you get lucky and just so happen to be in the right spot.