### PR TITLE
Update diverted destiny configs

### DIFF
--- a/entwatch/ze_diverted_destiny_c2f3.cfg
+++ b/entwatch/ze_diverted_destiny_c2f3.cfg
@@ -33,8 +33,8 @@
         "chat"              "true"
         "hud"               "true"
         "hammerid"          "327620"
-        "mode"              "2"
-        "maxuses"           "0"
+        "mode"              "4"
+        "maxuses"           "1"
         "cooldown"          "15"
         "maxamount"         "1"
     }

--- a/stripper/ze_diverted_destiny_c2f3.cfg
+++ b/stripper/ze_diverted_destiny_c2f3.cfg
@@ -1,0 +1,358 @@
+;stripper by koen (STEAM_1:1:114921174)
+
+;increase round time
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "svcmdCommandmp_roundtime 300-1"
+	}
+}
+
+;fix teleport avoidance spot at ball dodging platform
+add:
+{
+	"classname" "trigger_teleport"
+	"targetname" "tp12"
+	"target" "tp12_des"
+	"spawnflags" "1"
+	"StartDisabled" "1"
+	"origin" "-9131 6385 10144"
+	"model" "*169"
+}
+
+;fix zombies getting stuck in the floor after boss fight teleport
+modify:
+{
+	match:
+	{
+		"classname" "info_teleport_destination"
+		"origin" "-9648 5536 5136"
+	}
+	replace:
+	{
+		"origin" "-9648 5536 5148"
+	}
+}
+
+;prevent people from getting stuck in a tree
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "treestuck"
+	"StartDisabled" "0"
+	"spawnflags" "4097"
+	"origin" "-644 7621 384"
+	"model" "*78"
+	"rendermode" "10"
+	"OnStartTouch" "!activatorAddOutputorigin -652 7500 3720-1"
+}
+
+;antidelay to big room trigger
+add:
+{
+	"classname" "logic_relay"
+	"targetname" "antidelay"
+	"spawnflags" "0"
+	"StartDisabled" "0"
+	"OnTrigger" "autoslayTrigger90-1"
+}
+
+add:
+{
+	"classname" "logic_relay"
+	"targetname" "autoslay"
+	"spawnflags" "0"
+	"StartDisabled" "0"
+	"OnTrigger" "svcmdCommandsay ** You took too long to trigger... Slaying... **0-1"
+	"OnTrigger" "playerRunScriptCodeforeach(k,_ in{SetHealth=0}){if(self.GetTeam()==3&&self.GetHealth()>0)EntFireByHandle(self,k,(0).tostring(),0,null,null)}21"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_door_rotating"
+		"hammerid" "221074"
+	}
+	insert:
+	{
+		"OnOpen" "antidelayTrigger451"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "math_counter"
+		"targetname" "door2_counter"
+	}
+	insert:
+	{
+		"OnHitMax" "antidelayCancelPending01"
+	}
+}
+
+;fix autokiller chat spam
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "lastplatform_triggerhurt2"
+	}
+	delete:
+	{
+		"OnStartTouch" "svcmdCommandsay An autokiller has been prevented0-1"
+	}
+	insert:
+	{
+		"OnStartTouch" "svcmdCommandsay An autokiller has been prevented01"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "lastplatform_triggerhurt1"
+	}
+	delete:
+	{
+		"OnStartTouch" "svcmdCommandsay An autokill has been prevented0-1"
+	}
+	insert:
+	{
+		"OnStartTouch" "svcmdCommandsay An autokiller has been prevented01"
+	}
+}
+
+;fix chat messages not being detected by countdown plugin
+modify:
+{
+	match:
+	{
+		"classname" "func_door_rotating"
+		"hammerid" "221074"
+	}
+	delete:
+	{
+		"OnOpen" "svcmdCommandsay 4001"
+	}
+	insert:
+	{
+		"OnOpen" "svcmdCommandsay 40s01"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"hammerid" "247164"
+	}
+	delete:
+	{
+		"OnStartTouch" "svcmdCommandsay 3501"
+	}
+	insert:
+	{
+		"OnStartTouch" "svcmdCommandsay 35s01"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "math_counter"
+		"hammerid" "246410"
+	}
+	delete:
+	{
+		"OnHitMax" "svcmdCommandsay 1501"
+	}
+	insert:
+	{
+		"OnHitMax" "svcmdCommandsay 15s01"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_door_rotating"
+		"hammerid" "245770"
+	}
+	delete:
+	{
+		"OnOpen" "svcmdCommandsay Lift will rise in 3001"
+		"OnOpen" "svcmdCommandsay Zombies TP in 1001"
+	}
+	insert:
+	{
+		"OnOpen" "svcmdCommandsay Lift will rise in 30s01"
+		"OnOpen" "svcmdCommandsay Zombies TP in 10s01"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"hammerid" "247422"
+	}
+	delete:
+	{
+		"OnStartTouch" "svcmdCommandsay 2001"
+	}
+	insert:
+	{
+		"OnStartTouch" "svcmdCommandsay 20s01"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_door_rotating"
+		"hammerid" "218329"
+	}
+	delete:
+	{
+		"OnOpen" "svcmdCommandsay 2001"
+	}
+	insert:
+	{
+		"OnOpen" "svcmdCommandsay 20s01"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "math_counter"
+		"hammerid" "374784"
+	}
+	delete:
+	{
+		"OnHitMax" "svcmdCommandsay 150-1"
+	}
+	insert:
+	{
+		"OnHitMax" "svcmdCommandsay 15s0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"hammerid" "247232"
+	}
+	delete:
+	{
+		"OnStartTouch" "svcmdCommandsay 2501"
+	}
+	insert:
+	{
+		"OnStartTouch" "svcmdCommandsay 25s01"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_door_rotating"
+		"hammerid" "244644"
+	}
+	delete:
+	{
+		"OnOpen" "svcmdCommandsay 2001"
+	}
+	insert:
+	{
+		"OnOpen" "svcmdCommandsay 20s01"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"hammerid" "244904"
+	}
+	delete:
+	{
+		"OnStartTouch" "svcmdCommandsay 2001"
+	}
+	insert:
+	{
+		"OnStartTouch" "svcmdCommandsay 20s01"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "246484"
+	}
+	delete:
+	{
+		"OnStartTouch" "svcmdCommandsay 6001"
+	}
+	insert:
+	{
+		"OnStartTouch" "svcmdCommandsay 60s01"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"hammerid" "246551"
+	}
+	delete:
+	{
+		"OnStartTouch" "svcmdCommandsay 3001"
+	}
+	insert:
+	{
+		"OnStartTouch" "svcmdCommandsay 30s01"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "math_counter"
+		"hammerid" "244546"
+	}
+	delete:
+	{
+		"OnHitMax" "svcmdCommandsay 3001"
+	}
+	insert:
+	{
+		"OnHitMax" "svcmdCommandsay 30s01"
+	}
+}

--- a/stripper/ze_diverted_destiny_c2f3.cfg
+++ b/stripper/ze_diverted_destiny_c2f3.cfg
@@ -19,7 +19,7 @@ modify:
 	}
 	replace:
 	{
-		"damage" "2500"
+		"damage" "4000"
 	}
 }
 
@@ -65,14 +65,11 @@ modify:
 ;prevent people from getting stuck in a tree
 add:
 {
-	"classname" "trigger_multiple"
-	"targetname" "treestuck"
-	"StartDisabled" "0"
+	"classname" "func_wall_toggle"
 	"spawnflags" "4097"
 	"origin" "-644 7621 384"
 	"model" "*78"
 	"rendermode" "10"
-	"OnStartTouch" "!activatorAddOutputorigin -652 7500 3720-1"
 }
 
 ;antidelay to big room trigger

--- a/stripper/ze_diverted_destiny_c2f3.cfg
+++ b/stripper/ze_diverted_destiny_c2f3.cfg
@@ -1,18 +1,5 @@
 ;stripper by koen (STEAM_1:1:114921174)
 
-;increase round time
-modify:
-{
-	match:
-	{
-		"classname" "logic_auto"
-	}
-	insert:
-	{
-		"OnMapSpawn" "svcmdCommandmp_roundtime 300-1"
-	}
-}
-
 ;fix teleport avoidance spot at ball dodging platform
 add:
 {
@@ -35,7 +22,20 @@ modify:
 	}
 	replace:
 	{
-		"origin" "-9648 5536 5148"
+		"origin" "-9648 5536 5196"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "info_teleport_destination"
+		"origin" "-8576 6560 5136"
+	}
+	replace:
+	{
+		"origin" "-8576 6560 5196"
 	}
 }
 

--- a/stripper/ze_diverted_destiny_c2f3.cfg
+++ b/stripper/ze_diverted_destiny_c2f3.cfg
@@ -1,5 +1,28 @@
 ;stripper by koen (STEAM_1:1:114921174)
 
+;remove broken trigger_hurt for solar flare
+filter:
+{
+	"classname" "trigger_hurt"
+	"targetname" "solarflare_item_h"
+	"hammerid" "328010"
+}
+
+;adjust solar flare damage to prevent repeat killer
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "solarflare_item_h"
+		"hammerid" "328019"
+	}
+	replace:
+	{
+		"damage" "2500"
+	}
+}
+
 ;fix teleport avoidance spot at ball dodging platform
 add:
 {

--- a/stripper/ze_diverted_destiny_c2f3.cfg
+++ b/stripper/ze_diverted_destiny_c2f3.cfg
@@ -19,7 +19,7 @@ modify:
 	}
 	replace:
 	{
-		"damage" "4000"
+		"damage" "2000"
 	}
 }
 

--- a/zombiereloaded/ze_diverted_destiny_c2f3.cfg
+++ b/zombiereloaded/ze_diverted_destiny_c2f3.cfg
@@ -1,0 +1,1 @@
+mp_roundtime 20

--- a/zombiereloaded/ze_diverted_destiny_c2f3.cfg
+++ b/zombiereloaded/ze_diverted_destiny_c2f3.cfg
@@ -1,1 +1,1 @@
-mp_roundtime 20
+mp_roundtime 25


### PR DESCRIPTION
Add stripper/diverted destiny
-> Remove duplicate broken solar flare trigger hurt
-> Adjusted solar flare damage to prevent repeat killer
-> Patch teleport avoidance spot on top of zm cage at final ball dodging platform
-> Fix zombies getting stuck in the floor
-> Fix players getting stuck in the tree
-> Added antidelay to big room trigger
-> Rephrased all timer messages so GFL's chat plugin can detect it

Updated entwatch/diverted destiny
-> Fix incorrect mode for solar flare

Added zombiereloaded/diverted destiny
-> Increased round time