### PR TITLE
Fix heal button on temple raider

### DIFF
--- a/stripper/ze_temple_raider_kr1.cfg
+++ b/stripper/ze_temple_raider_kr1.cfg
@@ -1,3 +1,31 @@
+;fix heal not being useable if a player e-picks the button
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "Gun_Heal_Btn"
+	}
+	replace:
+	{
+		"wait" "1"
+		"spawnflags" "3073"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_elite"
+		"targetname" "Gun_Heal"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "Gun_Heal_Btn,Unlock,,0,1"
+	}
+}
+
 ;add stripper notice
 add:
 {

--- a/stripper/ze_temple_raider_kr1.cfg
+++ b/stripper/ze_temple_raider_kr1.cfg
@@ -1,4 +1,4 @@
-;fix heal not being useable if a player e-picks the button
+;rework heal cooldown system
 modify:
 {
 	match:
@@ -23,6 +23,20 @@ modify:
 	insert:
 	{
 		"OnPlayerPickup" "Gun_Heal_Btn,Unlock,,0,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "filter_activator_name"
+		"targetname" "Gun_Heal_Filter"
+	}
+	insert:
+	{
+		"OnPass" "Gun_Heal_Btn,Lock,,0,-1"
+		"OnPass" "Gun_Heal_Btn,Unlock,,50,-1"
 	}
 }
 


### PR DESCRIPTION
If a player attempts to e-pick heal and presses the button, it would be locked for 40 seconds before being pressable again. If the actual item user tries using heal afterwards, EntWatch will bug out and show it's used when the button was not pressed at all.

My solution is to:
1) Change the button wait time to 1 second
2) Lock the button by default and then unlocking it after the item is picked up