### PR TITLE
Fix visualizer boost pads being inconsistent (+Fix forhidden stripper)

### DIFF
--- a/stripper/ze_forhidden_slicoo_v5.cfg
+++ b/stripper/ze_forhidden_slicoo_v5.cfg
@@ -18,7 +18,7 @@ modify:
 	match:
 	{
 		"classname" "game_text"
-		targetname" "lfkb_boss_hpshow"
+		"targetname" "lfkb_boss_hpshow"
 	}
 	replace:
 	{

--- a/stripper/ze_visualizer_v2_1.cfg
+++ b/stripper/ze_visualizer_v2_1.cfg
@@ -12,7 +12,7 @@ modify:
 	}
 	insert:
 	{
-		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,720));0-1"
+		"OnEndTouch" "!activatorRunScriptCode{local vel=self.GetVelocity();self.SetVelocity(Vector(vel.x,vel.y,vel.z+720))}0-1"
 	}
 }
 
@@ -29,7 +29,7 @@ modify:
 	}
 	insert:
 	{
-		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,720));0-1"
+		"OnEndTouch" "!activatorRunScriptCode{local vel=self.GetVelocity();self.SetVelocity(Vector(vel.x,vel.y,vel.z+720))}0-1"
 	}
 }
 
@@ -46,7 +46,7 @@ modify:
 	}
 	insert:
 	{
-		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,620));0-1"
+		"OnEndTouch" "!activatorRunScriptCode{local vel=self.GetVelocity();self.SetVelocity(Vector(vel.x,vel.y,vel.z+620))}0-1"
 	}
 }
 
@@ -63,7 +63,7 @@ modify:
 	}
 	insert:
 	{
-		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,920));0-1"
+		"OnEndTouch" "!activatorRunScriptCode{local vel=self.GetVelocity();self.SetVelocity(Vector(vel.x,vel.y,vel.z+920))}0-1"
 	}
 }
 
@@ -80,7 +80,7 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,1150,350));0-1"
+		"OnStartTouch" "!activatorRunScriptCode{local vel=self.GetVelocity();self.SetVelocity(Vector(vel.x,vel.y+1150,vel.z+350))}0-1"
 	}
 }
 
@@ -97,7 +97,7 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,-1150,350));0-1"
+		"OnStartTouch" "!activatorRunScriptCode{local vel=self.GetVelocity();self.SetVelocity(Vector(vel.x,vel.y-1150,vel.z+350))}0-1"
 	}
 }
 
@@ -114,7 +114,7 @@ modify:
 	}
 	insert:
 	{
-		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,620));0-1"
+		"OnEndTouch" "!activatorRunScriptCode{local vel=self.GetVelocity();self.SetVelocity(Vector(vel.x,vel.y,vel.z+620))}0-1"
 	}
 }
 
@@ -131,7 +131,7 @@ modify:
 	}
 	insert:
 	{
-		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,900));0-1"
+		"OnEndTouch" "!activatorRunScriptCode{local vel=self.GetVelocity();self.SetVelocity(Vector(vel.x,vel.y,vel.z+900))}0-1"
 	}
 }
 
@@ -148,7 +148,7 @@ modify:
 	}
 	insert:
 	{
-		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,650));0-1"
+		"OnEndTouch" "!activatorRunScriptCode{local vel=self.GetVelocity();self.SetVelocity(Vector(vel.x,vel.y,vel.z+650))}0-1"
 	}
 }
 
@@ -165,7 +165,7 @@ modify:
 	}
 	insert:
 	{
-		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,650));0-1"
+		"OnEndTouch" "!activatorRunScriptCode{local vel=self.GetVelocity();self.SetVelocity(Vector(vel.x,vel.y,vel.z+650))}0-1"
 	}
 }
 
@@ -182,7 +182,7 @@ modify:
 	}
 	insert:
 	{
-		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,520));0-1"
+		"OnEndTouch" "!activatorRunScriptCode{local vel=self.GetVelocity();self.SetVelocity(Vector(vel.x,vel.y,vel.z+520))}0-1"
 	}
 }
 
@@ -199,7 +199,7 @@ modify:
 	}
 	insert:
 	{
-		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,520));0-1"
+		"OnEndTouch" "!activatorRunScriptCode{local vel=self.GetVelocity();self.SetVelocity(Vector(vel.x,vel.y,vel.z+520))}0-1"
 	}
 }
 
@@ -216,7 +216,7 @@ modify:
 	}
 	insert:
 	{
-		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,650));0-1"
+		"OnEndTouch" "!activatorRunScriptCode{local vel=self.GetVelocity();self.SetVelocity(Vector(vel.x,vel.y,vel.z+650))}0-1"
 	}
 }
 
@@ -234,7 +234,7 @@ modify:
 	}
 	insert:
 	{
-		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,250));0-1"
+		"OnEndTouch" "!activatorRunScriptCode{local vel=self.GetVelocity();self.SetVelocity(Vector(vel.x,vel.y,vel.z+250))}0-1"
 	}
 }
 
@@ -252,7 +252,7 @@ modify:
 	}
 	insert:
 	{
-		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,1050));0-1"
+		"OnEndTouch" "!activatorRunScriptCode{local vel=self.GetVelocity();self.SetVelocity(Vector(vel.x,vel.y,vel.z+1050))}0-1"
 	}
 }
 

--- a/stripper/ze_visualizer_v2_1.cfg
+++ b/stripper/ze_visualizer_v2_1.cfg
@@ -1,3 +1,261 @@
+// fix booster pads not working consistently
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "s5_booster_trigger04"
+	}
+	delete:
+	{
+		"OnEndTouch" "!activatorAddOutputbasevelocity 0 0 7200-1"
+	}
+	insert:
+	{
+		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,720));0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "s5_booster_trigger03"
+	}
+	delete:
+	{
+		"OnEndTouch" "!activatorAddOutputbasevelocity 0 0 7200-1"
+	}
+	insert:
+	{
+		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,720));0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "s5_booster_trigger02"
+	}
+	delete:
+	{
+		"OnEndTouch" "!activatorAddOutputbasevelocity 0 0 6200-1"
+	}
+	insert:
+	{
+		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,620));0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "s5_booster_trigger01"
+	}
+	delete:
+	{
+		"OnEndTouch" "!activatorAddOutputbasevelocity 0 0 9200-1"
+	}
+	insert:
+	{
+		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,920));0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "6_1_gravity1"
+	}
+	delete:
+	{
+		"OnStartTouch" "!activatorAddOutputbasevelocity 0 1150 3500-1"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,1150,350));0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "6_push1"
+	}
+	delete:
+	{
+		"OnStartTouch" "!activatorAddOutputbasevelocity 0 -1150 3500-1"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,-1150,350));0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "p2_s6_booster_trigger01"
+	}
+	delete:
+	{
+		"OnEndTouch" "!activatorAddOutputbasevelocity 0 0 6200-1"
+	}
+	insert:
+	{
+		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,620));0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "s2_booster_trigger05"
+	}
+	delete:
+	{
+		"OnEndTouch" "!activatorAddOutputbasevelocity 0 0 9000-1"
+	}
+	insert:
+	{
+		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,900));0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "s2_booster_trigger01"
+	}
+	delete:
+	{
+		"OnEndTouch" "!activatorAddOutputbasevelocity 0 0 6500-1"
+	}
+	insert:
+	{
+		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,650));0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "s2_booster_trigger02"
+	}
+	delete:
+	{
+		"OnEndTouch" "!activatorAddOutputbasevelocity 0 0 6500-1"
+	}
+	insert:
+	{
+		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,650));0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "s2_booster_trigger03"
+	}
+	delete:
+	{
+		"OnEndTouch" "!activatorAddOutputbasevelocity 0 0 5200-1"
+	}
+	insert:
+	{
+		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,520));0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "s2_booster_trigger04"
+	}
+	delete:
+	{
+		"OnEndTouch" "!activatorAddOutputbasevelocity 0 0 5200-1"
+	}
+	insert:
+	{
+		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,520));0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "s3_booster_trigger01"
+	}
+	delete:
+	{
+		"OnEndTouch" "!activatorAddOutputbasevelocity 0 0 6500-1"
+	}
+	insert:
+	{
+		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,650));0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "s4_booster_trigger01"
+		"origin" "11328 352 -10206"
+	}
+	delete:
+	{
+		"OnEndTouch" "!activatorAddOutputbasevelocity 0 0 2500-1"
+	}
+	insert:
+	{
+		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,250));0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "s4_booster_trigger01"
+		"origin" "10528 -15792 -14862"
+	}
+	delete:
+	{
+		"OnEndTouch" "!activatorAddOutputbasevelocity 0 0 10500-1"
+	}
+	insert:
+	{
+		"OnEndTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x,self.GetVelocity().y,1050));0-1"
+	}
+}
+
 ; fix item spawn on stage 2
 modify:
 {


### PR DESCRIPTION
stripper/forhidden slicoo
-> Fix missing `"`

stripper/visualizer
-> AddOutput basevelocity is inconsistent. While this works for the most part, rare edge cases of it not applying the proper boost do occur. Especially when servers start lagging a bit, sometimes it would just outright not work for majority of players. Using vscript is much more safer.