### PR TITLE
Various changes and fixes to maps

### DIFF
--- a/bosshud/ze_golubenkaya_meow_v1_2.txt
+++ b/bosshud/ze_golubenkaya_meow_v1_2.txt
@@ -1,0 +1,30 @@
+"math_counter"
+{
+    "0"
+    {
+        "HP_counter"        "catnpc_hp"
+        "CustomText"        "Cat"
+    }
+    "1"
+    {
+        "HP_counter"        "kurumi_counter"
+        "HPinit_counter"    "kurumi_hp_backup"
+        "HPbar_counter"     "kurumi_hp_iterations"
+        "HPbar_max"         "5"
+        "HPbar_min"         "0"
+        "HPbar_default"     "5"
+        "HPbar_mode"        "1"
+        "CustomText"        "Kurumi"
+    }
+    "2"
+    {
+        "HP_counter"        "boss_counter"
+        "HPinit_counter"    "boss_hp_backup"
+        "HPbar_counter"     "boss_hp_iterations"
+        "HPbar_max"         "5"
+        "HPbar_min"         "0"
+        "HPbar_default"     "5"
+        "HPbar_mode"        "1"
+        "CustomText"        "Boss"
+    }
+}

--- a/bosshud/ze_retro_cow_v1.txt
+++ b/bosshud/ze_retro_cow_v1.txt
@@ -14,6 +14,6 @@
 	{
 		"Type"				"breakable"
 		"BreakableName"		"neco_arc_final_break"
-		"CustomText"		"Neco Arc
+		"CustomText"		"Neco Arc"
 	}
 }

--- a/entwatch/ze_realm_f3.cfg
+++ b/entwatch/ze_realm_f3.cfg
@@ -101,7 +101,7 @@
     {
         "name"              "Zombie Ice"
         "shortname"         "ZM Ice"
-        "color"             "{cyan}"
+        "color"             "{blue}"
         "buttonclass"       "func_button"
         "filtername"        "player_z_ice"
         "hasfiltername"     "true"

--- a/entwatch/ze_zertinan_v1_4.cfg
+++ b/entwatch/ze_zertinan_v1_4.cfg
@@ -208,6 +208,7 @@
         "mode"              "2"
         "maxuses"           "0"
         "cooldown"          "60"
+        "buttonid"          "1402500"
         "maxamount"         "1"
     }
     "11"
@@ -265,6 +266,7 @@
         "mode"              "2"
         "maxuses"           "0"
         "cooldown"          "30"
+        "buttonid"          "1376197"
         "maxamount"         "1"
     }
     "14"

--- a/stripper/ze_aware_v1_2a.cfg
+++ b/stripper/ze_aware_v1_2a.cfg
@@ -1,0 +1,13 @@
+// fix ending of stage 3 so the balls don't kill zombies and trigger repeat killer
+modify:
+{ 
+	match:
+	{
+		"targetname" "st3_f_h1"
+		"classname" "trigger_hurt"
+	}
+	replace:
+	{
+		"filtername" "ct"
+	}
+}

--- a/stripper/ze_ffxii_westersand_v8zeta1k.cfg
+++ b/stripper/ze_ffxii_westersand_v8zeta1k.cfg
@@ -1,3 +1,28 @@
+// fix chaos summon during epic & god mode
+modify:
+{
+	match:
+	{
+		"targetname" "Summon_Chaos_Temp"
+		"classname" "point_template"
+	}
+	delete:
+	{
+		"Template01" "Chaos_Summon_*"
+	}
+	insert:
+	{
+		"Template01" "Chaos_Summon_Model"
+		"Template02" "Chaos_Summon_Move"
+		"Template03" "Chaos_Summon_Particle_1"
+		"Template04" "Chaos_Summon_Physbox"
+		"Template05" "Chaos_Summon_Relay_Meteor"
+		"Template06" "Chaos_Summon_Rotate"
+		"Template07" "Chaos_Summon_Trigger_1"
+		"Template08" "Chaos_Summon_Wall"
+	}
+}
+
 // fix dragon boost
 modify:
 {

--- a/stripper/ze_ffxii_westersand_v8zeta1k.cfg
+++ b/stripper/ze_ffxii_westersand_v8zeta1k.cfg
@@ -1,4 +1,4 @@
-;fix dragon boost
+// fix dragon boost
 modify:
 {
 	match:
@@ -16,7 +16,7 @@ modify:
 	}
 }
 
-;make electro and fire slow zombies like in css
+// make electro and fire slow zombies like in css
 add:
 {
 	"classname" "logic_relay"
@@ -88,7 +88,7 @@ modify:
 	}
 }
 
-;fix game_player_equip dropping weapons
+// fix game_player_equip dropping weapons
 modify:
 {
 	match:
@@ -102,7 +102,7 @@ modify:
 	}
 }
 
-;fix some damage not taking kevlar into account
+// fix some damage not taking kevlar into account
 modify:
 {
 	match:
@@ -115,16 +115,17 @@ modify:
 		"damagetype" "0"
 	}
 }
-;Fix heal burning players which could cause 1 hp players to die during the duration of when its used.
+
+// fix heal burning players which could cause 1 hp players to die during the duration of when its used.
 modify:
 {
 	match:
- 	{
-  		"classname" "trigger_multiple"
-		"filtername" "Staff_Heal_Trigger"
-  	}
-   	delete:
 	{
- 		"OnStartTouch" "!activatorIgniteLifetime001"
-   	}
+		"classname" "trigger_multiple"
+		"filtername" "Staff_Heal_Trigger"
+	}
+	delete:
+	{
+		"OnStartTouch" "!activatorIgniteLifetime001"
+	}
 }

--- a/stripper/ze_forhidden_slicoo_v5.cfg
+++ b/stripper/ze_forhidden_slicoo_v5.cfg
@@ -45,11 +45,7 @@ add:
 	"model" "*33"
 	"targetname" "snow_wall"
 	"origin" "-15404 11866 300"
-	"speed" "500"
-	"pushdir" "0 90 0"
-	"FallingSpeedThreshold" "-150"
-	"spawnflags" "1"
-	"classname" "trigger_push"
+	"classname" "func_brush"
 }
 
 add:
@@ -57,25 +53,16 @@ add:
 	"model" "*33"
 	"targetname" "snow_wall"
 	"origin" "-15404 11766 0"
-	"speed" "500"
-	"pushdir" "0 90 0"
-	"FallingSpeedThreshold" "-150"
-	"spawnflags" "1"
-	"classname" "trigger_push"
+	"classname" "func_brush"
 }
 
-// fix circle of winter from 2nd floor to skip to top way
+// prevent circle of winter jumping from top to bottom
 add:
 {
 	"model" "*114"
 	"targetname" "anti_skip"
 	"origin" "13200 -3571 5850"
-	"speed" "2000"
-	"pushdir" "0 0 90"
-	"FallingSpeedThreshold" "-150"
-	"filtername" "zombie"
-	"spawnflags" "1"
-	"classname" "trigger_push"
+	"classname" "func_brush"
 }
 
 add:
@@ -83,24 +70,5 @@ add:
 	"model" "*114"
 	"targetname" "anti_skip"
 	"origin" "13200 -2595 5850"
-	"speed" "2000"
-	"pushdir" "0 0 90"
-	"FallingSpeedThreshold" "-150"
-	"filtername" "zombie"
-	"spawnflags" "1"
-	"classname" "trigger_push"
-}
-
-// kill all added pushes when no longer needed
-modify:
-{
-	match:
-	{
-		"hammerid" "201813"
-	}
-	insert:
-	{
-		"OnStartTouch" "anti_skipKill201"
-		"OnStartTouch" "snow_wallKill201"
-	}
+	"classname" "func_brush"
 }

--- a/stripper/ze_forhidden_slicoo_v5.cfg
+++ b/stripper/ze_forhidden_slicoo_v5.cfg
@@ -1,4 +1,4 @@
-;temporary workaround for missing buyzone
+// temporary workaround for missing buyzone
 modify:
 {
 	match:
@@ -12,7 +12,7 @@ modify:
 	}
 }
 
-;fix boss health display causing flickering for other game_text
+// fix boss health display causing flickering for other game_text
 modify:
 {
 	match:
@@ -36,5 +36,71 @@ modify:
 	{
 		"OnMapSpawn" "lfkb_boss_hpshowRunScriptCodesaveTime<-Time();01"
 		"OnMapSpawn" "lfkb_boss_hpshowRunScriptCodeInputDisplay<-function(){if(Time()-saveTime>0.10){saveTime=Time();return true;}else{return false;}}0.021"
+	}
+}
+
+// fix players climbing up a hill to go outside the map
+add:
+{
+	"model" "*33"
+	"targetname" "snow_wall"
+	"origin" "-15404 11866 300"
+	"speed" "500"
+	"pushdir" "0 90 0"
+	"FallingSpeedThreshold" "-150"
+	"spawnflags" "1"
+	"classname" "trigger_push"
+}
+
+add:
+{
+	"model" "*33"
+	"targetname" "snow_wall"
+	"origin" "-15404 11766 0"
+	"speed" "500"
+	"pushdir" "0 90 0"
+	"FallingSpeedThreshold" "-150"
+	"spawnflags" "1"
+	"classname" "trigger_push"
+}
+
+// fix circle of winter from 2nd floor to skip to top way
+add:
+{
+	"model" "*114"
+	"targetname" "anti_skip"
+	"origin" "13200 -3571 5850"
+	"speed" "2000"
+	"pushdir" "0 0 90"
+	"FallingSpeedThreshold" "-150"
+	"filtername" "zombie"
+	"spawnflags" "1"
+	"classname" "trigger_push"
+}
+
+add:
+{
+	"model" "*114"
+	"targetname" "anti_skip"
+	"origin" "13200 -2595 5850"
+	"speed" "2000"
+	"pushdir" "0 0 90"
+	"FallingSpeedThreshold" "-150"
+	"filtername" "zombie"
+	"spawnflags" "1"
+	"classname" "trigger_push"
+}
+
+// kill all added pushes when no longer needed
+modify:
+{
+	match:
+	{
+		"hammerid" "201813"
+	}
+	insert:
+	{
+		"OnStartTouch" "anti_skipKill201"
+		"OnStartTouch" "snow_wallKill201"
 	}
 }

--- a/stripper/ze_neochrome_csgo3a.cfg
+++ b/stripper/ze_neochrome_csgo3a.cfg
@@ -11,3 +11,17 @@ add:
 	"CheckDestIfClearForPlayer" "0"
 	"spawnflags" "1"
 }
+
+// fix heal possibly spawning in the wall
+modify:
+{
+	match:
+	{
+		"classname" "env_entity_maker"
+		"targetname" "heal_maker_3"
+	}
+	replace:
+	{
+		"origin" "5984 6816 -2368"
+	}
+}

--- a/stripper/ze_undead_shrine_b1_2.cfg
+++ b/stripper/ze_undead_shrine_b1_2.cfg
@@ -1,0 +1,27 @@
+// patch an exploit that allowed zombies to teleport ahead of humans by moving the teleport destination back
+modify:
+{
+	match:
+	{
+		"targetname" "dest_tp_6"
+		"classname" "info_teleport_destination"
+	}
+	replace:
+	{
+		"origin" "-2290 9892 -6314"
+	}
+}
+
+// move the repositioned teleport destination back to its original place after humans have passed
+modify:
+{
+	match:
+	{
+		"targetname" "lvl1_block_tp"
+		"classname" "func_movelinear"
+	}
+	insert:
+	{
+		"OnFullyOpen" "dest_tp_6AddOutputorigin -3406 8650 -5671201"
+	}
+}

--- a/stripper/ze_zertinan_v1_4.cfg
+++ b/stripper/ze_zertinan_v1_4.cfg
@@ -1,0 +1,92 @@
+// fix entwatch not tracking some item cooldowns
+modify:
+{
+	match:
+	{
+		"targetname" "Item_Fire_Button"
+		"classname" "func_button"
+	}
+	replace:
+	{
+		"parentname" "Item_Fire_elite"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "Item_Ice_Button"
+		"classname" "func_button"
+	}
+	replace:
+	{
+		"parentname" "Item_Ice_elite"
+	}
+}
+
+// fix some boss attacks and nukes not doing any damage
+modify:
+{
+	match:
+	{
+		"DamageType" "8"
+	}
+	replace:
+	{
+		"DamageType" "1024"
+	}
+}
+
+// fix players phasing through doors or getting stuck on doors in stage 2
+modify:
+{
+	match:
+	{
+		"classname" "func_door_rotating"
+	}
+	replace:
+	{
+		"ignoredebris" "0"
+	}
+}
+
+// fix players controlling final airships
+modify:
+{
+	match:
+	{
+		"targetname" "stage3_airship_Move_2B"
+		"classname" "func_tracktrain"
+	}
+	replace:
+	{
+		"spawnflags" "514"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "stage3_airship_Move_1B"
+		"classname" "func_tracktrain"
+	}
+	replace:
+	{
+		"spawnflags" "514"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"targetname" "stage2_airship_Move"
+		"classname" "func_tracktrain"
+	}
+	replace:
+	{
+		"spawnflags" "514"
+	}
+}

--- a/stripper/ze_zertinan_v1_4.cfg
+++ b/stripper/ze_zertinan_v1_4.cfg
@@ -1,30 +1,3 @@
-// fix entwatch not tracking some item cooldowns
-modify:
-{
-	match:
-	{
-		"targetname" "Item_Fire_Button"
-		"classname" "func_button"
-	}
-	replace:
-	{
-		"parentname" "Item_Fire_elite"
-	}
-}
-
-modify:
-{
-	match:
-	{
-		"targetname" "Item_Ice_Button"
-		"classname" "func_button"
-	}
-	replace:
-	{
-		"parentname" "Item_Ice_elite"
-	}
-}
-
 // fix some boss attacks and nukes not doing any damage
 modify:
 {


### PR DESCRIPTION
Added bosshud/golubenkaya meow

bosshud/retro cow
-> Fixed missing `"` breaking display

entwatch/realm
-> Replaced `{cyan}` invalid color

stripper/aware
-> The ending of aware has balls that kill both zombies and humans. Added filtername so it doesn't kill zombies and trigger repeat killer

stripper/ffxii westersand v8
-> Fixed chaos summon issues from maptest

stripper/forhidden slicoo
-> Fixed an out of map exploit

stripper/neochrome
-> Fix heal spawning inside the wall before boss room teleport

stripper/undead shrine
-> Patched an exploit that allowed zombies to teleport ahead of humans

stripper/zertinan
-> Fixed some boss attacks not working due to damagetype
-> Fixed controllable ships (LMAO)
-> Fix ice and fire not showing CD due to button not being parented to the pistol
-> Fixed players getting stuck/phasing through doors due to `ignoredebris`