### PR TITLE
Fix bisounours party incorrect timer

### DIFF
--- a/stripper/ze_bisounours_party_p2.cfg
+++ b/stripper/ze_bisounours_party_p2.cfg
@@ -1,0 +1,17 @@
+;fix incorrect timer
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "end_lvl2"
+	}
+	delete:
+	{
+		"OnStartTouch" "scCommandsay *** Hold 30 secs! ***01"
+	}
+	insert:
+	{
+		"OnStartTouch" "scCommandsay *** Hold 35 secs! ***01"
+	}
+}


### PR DESCRIPTION
After 1st pedobear boss fight there is a 35 second hold in the cave but the chat message says 30.