### PR TITLE
Fix westersand v8 zombie heal

### DIFF
--- a/stripper/ze_ffxii_westersand_v8zeta1_b5k.cfg
+++ b/stripper/ze_ffxii_westersand_v8zeta1_b5k.cfg
@@ -24,6 +24,10 @@ add:
 	"spawnflags" "2"
 	"OnTrigger" "!activatorRunScriptCodeforeach(v,_ in {SetHealth=0}){EntFireByHandle(self,v,(self.GetHealth()-1).tostring(),0.0,null,null);}0-1"
 	"OnTrigger" "!activatorRunScriptCodeforeach(v,_ in {SetHealth=0}){EntFireByHandle(self,v,(self.GetHealth()+1).tostring(),0.0,null,null);}0.1-1"
+	"OnUser1" "!activatorAddContextFire_Trigger_Ignore:10-1"
+	"OnUser1" "!activatorRemoveContextFire_Trigger_Ignore13-1"
+	"OnUser2" "!activatorAddContextElectro_Trigger_Ignore:10-1"
+	"OnUser2" "!activatorRemoveContextElectro_Trigger_Ignore20-1"
 }
 
 modify:
@@ -35,8 +39,17 @@ modify:
 	}
 	insert:
 	{
-		"OnHurtPlayer" "Slowdown_PatchTrigger0-1"
+		"OnHurtPlayer" "Filter_Electro_Trigger_IgnoreTestActivator0-1"
 	}
+}
+
+add:
+{
+	"targetname" "Filter_Electro_Trigger_Ignore"
+	"Negated" "1"
+	"ResponseContext" "Electro_Trigger_Ignore"
+	"classname" "filter_activator_context"
+	"OnPass" "Slowdown_PatchTrigger0-1"
 }
 
 modify:
@@ -48,7 +61,30 @@ modify:
 	}
 	insert:
 	{
-		"OnHurtPlayer" "Slowdown_PatchTrigger0-1"
+		"OnHurtPlayer" "Filter_Fire_Trigger_IgnoreTestActivator0-1"
+	}
+}
+
+add:
+{
+	"targetname" "Filter_Fire_Trigger_Ignore"
+	"Negated" "1"
+	"ResponseContext" "Fire_Trigger_Ignore"
+	"classname" "filter_activator_context"
+	"OnPass" "Slowdown_PatchTrigger0-1"
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "Knife_Heal_Selecter"
+		"classname" "logic_case"
+	}
+	insert:
+	{
+		"OnCase01" "Knife_Heal_Trigger_2AddOutputOnStartTouch Slowdown_Patch:FireUser1::0:-10.01-1"
+		"OnCase02" "Knife_Heal_Trigger_2AddOutputOnStartTouch Slowdown_Patch:FireUser2::0:-10.01-1"
 	}
 }
 

--- a/stripper/ze_ffxii_westersand_v8zeta1_b5k.cfg
+++ b/stripper/ze_ffxii_westersand_v8zeta1_b5k.cfg
@@ -365,6 +365,7 @@ modify:
 	match:
 	{
 		"classname" "trigger_hurt"
+		"filtername" "Filter_Team_Humans"
 	}
 	replace:
 	{

--- a/stripper/ze_ffxii_westersand_v8zeta1k.cfg
+++ b/stripper/ze_ffxii_westersand_v8zeta1k.cfg
@@ -24,6 +24,10 @@ add:
 	"spawnflags" "2"
 	"OnTrigger" "!activatorRunScriptCodeforeach(v,_ in {SetHealth=0}){EntFireByHandle(self,v,(self.GetHealth()-1).tostring(),0.0,null,null);}0-1"
 	"OnTrigger" "!activatorRunScriptCodeforeach(v,_ in {SetHealth=0}){EntFireByHandle(self,v,(self.GetHealth()+1).tostring(),0.0,null,null);}0.1-1"
+	"OnUser1" "!activatorAddContextFire_Trigger_Ignore:10-1"
+	"OnUser1" "!activatorRemoveContextFire_Trigger_Ignore13-1"
+	"OnUser2" "!activatorAddContextElectro_Trigger_Ignore:10-1"
+	"OnUser2" "!activatorRemoveContextElectro_Trigger_Ignore20-1"
 }
 
 modify:
@@ -35,8 +39,17 @@ modify:
 	}
 	insert:
 	{
-		"OnHurtPlayer" "Slowdown_PatchTrigger0-1"
+		"OnHurtPlayer" "Filter_Electro_Trigger_IgnoreTestActivator0-1"
 	}
+}
+
+add:
+{
+	"targetname" "Filter_Electro_Trigger_Ignore"
+	"Negated" "1"
+	"ResponseContext" "Electro_Trigger_Ignore"
+	"classname" "filter_activator_context"
+	"OnPass" "Slowdown_PatchTrigger0-1"
 }
 
 modify:
@@ -48,7 +61,30 @@ modify:
 	}
 	insert:
 	{
-		"OnHurtPlayer" "Slowdown_PatchTrigger0-1"
+		"OnHurtPlayer" "Filter_Fire_Trigger_IgnoreTestActivator0-1"
+	}
+}
+
+add:
+{
+	"targetname" "Filter_Fire_Trigger_Ignore"
+	"Negated" "1"
+	"ResponseContext" "Fire_Trigger_Ignore"
+	"classname" "filter_activator_context"
+	"OnPass" "Slowdown_PatchTrigger0-1"
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "Knife_Heal_Selecter"
+		"classname" "logic_case"
+	}
+	insert:
+	{
+		"OnCase01" "Knife_Heal_Trigger_2AddOutputOnStartTouch Slowdown_Patch:FireUser1::0:-10.01-1"
+		"OnCase02" "Knife_Heal_Trigger_2AddOutputOnStartTouch Slowdown_Patch:FireUser2::0:-10.01-1"
 	}
 }
 

--- a/stripper/ze_ffxii_westersand_v8zeta1k.cfg
+++ b/stripper/ze_ffxii_westersand_v8zeta1k.cfg
@@ -72,6 +72,7 @@ modify:
 	match:
 	{
 		"classname" "trigger_hurt"
+		"filtername" "Filter_Team_Humans"
 	}
 	replace:
 	{


### PR DESCRIPTION
Whoever was the genius that decided to make **ALL** damage types to 0 broke zombie heal's immunity abilities (electro, fire, & holy), and they did not bother **AT ALL** to test these changes. That's how the map has been broken for over 4 years.

This PR does 2 things:
-> The change for trigger_hurts to account for kevlar damage has been changed to only match `trigger_hurt` entities that have the `filter_team_humans` filtername. This fixes zombie heal's immunity abilities.
-> Rework slowdown patch as now that the electro and fire hurt is actually fixed, make the slowdown patch actually apply if zombie heal was not used

Fuck whoever made this change and did not test it. I was gaslit into thinking it was my skill issue but guess what? Fuck you.