### PR TITLE
Update cyberspace configs

### DIFF
--- a/bosshud/ze_cyberspace_v1.txt
+++ b/bosshud/ze_cyberspace_v1.txt
@@ -32,14 +32,12 @@
     }
     "5"
     {
-        "Type"              "breakable"
-        "BreakableName"     "c3_boss_counter"
+        "HP_counter"        "c3_boss_counter"
         "CustomText"        "Core"
     }
     "6"
     {
-        "Type"              "breakable"
-        "BreakableName"     "c3_end_boss_counter"
+        "HP_counter"        "c3_end_boss_counter"
         "CustomText"        "Protect System"
     }
 }

--- a/entwatch/ze_cyberspace_v1.cfg
+++ b/entwatch/ze_cyberspace_v1.cfg
@@ -93,7 +93,7 @@
         "hammerid"          "435183"
         "mode"              "2"
         "maxuses"           "0"
-        "cooldown"          "80"
+        "cooldown"          "70"
         "trigger"           "435185"
         "maxamount"         "1"
     }

--- a/stripper/ze_cyberspace_v1.cfg
+++ b/stripper/ze_cyberspace_v1.cfg
@@ -1,3 +1,16 @@
+;prevent the map from changing freezetime
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	delete:
+	{
+		"OnMapSpawn" "ScommandCommandmp_freezetime 00-1"
+	}
+}
+
 ;lazy way to patch stage 3 nuke avoidance spot(s)
 modify:
 {

--- a/stripper/ze_cyberspace_v1.cfg
+++ b/stripper/ze_cyberspace_v1.cfg
@@ -1,3 +1,17 @@
+;lazy way to patch stage 3 nuke avoidance spot(s)
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "c3_end_lv_change"
+	}
+	insert:
+	{
+		"OnTrigger" "playerRunScriptCodeforeach(k,_ in{SetHealth=0}){if(self.GetTeam()==2&&self.GetHealth()>0)EntFireByHandle(self,k,(0).tostring(),0,null,null)}101"
+	}
+}
+
 ;Fixed version text
 modify:
 {

--- a/stripper/ze_cyberspace_v1.cfg
+++ b/stripper/ze_cyberspace_v1.cfg
@@ -21,7 +21,7 @@ modify:
 	}
 	insert:
 	{
-		"OnTrigger" "playerRunScriptCodelocal pos=self.GetOrigin();foreach(k,_ in{SetHealth=0}){if(pos.x>-9184)EntFireByHandle(self,k,(0).tostring(),0,null,null)}10-1"
+		"OnTrigger" "playerRunScriptCodelocal pos=self.GetOrigin();foreach(k,_ in{SetHealth=0}){if(pos.x>-9184)EntFireByHandle(self,k,(0).tostring(),0,null,null)}101"
 	}
 }
 

--- a/stripper/ze_cyberspace_v1.cfg
+++ b/stripper/ze_cyberspace_v1.cfg
@@ -21,7 +21,7 @@ modify:
 	}
 	insert:
 	{
-		"OnTrigger" "playerRunScriptCodeforeach(k,_ in{SetHealth=0}){if(self.GetTeam()==2&&self.GetHealth()>0)EntFireByHandle(self,k,(0).tostring(),0,null,null)}101"
+		"OnTrigger" "playerRunScriptCodelocal pos=self.GetOrigin();foreach(k,_ in{SetHealth=0}){if(pos.x>-9184)EntFireByHandle(self,k,(0).tostring(),0,null,null)}10-1"
 	}
 }
 

--- a/zombiereloaded/ze_cyberspace_v1.cfg
+++ b/zombiereloaded/ze_cyberspace_v1.cfg
@@ -1,1 +1,0 @@
-mp_freezetime 5

--- a/zombiereloaded/ze_cyberspace_v1.cfg
+++ b/zombiereloaded/ze_cyberspace_v1.cfg
@@ -1,0 +1,1 @@
+mp_freezetime 5


### PR DESCRIPTION
Fixex maptesting issues. Yes, I am **100%** aware that the anti-delay change is stupid but I cannot find any plausible way to use either `game_zone_player` (no trigger with brush ID that will work) or using nutless script to check origin with how the map is laid out. If humans win, they will 100% touch this trigger when pushed up, so it is safe to assume zombies should already be killed when humans touch this trigger.