### PR TITLE
Update deadcore entwatch

### DIFF
--- a/entwatch/ze_deadcore_k3.cfg
+++ b/entwatch/ze_deadcore_k3.cfg
@@ -14,9 +14,10 @@
 		"chat"				"true"
 		"hud"				"true"
 		"hammerid"			"609101"
-		"mode"				"2"
+		"mode"				"6"
 		"maxuses"			"0"
-		"cooldown"			"2"
+		"cooldown"			"12"
+		"mathid"			"609087"
 		"maxamount"			"3"
 	}
 	"1"
@@ -33,9 +34,10 @@
 		"chat"				"true"
 		"hud"				"true"
 		"hammerid"			"1259831"
-		"mode"				"2"
+		"mode"				"6"
 		"maxuses"			"0"
-		"cooldown"			"2"
+		"cooldown"			"12"
+		"mathid"			"1259817"
 		"maxamount"			"3"
 	}
 	"2"
@@ -52,9 +54,10 @@
 		"chat"				"true"
 		"hud"				"true"
 		"hammerid"			"1261070"
-		"mode"				"2"
+		"mode"				"6"
 		"maxuses"			"0"
-		"cooldown"			"2"
+		"cooldown"			"12"
+		"mathid"			"1261056"
 		"maxamount"			"3"
 	}
 }


### PR DESCRIPTION
Cannons operate on a rechargable math_counter. Rather than just showing `[+]`, it'd be cool to also show the charge level. Tested on DarkerZ's plugin although not too sure how it'd work on GFL's version of entwatch :shrug: