### PR TITLE
Update ridorana stripper

### DIFF
--- a/stripper/ze_ffxii_ridorana_cataract_t5_3_w6.cfg
+++ b/stripper/ze_ffxii_ridorana_cataract_t5_3_w6.cfg
@@ -169,97 +169,97 @@ modify:
 
 ;Remove max level of ZM items since they are incredibly unbalanced (old PS port flat out removed all level 3 ZM items and was far more balanced than current)
 ;ZM Heal - Remove KB and nade invulerability (Keeps the level 3 Heal amount, so don't replace pickup message to level 2)
-modify:
-{
-	match:
-	{
-		"targetname" "Item_Z_Heal_Level_Case"
-		"classname" "logic_case"
-	}
-	delete:
-	{
-		"OnCase04" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter::5:-10-1"
-		"OnCase04" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter:Filter_CT_Ignore:0:-10-1"
-		"OnCase03" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter::5:-10-1"
-		"OnCase03" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter:Nade_Ignore:0:-10-1"
-		"OnCase02" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter:Nade_Ignore:0:-10-1"
-		"OnCase02" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter::5:-10-1"
-	}
-}
+;modify:
+;{
+;	match:
+;	{
+;		"targetname" "Item_Z_Heal_Level_Case"
+;		"classname" "logic_case"
+;	}
+;	delete:
+;	{
+;		"OnCase04" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter::5:-10-1"
+;		"OnCase04" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter:Filter_CT_Ignore:0:-10-1"
+;		"OnCase03" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter::5:-10-1"
+;		"OnCase03" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter:Nade_Ignore:0:-10-1"
+;		"OnCase02" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter:Nade_Ignore:0:-10-1"
+;		"OnCase02" "Item_Z_Heal_TriggerAddOutputOnStartTouch !activator:SetDamageFilter::5:-10-1"
+;	}
+;}
 
 ;ZM Fire Level 3 -> Level 2
-modify:
-{
-	match:
-	{
-		"targetname" "Item_Z_Fire_Level_Case"
-		"classname" "logic_case"
-	}
-	delete:
-	{
-		"OnCase04" "Map_ScriptRunScriptCodeItemTextZFire(3);0-1"
-		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(23);0-1"
-		"OnCase04" "Item_Z_Fire_Effect_lvl3AddOutputtargetname Item_Z_Fire_Effect0-1"
-		"OnCase04" "Item_Relay_Z_FireAddOutputOnTrigger Item_Z_Fire_Effect:Stop::4:-10-1"
-		"OnCase04" "Item_Relay_Z_FireAddOutputOnTrigger Item_Z_Fire_Trigger:Disable::4:-10-1"
-		"OnCase04" "Item_Z_Fire_Trigger_lvl3AddOutputtargetname Item_Z_Fire_Trigger0-1"
-	}
-	insert:
-	{
-		"OnCase04" "Map_ScriptRunScriptCodeItemTextZFire(2);0-1"
-		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(22);0-1"
-		"OnCase04" "Item_Z_Fire_Effect_lvl2AddOutputtargetname Item_Z_Fire_Effect0-1"
-		"OnCase04" "Item_Relay_Z_FireAddOutputOnTrigger Item_Z_Fire_Effect:Stop::3:-10-1"
-		"OnCase04" "Item_Relay_Z_FireAddOutputOnTrigger Item_Z_Fire_Trigger:Disable::3:-10-1"
-		"OnCase04" "Item_Z_Fire_Trigger_lvl2AddOutputtargetname Item_Z_Fire_Trigger0-1"
-	}
-}
+;modify:
+;{
+;	match:
+;	{
+;		"targetname" "Item_Z_Fire_Level_Case"
+;		"classname" "logic_case"
+;	}
+;	delete:
+;	{
+;		"OnCase04" "Map_ScriptRunScriptCodeItemTextZFire(3);0-1"
+;		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(23);0-1"
+;		"OnCase04" "Item_Z_Fire_Effect_lvl3AddOutputtargetname Item_Z_Fire_Effect0-1"
+;		"OnCase04" "Item_Relay_Z_FireAddOutputOnTrigger Item_Z_Fire_Effect:Stop::4:-10-1"
+;		"OnCase04" "Item_Relay_Z_FireAddOutputOnTrigger Item_Z_Fire_Trigger:Disable::4:-10-1"
+;		"OnCase04" "Item_Z_Fire_Trigger_lvl3AddOutputtargetname Item_Z_Fire_Trigger0-1"
+;	}
+;	insert:
+;	{
+;		"OnCase04" "Map_ScriptRunScriptCodeItemTextZFire(2);0-1"
+;		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(22);0-1"
+;		"OnCase04" "Item_Z_Fire_Effect_lvl2AddOutputtargetname Item_Z_Fire_Effect0-1"
+;		"OnCase04" "Item_Relay_Z_FireAddOutputOnTrigger Item_Z_Fire_Effect:Stop::3:-10-1"
+;		"OnCase04" "Item_Relay_Z_FireAddOutputOnTrigger Item_Z_Fire_Trigger:Disable::3:-10-1"
+;		"OnCase04" "Item_Z_Fire_Trigger_lvl2AddOutputtargetname Item_Z_Fire_Trigger0-1"
+;	}
+;}
 
 ;ZM Darkaga Level 3 -> Level 2
-modify:
-{
-	match:
-	{
-		"targetname" "Item_Z_Darkaga_Level_Case"
-		"classname" "logic_case"
-	}
-	delete:
-	{
-		"OnCase04" "Map_ScriptRunScriptCodeItemTextZGravity(3);0-1"
-		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(26);0-1"
-		"OnCase04" "Item_Relay_Z_DarkagaAddOutputOnTrigger Item_Z_Darkaga_Push:Disable::3:-10-1"
-		"OnCase04" "Item_Relay_Z_DarkagaAddOutputOnTrigger Item_Z_Darkaga_Effect:Stop::3.5:-10-1"
-	}
-	insert:
-	{
-		"OnCase04" "Map_ScriptRunScriptCodeItemTextZGravity(2);0-1"
-		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(25);0-1"
-		"OnCase04" "Item_Relay_Z_DarkagaAddOutputOnTrigger Item_Z_Darkaga_Push:Disable::2:-10-1"
-		"OnCase04" "Item_Relay_Z_DarkagaAddOutputOnTrigger Item_Z_Darkaga_Effect:Stop::2.5:-10-1"
-	}
-}
+;modify:
+;{
+;	match:
+;	{
+;		"targetname" "Item_Z_Darkaga_Level_Case"
+;		"classname" "logic_case"
+;	}
+;	delete:
+;	{
+;		"OnCase04" "Map_ScriptRunScriptCodeItemTextZGravity(3);0-1"
+;		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(26);0-1"
+;		"OnCase04" "Item_Relay_Z_DarkagaAddOutputOnTrigger Item_Z_Darkaga_Push:Disable::3:-10-1"
+;		"OnCase04" "Item_Relay_Z_DarkagaAddOutputOnTrigger Item_Z_Darkaga_Effect:Stop::3.5:-10-1"
+;	}
+;	insert:
+;	{
+;		"OnCase04" "Map_ScriptRunScriptCodeItemTextZGravity(2);0-1"
+;		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(25);0-1"
+;		"OnCase04" "Item_Relay_Z_DarkagaAddOutputOnTrigger Item_Z_Darkaga_Push:Disable::2:-10-1"
+;		"OnCase04" "Item_Relay_Z_DarkagaAddOutputOnTrigger Item_Z_Darkaga_Effect:Stop::2.5:-10-1"
+;	}
+;}
 
 ;ZM Warp Level 3 -> Level 2
-modify:
-{
-	match:
-	{
-		"targetname" "Item_Z_Warp_Level_Case"
-		"classname" "logic_case"
-	}
-	delete:
-	{
-		"OnCase04" "Map_ScriptRunScriptCodeItemTextZWarp(3);0-1"
-		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(29);0-1"
-		"OnCase04" "Item_Z_Warp_SpawnerAddOutputEntityTemplate Item_Z_Warp_Temp_lvl30-1"
-	}
-	insert:
-	{
-		"OnCase04" "Map_ScriptRunScriptCodeItemTextZWarp(2);0-1"
-		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(28);0-1"
-		"OnCase04" "Item_Z_Warp_SpawnerAddOutputEntityTemplate Item_Z_Warp_Temp_lvl20-1"
-	}
-}
+;modify:
+;{
+;	match:
+;	{
+;		"targetname" "Item_Z_Warp_Level_Case"
+;		"classname" "logic_case"
+;	}
+;	delete:
+;	{
+;		"OnCase04" "Map_ScriptRunScriptCodeItemTextZWarp(3);0-1"
+;		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(29);0-1"
+;		"OnCase04" "Item_Z_Warp_SpawnerAddOutputEntityTemplate Item_Z_Warp_Temp_lvl30-1"
+;	}
+;	insert:
+;	{
+;		"OnCase04" "Map_ScriptRunScriptCodeItemTextZWarp(2);0-1"
+;		"OnCase04" "Map_ScriptRunScriptCodeWorldGameText(28);0-1"
+;		"OnCase04" "Item_Z_Warp_SpawnerAddOutputEntityTemplate Item_Z_Warp_Temp_lvl20-1"
+;	}
+;}
 
 ;Fix TP avoidance spot
 modify:


### PR DESCRIPTION
The goal of this stripper is to bring back level 3 zm items on ridorana. The mappers had intended for level 3 zombie items to work this way, and is so on css and other servers. 

Does not make sense why we disable it because an older port disabled it just because they thought it was overpowered.

This PR comments out all the extra changes and brings it in line with the original css version as intended by the mappers.