### PR TITLE
Fix aurora tower

### DIFF
--- a/stripper/ze_aurora_tower_v6_6.cfg
+++ b/stripper/ze_aurora_tower_v6_6.cfg
@@ -2,23 +2,35 @@
 add:
 {
 	"rendermode" "10"
-	"origin" "-5447.25 226.25 1037"
-	"angles" "0 0 0"
-	"targetname" "resize_me4"
-	"classname" "func_brush"
+	"origin" "-5634 154 1066"
+	"model" "*601"
+	"targetname" "no_button_skip"
+	"classname" "func_wall_toggle"
 }
 
 modify:
 {
 	match:
 	{
-		"classname" "logic_auto"
+		"classname" "trigger_once"
+		"targetname" "Gate#6_Platform_TriggerF"
 	}
 	insert:
 	{
-		"OnMapSpawn" "resize_me4AddOutputsolid 20.5-1"
-		"OnMapSpawn" "resize_me4AddOutputmins -15.75 -13.25 -731-1"
-		"OnMapSpawn" "resize_me4AddOutputmaxs 13.25 15.75 731-1"
+		"OnStartTouch" "no_button_skipKill21-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "Gate#6_Platform_TriggerLv3"
+	}
+	insert:
+	{
+		"OnStartTouch" "no_button_skipKill21-1"
 	}
 }
 

--- a/stripper/ze_aurora_tower_v6_6.cfg
+++ b/stripper/ze_aurora_tower_v6_6.cfg
@@ -40,48 +40,58 @@ modify:
 }
 
 ;patch tp avoidance spot
-modify:
+filter:
 {
-	match:
-	{
-		"classname" "trigger_teleport"
-		"targetname" "FallOutMap_Zombie_TeleArea"
-	}
-	delete:
-	{
-		"model" "*27"
-	}
+	"classname" "trigger_teleport"
+	"targetname" "FallOutMap_Zombie_TeleArea"
 }
 
-modify:
+add:
 {
-	match:
-	{
-		"classname" "trigger_hurt"
-		"targetname" "FallOutMap_CT_KillArea"
-	}
-	delete:
-	{
-		"model" "*28"
-	}
+	"targetname" "resize_me1"
+	"target" "Tele_CT_ShipDoor1_Spot"
+	"spawnflags" "4097"
+	"origin" "-6283.59 -156.5 14"
+	"filtername" "FilterAllow_T_Zombie"
+	"classname" "trigger_teleport"
 }
 
-modify:
+filter:
 {
-	match:
-	{
-		"classname" "trigger_teleport"
-		"targetname" "Lv3FinalRun_NoFreeFall_Teleport"
-		"origin" "-7020.14 -170.5 16"
-	}
-	replace:
-	{
-		"targetname" "resize_me"
-	}
-	delete:
-	{
-		"model" "*497"
-	}
+	"classname" "trigger_hurt"
+	"targetname" "FallOutMap_CT_KillArea"
+}
+
+add:
+{
+	"targetname" "resize_me2"
+	"spawnflags" "4097"
+	"origin" "-6300.5 -143.5 15.5"
+	"nodmgforce" "0"
+	"filtername" "FilterAllow_CT_Human"
+	"damagetype" "512"
+	"damagemodel" "0"
+	"damagecap" "99999"
+	"damage" "99999"
+	"classname" "trigger_hurt"
+}
+
+filter:
+{
+	"classname" "trigger_teleport"
+	"targetname" "Lv3FinalRun_NoFreeFall_Teleport"
+	"origin" "-7020.14 -170.5 16"
+}
+
+add:
+{
+	"UseLandmarkAngles" "1"
+	"targetname" "resize_me3"
+	"target" "Boss2Dead_Teleport_T_Spot"
+	"StartDisabled" "1"
+	"spawnflags" "4097"
+	"origin" "-7020.14 -170.5 16"
+	"classname" "trigger_teleport"
 }
 
 modify:
@@ -92,16 +102,18 @@ modify:
 	}
 	insert:
 	{
-		"OnMapSpawn" "FallOutMap_Zombie_TeleAreaAddOutputsolid 20.51"
-		"OnMapSpawn" "FallOutMap_Zombie_TeleAreaAddOutput mins -9288 -1658.5 -62.511"
-		"OnMapSpawn" "FallOutMap_Zombie_TeleAreaAddOutput maxs 9288 1658.5 62.511"
-		"OnMapSpawn" "FallOutMap_CT_KillAreaAddOutputsolid 20.51"
-		"OnMapSpawn" "FallOutMap_CT_KillAreaAddOutput mins -9288 -1658.5 -57.511"
-		"OnMapSpawn" "FallOutMap_CT_KillAreaAddOutput maxs 9288 1658.5 57.511"
-		"OnMapSpawn" "resize_meAddOutputsolid 20.51"
-		"OnMapSpawn" "resize_meAddOutput mins -9288 -1658.5 -53.511"
-		"OnMapSpawn" "resize_meAddOutput maxs 9288 1658.5 53.511"
-		"OnMapSpawn" "resize_meAddOutput targetname Lv3FinalRun_NoFreeFall_Teleport1.51"
+		"OnMapSpawn" "resize_me1AddOutputsolid 20.51"
+		"OnMapSpawn" "resize_me1AddOutputmins -10080 -1658.5 -62.511"
+		"OnMapSpawn" "resize_me1AddOutputmaxs 10080 1658.5 62.511"
+		"OnMapSpawn" "resize_me1AddOutputtargetname FallOutMap_Zombie_TeleArea1.51"
+		"OnMapSpawn" "resize_me2AddOutputsolid 20.51"
+		"OnMapSpawn" "resize_me2AddOutputmins -10080 -1658.5 -57.511"
+		"OnMapSpawn" "resize_me2AddOutputmaxs 10080 1658.5 57.511"
+		"OnMapSpawn" "resize_me2AddOutputtargetname FallOutMap_CT_KillArea1.51"
+		"OnMapSpawn" "resize_me3AddOutputsolid 20.51"
+		"OnMapSpawn" "resize_me3AddOutputmins -10080 -1658.5 -53.511"
+		"OnMapSpawn" "resize_me3AddOutputmaxs 10080 1658.5 53.511"
+		"OnMapSpawn" "resize_me3AddOutputtargetname Lv3FinalRun_NoFreeFall_Teleport1.51"
 	}
 }
 

--- a/stripper/ze_aurora_tower_v6_6.cfg
+++ b/stripper/ze_aurora_tower_v6_6.cfg
@@ -1,3 +1,50 @@
+;fix people using button to jump over fence and early trigger
+add:
+{
+	"rendermode" "10"
+	"origin" "-5447.25 226.25 1037"
+	"angles" "0 0 0"
+	"targetname" "resize_me4"
+	"classname" "func_brush"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "resize_me4AddOutputsolid 20.5-1"
+		"OnMapSpawn" "resize_me4AddOutputmins -15.75 -13.25 -731-1"
+		"OnMapSpawn" "resize_me4AddOutputmaxs 13.25 15.75 731-1"
+	}
+}
+
+;fix early triggering at bridge ladder part on stages 3 and 4
+add:
+{
+	"classname" "func_wall_toggle"
+	"origin" "-5767 930 5677"
+	"model" "*594"
+	"targetname" "no_ladder_early_trigger"
+	"rendermode" "10"
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "Gate#11_TowerTop_Window"
+		"classname" "func_breakable"
+	}
+	insert:
+	{
+		"OnBreak" "no_ladder_early_triggerKill51"
+	}
+}
+
 ;filter unpacked particle
 filter:
 {


### PR DESCRIPTION
After thorough debugging and help from both Console and jaek, I have fixed the issue with the original stripper. My original changes would have worked if I had accounted for the fact that the mapper had the origin ball off-center of the triggers, therefore my mins and maxs were off.

Changes:
-> Fixed a possible early trigger using the back button on stage 2 and 3
-> Fixed a possible early trigger due to GFL jump height where players can skip building the bridge and get on the ladder immediately
-> Fixed the original teleport avoidance spots that were suposedly fixed by resizing triggers