### PR TITLE
Update ze_aaa_grand_line_x.cfg

### DIFF
--- a/stripper/ze_aaa_grand_line_x.cfg
+++ b/stripper/ze_aaa_grand_line_x.cfg
@@ -16,6 +16,9 @@ modify:
 	}
 }
 
+;adds the tp from the movie theater area and duplicates it at spawn
+;some servers have crowdspawn, but in the case that zm tp back to player_spawn
+;this extra trigger is needed otherwise zm will be stuck with movetype 0 until credits end
 add:
 {
   	"model" "*471"

--- a/stripper/ze_aaa_grand_line_x.cfg
+++ b/stripper/ze_aaa_grand_line_x.cfg
@@ -15,3 +15,17 @@ modify:
 		"vscripts" "gfl/aaa_magic_fix.nut"
 	}
 }
+
+add:
+{
+  	"model" "*471"
+   	"wait" "0"
+	"targetname" "zm_tp_credits"
+ 	"StartDisabled" "1"
+  	"spawnflags" "4097"
+   	"origin" "-5480 10240 -2560"
+	"filtername" "filter_t"
+	"classname" "trigger_multiple"
+ 	"OnStartTouch" "aaa_magicRunScriptCodezm_credits_tp()0-1"
+}
+


### PR DESCRIPTION
add a trigger_multiple to spawn area on level three to avoid zombies getting stuck with movetype 0 instead of getting tp'd back to the movie theatre