### PR TITLE
Rizomata fixes

### DIFF
--- a/stripper/ze_rizomata_va2.cfg
+++ b/stripper/ze_rizomata_va2.cfg
@@ -1,3 +1,42 @@
+;tp avoidance on stage 2 by bugging through displacement
+add:
+{
+	"model" "*350"
+	"classname" "trigger_teleport"
+	"targetname" "2_afktele3"
+	"origin" "-6702.5 6378 -5662"
+	"spawnflags" "4097"
+	"StartDisabled" "1"
+	"target" "des2"
+	"UseLandmarkAngles" "1"
+}
+
+;stop stage 3 ending elevator getting blocked
+modify:
+{
+	match:
+	{
+		"targetname" "3_bosslift2"
+	}
+	replace:
+	{
+		"blockdamage" "999999"
+	}
+}
+
+;stop stage 5 ending elevator getting blocked
+modify:
+{
+	match:
+	{
+		"targetname" "5_boss_lift1"
+	}
+	replace:
+	{
+		"blockdamage" "999999"
+	}
+}
+
 ;prevent early trigger on stage 4 from triple boost
 ;dont prevent triple boost cuz its fun
 modify:


### PR DESCRIPTION
- Add another tp in stage 2 pre-boss/escape sequence to cover a tiny area behind a displacement which isnt covered. Currently can be used to avoid being in the boss fight and be at the exit early as either team.

- Fix elevators getting blocked