### PR TITLE
Final Person Standing

### DIFF
--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -5336,7 +5336,6 @@ modify:
 }
 
 ; Nerf "Predator" item jump ability height a little.
-
 modify:
 {
 	match:

--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -1,4 +1,4 @@
-; - - - - - - - - - - - - - - - - - - - - - - -
+; - - - - - - - - - - - - - - - - - - - - - - - 
 ; 				  ze Last Man Standing
 ; 				 Map version "p3" (CS:GO)
 ; - - - - - - - - - - - - - - - - - - - - - - -
@@ -20,119 +20,6 @@ modify:
 ; - - - - - - - - - - - - - - - - - - - - - - -
 ; Changes done by "Hichatu".
 ; - - - - - - - - - - - - - - - - - - - - - - -
-
-; Fix some Stage5 TP avoidance spots, move the trigger up a bit
-modify:
-{
-	match:
-	{
-		"targetname" "lms_fuckoffzombies"
-	}
-	replace:
-	{
-		"origin" "4608 -4608 13552"
-	}
-}
-
-; Nerf Predator jump height a little
-modify:
-{
-	match:
-	{
-		"targetname" "Zombie_Item_Predator_Jump"
-	}
-	delete:
-	{
-		"OnLessThan" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x, self.GetVelocity().y, 500));0-1"
-	}
-	insert:
-	{
-		"OnLessThan" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x, self.GetVelocity().y, 400));0-1"
-	}
-}
-
-; Fix dumb adminroom TP angles for my own convenience
-modify:
-{
-	match:
-	{
-		"targetname" "adminroomtp"
-	}
-	insert:
-	{
-		"OnStartTouch" "!activatorRunScriptCodeself.SetAngles(0,180,0)0-1"
-		"OnStartTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(0,0,0))0-1"
-	}
-}
-
-; We are going to remake the Teamwin Heli/Sacrifice endings
-; Delete the original condition for Heli ending
-modify:
-{
-	match:
-	{
-		"targetname" "stage_x_helicopter_6"
-		"classname" "path_track"
-	}
-	delete:
-	{
-		"OnPass" "Event_Status_Stage_x_helicopter_EscapesCompare0-1"
-	}
-}
-
-; We will base it on the amount of events completed throughout the map, when on Stage5
-; 10 to be specific
-add:
-{
-	"classname" "math_counter"
-	"targetname" "Stage5TeamwinEndingChooser"
-	"StartDisabled" "0"
-	"startvalue" "0"
-	"min" "0"
-	"max" "10"
-	"OnHitMax" "Case_Events_Stage_5InValuestage_x_helicopter_escapes1-1"
-}
-modify:
-{
-	match:
-	{
-		"targetname" "Case_Events_Stage_5"
-		"classname" "logic_case"
-	}
-	insert:
-	{
-		"OnCase01" "Stage5TeamwinEndingChooserAdd10-1"
-		"OnCase02" "Stage5TeamwinEndingChooserAdd10-1"
-		"OnCase03" "Stage5TeamwinEndingChooserAdd10-1"
-		"OnCase04" "Stage5TeamwinEndingChooserAdd10-1"
-		"OnCase05" "Stage5TeamwinEndingChooserAdd10-1"
-		"OnCase06" "Stage5TeamwinEndingChooserAdd10-1"
-		"OnCase07" "Stage5TeamwinEndingChooserAdd10-1"
-		"OnCase08" "Stage5TeamwinEndingChooserAdd10-1"
-		"OnCase09" "Stage5TeamwinEndingChooserAdd10-1"
-		"OnCase10" "Stage5TeamwinEndingChooserAdd10-1"
-		"OnCase11" "Stage5TeamwinEndingChooserAdd10-1"
-		"OnCase12" "Stage5TeamwinEndingChooserAdd10-1"
-		"OnCase13" "Stage5TeamwinEndingChooserAdd10-1"
-		"OnCase14" "Stage5TeamwinEndingChooserAdd10-1"
-		"OnCase15" "Stage5TeamwinEndingChooserAdd10-1"
-		"OnCase16" "Stage5TeamwinEndingChooserAdd10-1"
-	}
-}
-
-; Reset mech gravity after core is fully charged
-modify:
-{
-	match:
-	{
-		"classname" "logic_relay"
-		"targetname" "stage_5_top_relay_core_working"
-	}
-	insert:
-	{
-		"OnTrigger" "human_mech,AddOutput,gravity 1,0,-1"
-	}
-}
 
 ; Fix stage 2 skips in first room.
 add:
@@ -167,7 +54,127 @@ add:
 	"rendermode" "10"
 }
 
-; Fix possible skip with "Tank" on stage 4.
+; Fix admin room teleport angles.
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "adminroomtp"
+	}
+	replace:
+	{
+		"wait" "1e30"
+	}
+	insert:
+	{
+		"OnStartTouch" "!activatorRunScriptCodeself.SetAngles(0, 180, 0);-1"
+		"OnStartTouch" "!activatorRunScriptCodeself.SetVelocity(Vector());-1"
+	}
+}
+
+; Remake the "Team Win Ending".
+; Delete the original condition for the stage 1 helicopter ending.
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stage_x_helicopter_6"
+	}
+	delete:
+	{
+		"OnPass" "Event_Status_Stage_x_helicopter_EscapesCompare0-1"
+	}
+}
+
+filter:
+{
+	"classname" "logic_compare"
+	"targetname" "Event_Status_Stage_x_helicopter_Escapes"
+}
+
+; Base it on the amount of events completed throughout the map by humans, when on stage 5.
+; 10 events to be specific.
+add:
+{
+	"classname" "math_counter"
+	"targetname" "stage_5_teamwinending1"
+	"max" "10"
+	"OnHitMax" "!self,Kill,,,1"
+	"OnHitMax" "Case_Events_Stage_5,InValue,stage_x_helicopter_escapes,,1"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_case"
+		"targetname" "Case_Events_Stage_5"
+		"origin" "-4272 11224 -8552"
+	}
+	insert:
+	{
+		"OnCase01" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase02" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase03" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase04" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase05" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase06" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase07" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase08" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase09" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase10" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase11" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase12" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase13" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase14" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase15" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase16" "stage_5_teamwinending1,Add,1,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_case"
+		"targetname" "Case_Events_Stage_5"
+		"origin" "-4272 11240 -8552"
+	}
+	insert:
+	{
+		"OnCase01" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase02" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase03" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase04" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase05" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase06" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase07" "stage_5_teamwinending1,Add,1,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_case"
+		"targetname" "Case_Events_Stage_5"
+		"origin" "-4256 11256 -8552"
+	}
+	insert:
+	{
+		"OnCase09" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase10" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase11" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase13" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase14" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase15" "stage_5_teamwinending1,Add,1,,1"
+		"OnCase16" "stage_5_teamwinending1,Add,1,,1"
+	}
+}
+
+; Fix possible skip with "Tank" vehicle on stage 4.
 add:
 {
 	"classname" "func_brush"
@@ -224,7 +231,7 @@ add:
 	"parentname" "Weapon_PortalGun_Portal_1_Teleport"
 	"StartDisabled" "1"
 	"filtername" "Weapon_PortalGun_FixFilter_2"
-	"wait" ".01"
+	"wait" "1e30"
 	"OnStartTouch" "!activator,AddContext,player_portal_1:1,,-1"
 	"OnStartTouch" "Weapon_PortalGun_EnterPortalSound,FireUser1,,,-1"
 }
@@ -239,7 +246,7 @@ add:
 	"parentname" "Weapon_PortalGun_Portal_2_Teleport"
 	"StartDisabled" "1"
 	"filtername" "Weapon_PortalGun_FixFilter_1"
-	"wait" ".01"
+	"wait" "1e30"
 	"OnStartTouch" "!activator,AddContext,player_portal_2:1,,-1"
 	"OnStartTouch" "Weapon_PortalGun_EnterPortalSound,FireUser1,,,-1"
 }
@@ -296,325 +303,36 @@ modify:
 	}
 }
 
-; Move stage_4_trigger_end back some units so it no longer sticks out of the wall
-filter:
-{
-	"classname" "trigger_once"
-	"targetname" "stage_4_trigger_end"
-}
-add:
-{
-	"model" "*2"
-	"classname" "trigger_once"
-	"targetname" "stage_4_trigger_end"
-	"filtername" "team_filter_humans"
-	"origin" "11408 -9200 3504"
-	"spawnflags" "1"
-	"StartDisabled" "1"
-	"OnStartTouch" "Global_GameText_AnnouncementRunScriptCodesetMessage(9)0-1"
-	"OnStartTouch" "Vehicle_Fake_Helicopter_TrackTrain*FireUser111"
-	"OnStartTouch" "Event_Status_Stage_1_Tank_Reaches_EndFireUser10-1"
-	"OnStartTouch" "stage_x_end_rescue_helicopterTrigger401"
-	"OnStartTouch" "Global_GameText_AnnouncementFireUser40-1"
-	"OnTrigger" "stage_4_end_button*,Unlock,,,1"
-	"OnTrigger" "stage_4_end_button_protection,AddOutput,OnDamaged !self:FireUser1:::1,,1"
-}
-
-; New way of filtering the 1st nuke button on Stage4
-; Elegant names I know, makes it memorable
-add:
-{
-	"classname" "filter_activator_team"
-	"targetname" "ZMTRIGGERCUNTLORDSUPREME"
-	"Negated" "Allow entities that match criteria"
-	"filterteam" "2"
-	"OnPass" "ZOMBIESTRIGGEREDTrigger01"
-}
-add:
-{
-	"classname" "filter_activator_team"
-	"targetname" "HMTRIGGERCUNTLORDSUPREME"
-	"Negated" "Allow entities that match criteria"
-	"filterteam" "3"
-	"OnPass" "ZMTRIGGERCUNTLORDSUPREMEKill01"
-}
-
-; If zombies press first while unlocked, round is ended
-; If humans press first while unlocked, the other filter is killed, so zombies cannot press it and end the round
+; Fix buggy train on stage 4.
 modify:
 {
 	match:
 	{
-		"targetname" "stage_4_end_button"
-	}
-	insert:
-	{
-		"OnPressed" "ZMTRIGGERCUNTLORDSUPREMETestActivator01"
-		"OnPressed" "HMTRIGGERCUNTLORDSUPREMETestActivator01"
-	}
-}
-
-; A new way of unlocking the 1st nuke button on Stage4
-; Either humans get close and the button unlocks, or Ultralisk gets close and zombies can now press the button
-modify:
-{
-	match:
-	{
-		"targetname" "stage_x_ultralistk_path_6"
-	}
-	insert:
-	{
-		"OnPass" "stage_4_end_button*Unlock01"
-	}
-}
-
-; Stage4 train angle shittery
-modify:
-{
-	match:
-	{
-		"targetname" "Vehicle_Fake_Truck_Tracktrain1"
 		"classname" "func_tanktrain"
+		"targetname" "Vehicle_Fake_Truck_Tracktrain1"
 	}
 	replace:
 	{
 		"orientationtype" "1"
 	}
 }
+
 modify:
 {
 	match:
 	{
-		"targetname" "Vehicle_Fake_Truck_Path_Track_5"
 		"classname" "path_track"
+		"targetname" "Vehicle_Fake_Truck_Path_Track_5"
 	}
 	insert:
 	{
-		"OnPass" "!activatorRunScriptCodeself.SetAngles(0,180,0)01"
+		"OnPass" "!activator,AddOutput,angles 0 180,,1"
 	}
 }
 
 ; - - - - - - - - - - - - - - - - - - - - - - -
 ; 	Changes done by "iszaar".
 ; - - - - - - - - - - - - - - - - - - - - - - -
-
-; Particle and sprite crap
-add:
-{
-	"classname" "env_lightglow"
-	"targetname" "stage_5_stuff1"
-	"origin" "4609 -4610 12743"
-	"HorizontalGlowSize" "210"
-	"MaxDist" "7500"
-	"MinDist" "100"
-	"OuterMaxDist" "1200"
-	"rendercolor" "130 192 255"
-	"VerticalGlowSize" "120"
-	"GlowProxySize" "16"
-	"HDRColorScale" "0.5"
-}
-add:
-{
-	"classname" "env_lightglow"
-	"targetname" "stage_5_stuff1"
-	"origin" "-8704 -979.863 -4848"
-	"HorizontalGlowSize" "210"
-	"MaxDist" "11000"
-	"MinDist" "-1"
-	"OuterMaxDist" "1200"
-	"rendercolor" "130 192 255"
-	"VerticalGlowSize" "180"
-	"GlowProxySize" "16"
-	"HDRColorScale" "1"
-}
-add:
-{
-	"classname" "env_lightglow"
-	"targetname" "stage_5_stuff1"
-	"origin" "-8744 -13854 -14160"
-	"HorizontalGlowSize" "210"
-	"MaxDist" "27000"
-	"MinDist" "0"
-	"OuterMaxDist" "28000"
-	"rendercolor" "255 255 255"
-	"VerticalGlowSize" "180"
-	"GlowProxySize" "2"
-	"HDRColorScale" "0.5"
-}
-add:
-{
-	"classname" "env_lightglow"
-	"targetname" "stage_5_stuff1"
-	"origin" "-8750 -12393 -13824"
-	"HorizontalGlowSize" "210"
-	"MaxDist" "27000"
-	"MinDist" "7500"
-	"OuterMaxDist" "28000"
-	"rendercolor" "255 255 255"
-	"VerticalGlowSize" "180"
-	"GlowProxySize" "2"
-	"HDRColorScale" "0.5"
-}
-add:
-{
-	"classname" "env_lightglow"
-	"targetname" "stage_3_stuff1"
-	"origin" "2494 -10305 1520"
-	"HorizontalGlowSize" "120"
-	"MaxDist" "10000"
-	"MinDist" "1500"
-	"OuterMaxDist" "11000"
-	"rendercolor" "255 255 255"
-	"VerticalGlowSize" "60"
-	"GlowProxySize" "2"
-	"HDRColorScale" "0.5"
-}
-add:
-{
-	"targetname" "stage_5_stuff1"
-	"spawnflags" "1"
-	"scale" "40"
-	"rendermode" "7"
-	"renderfx" "0"
-	"rendercolor" "255 255 255"
-	"renderamt" "140"
-	"origin" "-8736 -13856 -13776"
-	"model" "sprites/glow.vmt"
-	"mindxlevel" "0"
-	"maxdxlevel" "0"
-	"HDRColorScale" "1.0"
-	"GlowProxySize" "10.0"
-	"framerate" "10.0"
-	"disablereceiveshadows" "0"
-	"classname" "env_sprite"
-}
-add:
-{
-	"targetname" "stage_5_stuff1"
-	"spawnflags" "1"
-	"scale" "40"
-	"rendermode" "7"
-	"renderfx" "0"
-	"rendercolor" "255 255 255"
-	"renderamt" "140"
-	"origin" "-8744 -13854 -14160"
-	"model" "sprites/glow.vmt"
-	"mindxlevel" "0"
-	"maxdxlevel" "0"
-	"HDRColorScale" "1.0"
-	"GlowProxySize" "10.0"
-	"framerate" "10.0"
-	"disablereceiveshadows" "0"
-	"classname" "env_sprite"
-}
-add:
-{
-	"targetname" "stage_5_stuff1"
-	"spawnflags" "1"
-	"scale" "40"
-	"renderfx" "0"
-	"rendercolor" "255 255 255"
-	"renderamt" "140"
-	"origin" "-8704 -979.863 -5248"
-	"model" "sprites/halo.vmt"
-	"rendermode" "7"
-	"mindxlevel" "0"
-	"maxdxlevel" "0"
-	"HDRColorScale" "1.0"
-	"GlowProxySize" "10.0"
-	"framerate" "10.0"
-	"disablereceiveshadows" "0"
-	"classname" "env_sprite"
-}
-
-; More particle and sprite crap
-add:
-{
-	"targetname" "SpriteTemplate1"
-	"origin" "4190 1239 -7422"
-	"spawnflags" "1"
-	"scale" "2"
-	"rendermode" "9"
-	"renderfx" "14"
-	"rendercolor" "216 205 180"
-	"renderamt" "200"
-	"model" "sprites/glow_test02.vmt"
-	"mindxlevel" "0"
-	"maxdxlevel" "0"
-	"HDRColorScale" ".5"
-	"GlowProxySize" "10"
-	"framerate" "10.0"
-	"disablereceiveshadows" "0"
-	"classname" "env_sprite"
-}
-add:
-{
-	"origin" "4190 1239 -7422"
-	"Template01" "SpriteTemplate1"
-	"targetname" "TemplateSystem1"
-	"spawnflags" "0"
-	"classname" "point_template"
-}
-modify:
-{
-	match:
-	{
-		"targetname" "Stage_Start_Stage_2"
-	}
-	insert:
-	{
-		"OnTrigger" "TemplateSystem1,AddOutput,origin 4894 1092 -6834,0,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,0.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin 4126 1092 -6834,1,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,1.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin 7686 4356 -7058,2,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,2.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin 6406 4356 -7058,3,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,3.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin 5126 4356 -7058,4,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,4.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin 3846 4356 -7058,5,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,5.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin 2566 4356 -7058,6,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,6.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin 1286 4356 -7058,7,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,7.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin 6 4356 -7058,8,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,8.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin -1274 4356 -7058,9,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,9.1,-1"
-	}
-}
-modify:
-{
-	match:
-	{
-		"targetname" "Stage_Start_Stage_4"
-	}
-	insert:
-	{
-		"OnTrigger" "TemplateSystem1,AddOutput,origin -9130 -8716 3959,0,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,0.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin -9818 -8716 3959,1,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,1.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin -8586 -8700 3959,2,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,2.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin -8058 -8700 3959,3,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,3.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin -7514 -8700 3959,4,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,4.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin -7514 -11132 3959,5,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,5.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin -8058 -11132 3959,6,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,6.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin -8586 -11132 3959,7,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,7.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin -9130 -11148 3959,8,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,8.1,-1"
-		"OnTrigger" "TemplateSystem1,AddOutput,origin -9818 -11148 3959,9,-1"
-		"OnTrigger" "TemplateSystem1,ForceSpawn,,9.1,-1"
-	}
-}
 
 ; Humans don't need to trigger this on extreme stage 1 but zombies can still trigger it.
 modify:
@@ -628,7 +346,7 @@ modify:
 	{
 		"OnPressed" "ZOMBIESTRIGGEREDRunScriptCodeprogressTrigger()01"
 	}
-}
+}	
 
 ; Remove the push for camping.
 filter:
@@ -648,12 +366,12 @@ modify:
 	insert:
 	{
 		"OnPass" "Global_GameText_Announcement,FireUser3,,,1"
-		"OnPass" "Global_GameText_Announcement,AddOutput,message ** ZOMBIES DETECTED! YOU LOSE! **,,1"
+		"OnPass" "Global_GameText_Announcement,SetText,** ZOMBIES DETECTED! YOU LOSE! **,,1"
 		"OnPass" "map1roundend1,EndRound_TerroristsWin,7,3,1"
 	}
 }
 
-; Open doors to prevent zombies being locked out on solo ending.
+; Open doors to prevent zombies being locked out on "Solo Ending".
 modify:
 {
 	match:
@@ -685,34 +403,7 @@ modify:
 	}
 }
 
-; Fix stage 2 last vent entrance being breakable early.
-modify:
-{
-	match:
-	{
-		"classname" "trigger_multiple"
-		"targetname" "stage_2_teleport_2"
-	}
-	insert:
-	{
-		"OnStartTouch" "stage_2_escape_vent,SetHealth,100,5,1"
-	}
-}
-
-modify:
-{
-	match:
-	{
-		"classname" "func_breakable"
-		"targetname" "stage_2_escape_vent"
-	}
-	replace:
-	{
-		"health" "0"
-	}
-}
-
-; Avoid delay on stage 5.
+; Avoid delaying on stage 5.
 modify:
 {
 	match:
@@ -722,8 +413,7 @@ modify:
 	}
 	insert:
 	{
-		"OnHitMax" "stage5_antidelay,Trigger,,,1"
-		"OnHitMax" "!self,Kill,,,1"
+		"OnHitMax" "stage_5_antidelay1,Trigger,,,1"
 	}
 }
 
@@ -731,53 +421,41 @@ modify:
 {
 	match:
 	{
-		"classname" "filter_activator_team"
-		"targetname" "stage_5_button_filter"
+		"classname" "func_button"
+		"targetname" "stage_5_lower_door_button_LIFT"
 	}
 	insert:
 	{
-		"OnPass" "stage5_antidelay,CancelPending,,,1"
+		"OnPressed" "stage_5_antidelay1,Kill,,,1"
+		"OnPressed" "stage_5_antidelay1,CancelPending,,,1"
 	}
 }
 
 add:
 {
 	"classname" "logic_relay"
-	"targetname" "stage5_antidelay"
+	"targetname" "stage_5_antidelay1"
 	"OnTrigger" "Global_GameText_Announcement,FireUser3,,6,1"
-	"OnTrigger" "Global_GameText_Announcement,AddOutput,message ** ACTIVATE THE ELEVATOR QUICKLY! (1/3) **,6,1"
+	"OnTrigger" "Global_GameText_Announcement,SetText,** ACTIVATE THE ELEVATOR QUICKLY! (1/3) **,5,1"
 	"OnTrigger" "Global_GameText_Announcement,FireUser3,,16,1"
-	"OnTrigger" "Global_GameText_Announcement,AddOutput,message ** ACTIVATE THE ELEVATOR QUICKLY! (2/3) **,16,1"
+	"OnTrigger" "Global_GameText_Announcement,SetText,** ACTIVATE THE ELEVATOR QUICKLY! (2/3) **,15,1"
 	"OnTrigger" "Global_GameText_Announcement,FireUser3,,26,1"
-	"OnTrigger" "Global_GameText_Announcement,AddOutput,message ** LAST WARNING! ACTIVATE THE ELEVATOR QUICKLY! (3/3) **,26,1"
-	"OnTrigger" "map1roundend1,EndRound_TerroristsWin,7,36,1"
-}
-
-add:
-{
-	"classname" "game_round_end"
-	"targetname" "map1roundend1"
-	"OnRoundEnded" "map1roundend1,Kill,,,1"
+	"OnTrigger" "Global_GameText_Announcement,SetText,** LAST WARNING! ACTIVATE THE ELEVATOR QUICKLY! (3/3) **,25,1"
+	"OnTrigger" "map1roundend1,EndRound_TerroristsWin,7,35,1"
 }
 
 ; Fix zombies being able to surf and stop stage 2 from being completed, only really doable with high air acceleration but just incase.
 add:
 {
-	"classname" "filter_activator_team"
-	"targetname" "team_filter_stage2water_human"
-	"filterteam" "3"
-}
-
-modify:
-{
-	match:
-	{
-		"targetname" "stage_2_hurt_water"
-	}
-	replace:
-	{
-		"filtername" "team_filter_stage2water_human"
-	}
+	"classname" "trigger_multiple"
+	"targetname" "stage_2_antistrafe1"
+	"origin" "4608 -7232 -8864"
+	"spawnflags" "1"
+	"model" "*613"
+	"StartDisabled" "1"
+	"filtername" "team_filter_zombies"
+	"wait" "1e30"
+	"OnStartTouch" "!activatorRunScriptCodeif (self.GetTeam() == 2) self.SetVelocity(Vector(0, 0, self.GetVelocity().z));-1"
 }
 
 modify:
@@ -789,8 +467,7 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "team_filter_stage2water_human,Kill,,,1"
-		"OnStartTouch" "stage_2_hurt_water,AddOutput,damage 5000,,1"
+		"OnTrigger" "stage_2_antistrafe1,Enable,,1,1"
 	}
 }
 
@@ -808,26 +485,13 @@ modify:
 	}
 }
 
-; Stage 5 lower delay on the buttons on top.
+; Lower delay on the buttons on top of stage 5.
 modify:
 {
 	match:
 	{
 		"classname" "func_button"
-		"targetname" "stage_5_end_button_blue"
-	}
-	replace:
-	{
-		"wait" ".01"
-	}
-}
-
-modify:
-{
-	match:
-	{
-		"classname" "func_button"
-		"targetname" "stage_5_end_button_red"
+		"targetname" "/stage_x_end_button_(blue|red)/"
 	}
 	replace:
 	{
@@ -845,9 +509,10 @@ modify:
 	}
 	insert:
 	{
-		"OnUser1" "stage4_nuke_broke,Enable,,,1"
+		"OnUser1" "stage_4_nuke_broke,Enable,,,1"
 	}
 }
+
 modify:
 {
 	match:
@@ -857,24 +522,24 @@ modify:
 	}
 	insert:
 	{
-		"OnPass" "stage4_nuke_broke,Trigger,,,1"
+		"OnPass" "stage_4_nuke_broke,Trigger,,,1"
 	}
 }
 
 add:
 {
 	"classname" "logic_relay"
-	"targetname" "stage4_nuke_broke"
+	"targetname" "stage_4_nuke_broke"
 	"spawnflags" "1"
 	"StartDisabled" "1"
 	"OnTrigger" "Global_GameText_Announcement,FireUser3,,2,1"
-	"OnTrigger" "Global_GameText_Announcement,AddOutput,message ** THE NUKE FAILED! **,2,1"
+	"OnTrigger" "Global_GameText_Announcement,SetText,** THE NUKE FAILED! **,2,1"
 	"OnTrigger" "Global_GameText_Announcement,FireUser3,,8,1"
-	"OnTrigger" "Global_GameText_Announcement,AddOutput,message ** THE ULTRALISK IS STILL ALIVE HOPE WE DON'T HAVE TO MEET HIM AGAIN... **,8,1"
+	"OnTrigger" "Global_GameText_Announcement,SetText,** THE ULTRALISK IS STILL ALIVE HOPE WE DON'T HAVE TO MEET HIM AGAIN... **,8,1"
 	"OnTrigger" "stage_end_explosion_working,Trigger,,10,1"
 }
 
-; Nerf "Antlion", this was done due to it being overpowered if you know what to do.
+; Nerf "Antlion" item, this was done due to it being overpowered if you know what to do.
 modify:
 {
 	match:
@@ -892,7 +557,7 @@ modify:
 	}
 }
 
-; Move stage 1 "Vortigaunt" item to let you get past easier with "Tank".
+; Move stage 1 "Vortigaunt" item spawn place to let you get past easier with "Tank" vehicle.
 modify:
 {
 	match:
@@ -906,9 +571,9 @@ modify:
 	}
 	insert:
 	{
-		"OnTrigger" "Zombie_Item_Vortigaunt_Template,AddOutput,origin 7886 3108 -13662,,-1"
+		"OnTrigger" "Zombie_Item_Vortigaunt_Template,SetLocalOrigin,7886 3108 -13662,,-1"
 	}
-}
+}	
 
 ; Fix boost on stage 5 with core.
 modify:
@@ -920,7 +585,7 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "!activatorRunScriptCodeself.SetVelocity(Vector(0, 0, self.GetVelocity().z));-1"
+		"OnStartTouch" "!activatorRunScriptCodeself.SetVelocity(Vector());-1"
 	}
 }
 
@@ -938,7 +603,7 @@ modify:
 	}
 }
 
-; Fix the helicopter shitting itself due to the added skybox.
+; Fix the helicopter path due to the added skybox.
 modify:
 {
 	match:
@@ -991,6 +656,7 @@ add:
 	"holdtime" ".75"
 	"duration" ".5"
 }
+
 modify:
 {
 	match:
@@ -1003,6 +669,7 @@ modify:
 		"OnPressed" "stage_3_fade1,Fade,,5,1"
 	}
 }
+
 modify:
 {
 	match:
@@ -1012,33 +679,8 @@ modify:
 	}
 	insert:
 	{
+		"OnUser1" "stage_3_fade1,Kill,,19,-1"
 		"OnUser1" "stage_3_fade1,Fade,,19,-1"
-	}
-}
-
-; make this open for dramatic effect stage 3 boss escape
-modify:
-{
-	match:
-	{
-		"targetname" "stage_3_boos_end_door"
-	}
-	replace:
-	{
-		"spawnpos" "0"
-		"speed" "20"
-	}
-}
-modify:
-{
-	match:
-	{
-		"targetname" "stage_x_end_vehicle_escape_track_1"
-	}
-	insert:
-	{
-		"OnPass" "stage_3_boos_end_door,Open,,0,1"
-		"OnPass" "stage_3_boos_end_door,Open,,0,1"
 	}
 }
 
@@ -1053,26 +695,444 @@ modify:
 	replace:
 	{
 		"renderamt" "254"
-	}
+	}	
 	insert:
 	{
 		"rendermode" "2"
 		"renderfx" "14"
 	}
 }
+
+; Special effects.
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_3_stuff1"
+	"origin" "2494 -10305 1520"
+	"spawnflags" "1"
+	"model" "sprites/glow04.vmt"
+	"scale" "30"
+	"rendermode" "7"
+	"renderamt" "140"
+	"GlowProxySize" "10"
+	"HDRColorScale" "1"
+}
+
 add:
 {
 	"classname" "env_sprite"
 	"targetname" "stage_5_stuff1"
-	"origin" "-8704 -979.863 -5248"
+	"origin" "-8704 -980 -5248"
 	"spawnflags" "1"
 	"model" "sprites/halo.vmt"
 	"scale" "40"
-	"rendercolor" "255 255 255"
 	"renderamt" "140"
 	"rendermode" "7"
 	"GlowProxySize" "10"
 	"HDRColorScale" "1"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_5_stuff1"
+	"origin" "-8744 -13854 -14160"
+	"spawnflags" "1"
+	"model" "sprites/glow.vmt"
+	"scale" "40"
+	"rendermode" "7"
+	"renderamt" "140"
+	"HDRColorScale" "1"
+	"GlowProxySize" "10"
+}
+
+; Light sprites.
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_2_stuff1"
+	"origin" "4894 1092 -6834"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_2_stuff1"
+	"origin" "4126 1092 -6834"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_2_stuff1"
+	"origin" "7686 4356 -7058"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_2_stuff1"
+	"origin" "6406 4356 -7058"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_2_stuff1"
+	"origin" "5126 4356 -7058"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_2_stuff1"
+	"origin" "3846 4356 -7058"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_2_stuff1"
+	"origin" "2566 4356 -7058"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_2_stuff1"
+	"origin" "1286 4356 -7058"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_2_stuff1"
+	"origin" "6 4356 -7058"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_2_stuff1"
+	"origin" "-1274 4356 -7058"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_4_stuff1"
+	"origin" "-9130 -8716 3959"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_4_stuff1"
+	"origin" "-9818 -8716 3959"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_4_stuff1"
+	"origin" "-8586 -8700 3959"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_4_stuff1"
+	"origin" "-8058 -8700 3959"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_4_stuff1"
+	"origin" "-7514 -8700 3959"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_4_stuff1"
+	"origin" "-7514 -11132 3959"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_4_stuff1"
+	"origin" "-8058 -11132 3959"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_4_stuff1"
+	"origin" "-8586 -11132 3959"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_4_stuff1"
+	"origin" "-9130 -11148 3959"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add:
+{
+	"classname" "env_sprite"
+	"targetname" "stage_4_stuff1"
+	"origin" "-9818 -11148 3959"
+	"spawnflags" "1"
+	"model" "sprites/glow_test02.vmt"
+	"scale" "2"
+	"rendermode" "9"
+	"renderfx" "14"
+	"rendercolor" "216 205 180"
+	"renderamt" "200"
+	"HDRColorScale" ".5"
+	"GlowProxySize" "10"
+}
+
+add: 
+{
+	"classname" "env_lightglow"
+	"targetname" "stage_3_stuff1"
+	"origin" "2494 -10305 1520"
+	"HorizontalGlowSize" "210"
+	"MaxDist" "10000"
+	"OuterMaxDist" "11000"
+	"VerticalGlowSize" "180"
+	"GlowProxySize" "64"
+	"HDRColorScale" "4"
+}
+
+add: 
+{
+	"classname" "env_lightglow"
+	"targetname" "stage_5_stuff1"
+	"origin" "4609 -4610 12743"
+	"HorizontalGlowSize" "210"
+	"MinDist" "100"
+	"MaxDist" "7500"
+	"OuterMaxDist" "1200"
+	"rendercolor" "130 192 255"
+	"VerticalGlowSize" "180"
+	"GlowProxySize" "32"
+	"HDRColorScale" "2"
+}
+
+add: 
+{
+	"classname" "env_lightglow"
+	"targetname" "stage_5_stuff1"
+	"origin" "-8704 -980 -4848"
+	"HorizontalGlowSize" "210"
+	"MaxDist" "11000"
+	"OuterMaxDist" "1200"
+	"rendercolor" "130 192 255"
+	"VerticalGlowSize" "180"
+	"GlowProxySize" "32"
+	"HDRColorScale" "2"
+}
+
+add: 
+{
+	"classname" "env_lightglow"
+	"targetname" "stage_5_stuff1"
+	"origin" "-8744 -13854 -14160"
+	"HorizontalGlowSize" "210"
+	"MaxDist" "27000"
+	"OuterMaxDist" "28000"
+	"VerticalGlowSize" "180"
+	"GlowProxySize" "64"
+	"HDRColorScale" "4"
+}
+
+add: 
+{
+	"classname" "env_lightglow"
+	"targetname" "stage_5_stuff1"
+	"origin" "-8750 -12393 -13824"
+	"HorizontalGlowSize" "210"
+	"MaxDist" "27000"
+	"OuterMaxDist" "28000"
+	"VerticalGlowSize" "180"
+	"GlowProxySize" "64"
+	"HDRColorScale" "4"
 }
 
 ; - - - - - - - - - - - - - - - - - - - - - - -
@@ -1082,7 +1142,7 @@ add:
 ; Fix spawn trigger not resetting players and make it teleport faster.
 filter:
 {
-	"classname" "trigger_multiple"
+	"classname" "trigger_teleport"
 	"targetname" "teleporter_main_trigger_positioner"
 }
 
@@ -1090,21 +1150,35 @@ modify:
 {
 	match:
 	{
-		"classname" "trigger_teleport"
+		"classname" "trigger_multiple"
 		"targetname" "teleporter_main_trigger_positioner"
 	}
 	replace:
 	{
 		"origin" "-3488 9376 -8528"
+		"wait" "1e30"
 	}
 	delete:
 	{
-		"model" "*684"
+		"model" "*273"
+		"filtername" "Z_Items_Filter_Name"
+		"OnStartTouch" "!activatorAddOutputtargetname 0-1"
+		"OnStartTouch" "!activatorAddOutputgravity 10-1"
+		"OnStartTouch" "!activatorAddOutputOnUser2 filter_player_killer:TestActivator::5:10-1"
+		"OnStartTouch" "!activatorAddOutputOnUser3 !self:AddOutput:health 1200:0:10-1"
+		"OnStartTouch" "!activatorAddOutputrendermode 00-1"
+		"OnStartTouch" "!activatorAddOutputgravity 10-1"
+		"OnUser1" "!activatorAddOutputOnUser3 !self:AddOutput:health 10000:0.1:10-1"
+		"OnStartTouch" "!activatorAddOutputrenderfx 00-1"
+		"OnStartTouch" "stage_end_explosion_workingTrigger5401"
+		"OnStartTouch" "!activatorSetDamageFilter0-1"
+		"OnStartTouch" "!activatorClearContext0-1"
+		"OnStartTouch" "Global_Speed_suppressModifySpeed10-1"
 	}
 	insert:
 	{
+		"OnStartTouch" "Z_Items_Filter_Name,TestActivator,,,-1"
 		"OnStartTouch" "stage_end_explosion_working,Trigger,,540,1"
-		"OnStartTouch" "Z_Items_Filter,TestActivator,,,-1"
 	}
 }
 
@@ -1112,8 +1186,71 @@ modify:
 {
 	match:
 	{
-		"classname" "filter_multi"
-		"targetname" "Z_Items_Filter"
+		"classname" "logic_case"
+		"targetname" "/teleporter_main_counter_case_[1-4]/"
+	}
+	insert:
+	{
+		"OnCase01" "stages_teleport_destination,TeleportToCurrentPos,,,-1"
+		"OnCase02" "stages_teleport_destination,TeleportToCurrentPos,,,-1"
+		"OnCase03" "stages_teleport_destination,TeleportToCurrentPos,,,-1"
+		"OnCase04" "stages_teleport_destination,TeleportToCurrentPos,,,-1"
+		"OnCase05" "stages_teleport_destination,TeleportToCurrentPos,,,-1"
+		"OnCase06" "stages_teleport_destination,TeleportToCurrentPos,,,-1"
+		"OnCase07" "stages_teleport_destination,TeleportToCurrentPos,,,-1"
+		"OnCase08" "stages_teleport_destination,TeleportToCurrentPos,,,-1"
+		"OnCase09" "stages_teleport_destination,TeleportToCurrentPos,,,-1"
+		"OnCase10" "stages_teleport_destination,TeleportToCurrentPos,,,-1"
+		"OnCase11" "stages_teleport_destination,TeleportToCurrentPos,,,-1"
+		"OnCase12" "stages_teleport_destination,TeleportToCurrentPos,,,-1"
+		"OnCase13" "stages_teleport_destination,TeleportToCurrentPos,,,-1"
+		"OnCase14" "stages_teleport_destination,TeleportToCurrentPos,,,-1"
+		"OnCase15" "stages_teleport_destination,TeleportToCurrentPos,,,-1"
+		"OnCase16" "stages_teleport_destination,TeleportToCurrentPos,,,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "math_counter"
+		"targetname" "teleporter_main_counter"
+	}
+	replace:
+	{
+		"startvalue" "0"
+		"min" "0"
+	}
+	insert:
+	{
+		"OnHitMax" "!self,SetValue,0,,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "info_teleport_destination"
+		"targetname" "stages_teleport_destination"
+	}
+	replace:
+	{
+		"classname" "point_teleport"
+	}
+	insert:
+	{
+		"target" "!activator"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "filter_activator_name"
+		"targetname" "Z_Items_Filter_Name"
 	}
 	insert:
 	{
@@ -1122,11 +1259,10 @@ modify:
 		"OnPass" "!activator,AddOutput,OnUser3 !self:AddOutput:health 1200::1,.01,-1"
 		"OnPass" "!activator,AddOutput,rendermode 0,,-1"
 		"OnPass" "!activator,AddOutput,renderfx 0,,-1"
+		"OnPass" "!activator,AddOutput,renderamt 255,,-1"
 		"OnPass" "!activator,SetDamageFilter,,,-1"
 		"OnPass" "!activator,ClearContext,,,-1"
-		"OnPass" "teleporter_main_counter,Add,1,,-1"
 		"OnPass" "Global_Speed_suppress,ModifySpeed,1,,-1"
-		"OnPass" "stage_5_top_teleport_counter,Add,1,,-1"
 		"OnUser1" "!activator,AddOutput,OnUser3 !self:AddOutput:health 10000::1,,-1"
 	}
 }
@@ -1144,7 +1280,7 @@ modify:
 	}
 	insert:
 	{
-		"OnTrigger" "Z_Items_Filter,AddOutput,OnPass !self:FireUser1:::-1,,1"
+		"OnTrigger" "Z_Items_Filter_Name,AddOutput,OnPass !self:FireUser1:::-1,,1"
 	}
 }
 
@@ -1174,7 +1310,7 @@ modify:
 		"spawnflags" "8"
 		"movedir" "-90 0 0"
 		"speed" "1500"
-		"movedistance" "96"
+		"movedistance" "288"
 	}
 	insert:
 	{
@@ -1196,7 +1332,7 @@ modify:
 	}
 }
 
-; Add props to get out of a stuck spot near "Tank" spawn on extreme stage 1.
+; Add props to get out of a stuck spot near "Tank" vehicle spawn on extreme stage 1.
 add:
 {
 	"classname" "prop_dynamic"
@@ -1205,6 +1341,7 @@ add:
 	"angles" "0 -15 0"
 	"model" "models/props/props_crates/wooden_crate_64x64.mdl"
 	"solid" "6"
+	"disableshadows" "1"
 }
 
 add:
@@ -1214,6 +1351,7 @@ add:
 	"origin" "2368 320 -13608"
 	"model" "models/props/props_crates/wooden_crate_64x64.mdl"
 	"solid" "6"
+	"disableshadows" "1"
 }
 
 add:
@@ -1224,9 +1362,16 @@ add:
 	"angles" "-10 0 0"
 	"model" "models/props/de_nuke/crate_large.mdl"
 	"solid" "6"
+	"disableshadows" "1"
 }
 
 ; Add viewcontrol template related outputs, filter stage 1 "Juggernaut" trigger to humans, reset targetnames and prevent viewmodel from being glitched out.
+filter:
+{
+	"classname" "logic_auto"
+	"origin" "-2984 13152 -8552"
+}
+
 modify:
 {
 	match:
@@ -1238,23 +1383,92 @@ modify:
 	{
 		"spawnflags" "1"
 	}
+	delete:
+	{
+		"targetname" "Auto"
+		"OnSpawn" "playerAddOutputtargetname nodriver0.05-1"
+	}
 	insert:
 	{
-		"OnSpawn" "map1viewcontrolpreservedtemplate1,ForceSpawn,,.01,1"
-		"OnSpawn" "map1viewcontroltemplate1,Kill,,.01,1"
+		"OnSpawn" "worldspawn_brush,FireUser1,,,1"
+		"OnSpawn" "Stages_Start_Fade,Fade,,,1"
+		"OnSpawn" "Human_Item_Mech_RightArm,SetParentAttachment,RightArm,,1"
+		"OnSpawn" "Human_Item_Mech_Left_Arm,SetParentAttachment,LeftArm,,1"
+		"OnSpawn" "console,FireUser1,,,1"
+		"OnSpawn" "stage_x_saw_rotating,FireUser1,,,1"
+		"OnSpawn" "correction2,Disable,,,1"
+		"OnSpawn" "correction,Disable,,,1"
+		"OnSpawn" "Tonemap,FireUser1,,,-1"
+		"OnSpawn" "consolaCliall,FireUser1,,,1"
+		"OnSpawn" "Sun,FireUser1,,,1"
+		"OnSpawn" "console,Command,zr_infect_mzombie_ratio 6,,1"
 		"OnSpawn" "worldspawn_brush_target,FireUser2,,,1"
 		"OnSpawn" "stage_x_crane_breakableRunScriptCodefunction InputUse() { return activator.GetTeam() == 3; }1"
 		"OnSpawn" "stage_x_crane_crateRunScriptCodefunction InputUse() { return activator.GetTeam() == 3; }1"
 		"OnSpawn" "player,AddOutput,targetname ,,1"
-		"OnSpawn" "playerRunScriptCodeif (self.GetName() == _.zombie_boss || self.GetName() == _.human_mech) EntFireByHandle(caller, _.FireUser1, __, 0, self, null);1"
-		"OnSpawn" "!selfRunScriptCode::_ <- delegate { function _get(strKey) { return strKey; } } : {};1"
-		"OnSpawn" "!selfRunScriptCode::__ <- ' '.tochar();1"
-		"OnUser1" "Map_End_Camera,RemovePlayer,,,1"
-		"OnUser1" "Map_End_Camera,AddPlayer,,,1"
+		"OnSpawn" "playerRunScriptCodeif (self.GetName() == _.zombie_boss || self.GetName() == _.human_mech) EntFireByHandle(Entities.FindByName(null, _.game_playerdie), _.FireUser1, __, -1, self, null);1"
+		"OnSpawn" "map1manager1,CallScriptFunction,RoundSpawn,,1"
+		"OnSpawn" "map1viewcontrolpreservedtemplate1,ForceSpawn,,.01,1"
+		"OnSpawn" "map1viewcontroltemplate1,Kill,,.01,1"
+		"OnSpawn" "Level_Counter,GetValue,,.02,1"
+		"OnSpawn" "stage_flame_particle,Start,,2,1"
+		"OnSpawn" "Mode_Extreme_Compare,FireUser1,,3,1"
+		"OnSpawn" "console,Command,say ++ MAP BY HANNIBAL[SPA] / Rafuron ++,3,1"
+		"OnSpawn" "Mode_Extreme_Counter,Add,1,3.1,1"
+		"OnSpawn" "console,Command,say ++ MAP BY HANNIBAL[SPA] / Rafuron ++,4,1"
+		"OnSpawn" "console,Command,say ++ MAP BY HANNIBAL[SPA] / Rafuron ++,5,1"
+		"OnSpawn" "console,Command,say ++ MAP FIXED BY STRUPPI ++,7,1"
+		"OnSpawn" "console,Command,say ++ Thanks to George and Sgt. zuff ++,8,1"
+		"OnSpawn" "console,Command,say ++ Type ''!showmapstats'' to see the events you completed and damage dealt to zombies on stage 5. ++,9,1"
+		"OnSpawn" "console,Command,say ++ They increase your chance to be chosen for the solo ending. ++,10,1"
+		"OnSpawn" "v_button1,Unlock,,10,1"
+		"OnSpawn" "teleporter_main_trigger_positioner,AddOutput,OnStartTouch stages_teleport_destination:TeleportToCurrentPos:::-1,20,1"
+		"OnSpawn" "teleporter_main_counter*,Kill,,20,1"
 	}
 }
 
-; Optional: Prevent the "Portal Gun" skip.
+; Reduce stage 2 car generator movelinear speed slightly to prevent console error.
+modify:
+{
+	match:
+	{
+		"classname" "func_movelinear"
+		"targetname" "Spawn_Phy_Car_Generator_Movelinear"
+	}
+	replace:
+	{
+		"speed" "1900"
+	}
+}
+
+; Fix stage 2 last vent entrance being breakable early.
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "stage_2_teleport_2"
+	}
+	insert:
+	{
+		"OnStartTouch" "stage_2_escape_vent,SetHealth,100,10,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_breakable"
+		"targetname" "stage_2_escape_vent"
+	}
+	replace:
+	{
+		"health" "0"
+	}
+}
+
+; Optional: Prevent "Portal Gun" item skips.
 ;modify:
 ;{
 ;	match:
@@ -1281,7 +1495,7 @@ modify:
 ;	}
 ;}
 
-; Fix stage 2 last vent fall breaking despite second room being "Mutator Test".
+; Fix stage 2 last vent fall breaking despite second room being "Mutator Test" and fix pressing the buttons when room isn't selected.
 modify:
 {
 	match:
@@ -1291,10 +1505,48 @@ modify:
 	}
 	insert:
 	{
+		"OnCase01" "stage_2_main_room_second_button_next,Unlock,,,1"
+		"OnCase01" "stage_2_main_room_second_button_nextRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
+		"OnCase01" "stage_2_main_room_button_next,Kill,,,1"
+		"OnCase03" "stage_2_main_room_button_next,Unlock,,,1"
+		"OnCase03" "stage_2_main_room_button_nextRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
+		"OnCase03" "stage_2_main_room_second_button_next,Kill,,,1"
 		"OnCase03" "stage_2_end_trigger,AddOutput,OnTrigger stage_2_vent_breakable:Break:::1,,1"
 	}
 }
 
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "stage_2_main_room_button_next"
+	}
+	replace:
+	{
+		"spawnflags" "19457"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "stage_2_main_room_button_next"
+		"origin" "5462 1048 -6892"
+	}
+	delete:
+	{
+		"OnPressed" "stage_2_open_random_logicTrigger0-1"
+	}
+	replace:
+	{
+		"targetname" "stage_2_main_room_second_button_next"
+	}
+}
+
+; Fix possibility of this trigger firing outputs more than once.
 modify:
 {
 	match:
@@ -1305,10 +1557,25 @@ modify:
 	delete:
 	{
 		"OnStartTouch" "stage_2_vent_breakableBreak0-1"
+		"OnStartTouch" "stage2_afk_teleportEnable0-1"
+		"OnStartTouch" "stage2_afk_teleportDisable1-1"
+		"OnStartTouch" "Spawn_Phy_Car_Hurt*Kill0-1"
+		"OnStartTouch" "Spawn_Phy_Car_2_Hurt*Kill0-1"
+		"OnStartTouch" "stage_x_second_doorClose0-1"
+		"OnStartTouch" "stage_2_end_pushKill0-1"
+	}
+	insert:
+	{
+		"OnTrigger" "stage2_afk_teleport,Enable,,,1"
+		"OnTrigger" "stage2_afk_teleport,Disable,,1,1"
+		"OnTrigger" "Spawn_Phy_Car_Hurt*,Kill,,,1"
+		"OnTrigger" "Spawn_Phy_Car_2_Hurt*,Kill,,,1"
+		"OnTrigger" "stage_x_second_door,Close,,,1"
+		"OnTrigger" "stage_2_end_push,Kill,,,1"
 	}
 }
 
-; Reduce volume of "Mech" minigun sound.
+; Reduce volume of "Mech" item "Minigun" sound.
 modify:
 {
 	match:
@@ -1351,6 +1618,7 @@ modify:
 	replace:
 	{
 		"spawnflags" "3073"
+		"wait" "-1"
 	}
 	delete:
 	{
@@ -1365,14 +1633,14 @@ modify:
 	insert:
 	{
 		"OnUser1" "!self,Kill,,,1"
-		"OnUser1" "Global_GameText_AnnouncementRunScriptCodesetMessage(33);1"
 		"OnUser1" "stage_4_nuke_works,Disable,,,1"
 		"OnUser1" "stage_4_end_nuke_malfunction,StartSpark,,,1"
 		"OnUser1" "Global_Message_Top_Right,Display,,,1"
-		"OnUser1" "Global_Message_Top_Right,AddOutput,message ,,1"
+		"OnUser1" "Global_Message_Top_Right,SetText,,,1"
 		"OnUser1" "Global_Message_Top_Right,AddOutput,holdtime 0,,1"
 		"OnUser1" "Global_Message_Top_Countdown,Kill,,,1"
 		"OnUser1" "Global_GameText_Announcement,FireUser3,,,1"
+		"OnUser1" "Global_GameText_AnnouncementRunScriptCodesetMessage(33);1"
 	}
 }
 
@@ -1419,7 +1687,20 @@ modify:
 	}
 }
 
-; When a "Tank" controlled by a zombie is broken, don't make it disappear but make it non-solid and darken it.
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Spawn_Nuke_Trigger"
+	}
+	insert:
+	{
+		"OnSpawn" "Spawn_Nuke_Hurt,AddOutput,classname norepeatkiller1,,1"
+	}
+}
+
+; When a "Tank" vehicle controlled by a zombie is killed, don't make it disappear but make it non-solid and darken it.
 modify:
 {
 	match:
@@ -1657,13 +1938,17 @@ add:
 	"OnEndTouch" "!activator,SetDamageFilter,,.01,-1"
 }
 
-; Implement the unused zombie teleport in extreme stage 1.
+; Implement the unused zombie teleport in extreme stage 1 and also make it not go too further when opening.
 modify:
 {
 	match:
 	{
 		"classname" "func_movelinear"
 		"targetname" "stage_x_camp_door"
+	}
+	replace:
+	{
+		"movedistance" "256"
 	}
 	insert:
 	{
@@ -1685,7 +1970,7 @@ modify:
 	}
 }
 
-; Fix viewcontrols being laggy for "Alex Mercer" and "Mech".
+; Fix viewcontrols being laggy for "Boss" and "Mech" items.
 ; Delete the old system used for viewcontrols.
 filter:
 {
@@ -1774,10 +2059,11 @@ modify:
 	}
 	insert:
 	{
+		"DontMessageParent" "1"
 		"OnUse" "!activator,AddOutput,targetname ,,-1"
-		"OnUse" "!activatorRunScriptCodeif (self.GetName() == _.zombie_boss || self.GetName() == _.human_mech) EntFireByHandle(caller, _.FireUser1, __, 0, self, null);-1"
-		"OnUser1" "Map_End_Camera,RemovePlayer,,,1"
-		"OnUser1" "Map_End_Camera,AddPlayer,,,1"
+		"OnUse" "!activatorRunScriptCodeif (self.GetName() == _.zombie_boss || self.GetName() == _.human_mech) EntFireByHandle(caller, _.FireUser1, __, -1, self, null);-1"
+		"OnUser1" "Map_End_Camera,RemovePlayer,,,2"
+		"OnUser1" "Map_End_Camera,AddPlayer,,,2"
 	}
 }
 
@@ -1796,7 +2082,7 @@ modify:
 	}
 }
 
-; Implement a better zombie trigger system and prevent zombie "Freezer" item from triggering on stage 4.
+; Implement a better zombie trigger system.
 modify:
 {
 	match:
@@ -1806,7 +2092,7 @@ modify:
 	}
 	insert:
 	{
-		"OnTrigger" "stage_1_zmtrigger1,Kill,,,1"
+		"OnTrigger" "stage_1_extratrigger1,Kill,,,1"
 	}
 }
 
@@ -1845,6 +2131,13 @@ modify:
 	}
 }
 
+add:
+{
+	"classname" "game_round_end"
+	"targetname" "map1roundend1"
+	"OnRoundEnded" "map1roundend1,Kill,,,1"
+}
+
 modify:
 {
 	match:
@@ -1854,7 +2147,7 @@ modify:
 	}
 	replace:
 	{
-		"targetname" "stage_1_zmtrigger1"
+		"targetname" "stage_1_extratrigger1"
 	}
 	delete:
 	{
@@ -1862,8 +2155,8 @@ modify:
 	}
 	insert:
 	{
-		"OnStartTouch" "stage_1_button_end_2RunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
-		"OnStartTouch" "stage_1_button_end_2,AddOutput,OnPressed !self:Kill:::1,,1"
+		"OnTrigger" "stage_1_button_end_2RunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
+		"OnTrigger" "stage_1_button_end_2,AddOutput,OnPressed !self:Kill:::1,,1"
 	}
 }
 
@@ -1873,6 +2166,11 @@ modify:
 	{
 		"classname" "func_button"
 		"OnPressed" "ZOMBIESTRIGGEREDRunScriptCodeprogressTrigger()01"
+	}
+	replace:
+	{
+		"wait" "-1"
+		"rendermode" "10"
 	}
 	delete:
 	{
@@ -1893,23 +2191,25 @@ modify:
 	}
 	insert:
 	{
+		"OnEntitySpawned" "stage_1_button_tower_topRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
+		"OnEntitySpawned" "stage_1_road_button_alternative_pathRunScriptCodefunction InputUse() { if (activator) { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; } }1"
 		"OnEntitySpawned" "stage_1_bridge_buttonRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
+		"OnEntitySpawned" "stage_1_button_endRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
 	}
 }
 
-; Optional: Zombie trigger for the underground button on stage 1 added by the porter, I am not sure if it should be kept considering humans can progress without pressing it.
-;modify:
-;{
-;	match:
-;	{
-;		"classname" "point_template"
-;		"targetname" "stage1_x_things"
-;	}
-;	insert:
-;	{
-;		"OnEntitySpawned" "stage_x_btn_endRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
-;	}
-;}
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "stage1_x_things"
+	}
+	insert:
+	{
+		"OnEntitySpawned" "stage_x_btn_endRunScriptCodefunction InputUse() { return activator.GetTeam() == 3; }1"
+	}
+}
 
 modify:
 {
@@ -1920,10 +2220,11 @@ modify:
 	}
 	insert:
 	{
+		"OnEntitySpawned" "stage_2_entrance_buttonRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
 		"OnEntitySpawned" "stage_2_btn_mainRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
 		"OnEntitySpawned" "stage_2_button_weapon_doorRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
+		"OnEntitySpawned" "stage_2_minifier_buttonRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
 		"OnEntitySpawned" "stage_2_button_core_generatorRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
-		"OnEntitySpawned" "stage_2_main_room_button_nextRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
 	}
 }
 
@@ -1936,7 +2237,25 @@ modify:
 	}
 	insert:
 	{
+		"OnEntitySpawned" "stage_3_spawnRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
+		"OnEntitySpawned" "stage_3_corridor_button_*RunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
+		"OnEntitySpawned" "stage_3_button_lock*RunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
+		"OnEntitySpawned" "stage_3_button_core_*RunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
 		"OnEntitySpawned" "stage_3_core_buttonRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Extreme_Stage_3"
+	}
+	insert:
+	{
+		"OnTrigger" "stage_3_weapons_button_2RunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }21"
+		"OnTrigger" "stage_3_weapons_button_3*RunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }21"
 	}
 }
 
@@ -1949,13 +2268,186 @@ modify:
 	}
 	insert:
 	{
-		;"OnEntitySpawned" "stage_4_end_buttonRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
 		"OnEntitySpawned" "stage_4_custombrush1,AddOutput,solid 2,,1"
 		"OnEntitySpawned" "stage_4_custombrush1RunScriptCodeself.SetSize(Vector(-256, -448, -1696), Vector(256, 448, 1696));1"
+		"OnEntitySpawned" "stage_4_teleport,AddOutput,solid 2,,1"
+		"OnEntitySpawned" "stage_4_teleportRunScriptCodeself.SetSize(Vector(-4700, -11.5, -1856), Vector(4700, 11.5, 1856));1"
+		"OnEntitySpawned" "stage_4_end_button*RunScriptCodefunction InputUse() { return activator.GetTeam() == 3; }1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "stage4_x_things"
+	}
+	insert:
+	{
+		"OnEntitySpawned" "stage_x_part_4_explosion_buttonRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2 && activator.GetName() != _.zombie_freezer) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "stage5_things"
+	}
+	insert:
+	{
+		"OnEntitySpawned" "stage_5_hurt,AddOutput,classname norepeatkiller1,,1"
+	}
+}
+
+; Make "Ultralisk" come faster on event he's not killed.
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "stage5_things"
+	}
+	insert:
+	{
+		"OnEntitySpawned" "stage_5_lower_door_button_LIFTRunScriptCodefunction InputUse() { return activator.GetTeam() == 3; }1"
+	}
+}
+
+; Prevent pressing trigger buttons when triggered.
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "stage_1_button_elevator"
+	}
+	insert:
+	{
+		"OnPressed" "!self,AddOutput,spawnflags 1,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_breakable"
+		"targetname" "stage_x_end_elevator_1_doors"
+	}
+	insert:
+	{
+		"OnBreak" "stage_1_button_elevatorRunScriptCodefunction InputUse() { return activator.GetTeam() == 3; }51"
+		"OnBreak" "stage_1_button_elevatorRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }201"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "stage_x_part_4_explosion_button"
+	}
+	insert:
+	{
+		"OnPressed" "!selfRunScriptCodedelete InputUse;1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "/stage_(1_(button_(tower_top|end)|road_button_alternative_path)|2_((entrance|minifier)_button|main_room_button_next|button_(factory_control|core_factory)))/"
+	}
+	replace:
+	{
+		"wait" "-1"
+		"rendermode" "10"
+	}
+	insert:
+	{
+		"OnPressed" "!self,Kill,,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "/stage_(3_(spawn|corridor_button_(1|3(x|)|4|8)|weapons_button_(2|3(x|))|tests_door_button_8|core_button|button(_(2|(lock(_[2-6]|)|core_(left|right)))|))|4_part_(3_button|5_button_(2|[7-9]|10)))/"
+	}
+	replace:
+	{
+		"wait" "-1"
+		"rendermode" "10"
+	}
+	insert:
+	{
+		"OnPressed" "!self,Kill,,,1"
+	}
+}
+
+; Kill entities when used.
+modify:
+{
+	match:
+	{
+		"classname" "math_counter"
+		"targetname" "/stage_(3_cor(ridor_door_[4-5]_unlock|e_counter)|5_lower_counter_energy)/"
+	}
+	insert:
+	{
+		"OnHitMax" "!self,Kill,,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_compare"
+		"targetname" "stage_3_core_counter_elevator"
+	}
+	insert:
+	{
+		"OnEqualTo" "!self,Kill,,,1"
 	}
 }
 
 ; No need for filters anymore.
+filter:
+{
+	"classname" "filter_activator_team"
+	"targetname" "stage_3_core_button_filter"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "stage_3_core_button"
+	}
+	delete:
+	{
+		"OnPressed" "stage_3_core_button_filterTestActivator0-1"
+	}
+	insert:
+	{
+		"OnPressed" "stage_target_helper_3,SetLocalOrigin,0 0 0,,1"
+		"OnPressed" "Global_GameText_Objective,FireUser2,,,1"
+		"OnPressed" "stage_3_tests_door_button_7,FireUser1,,,1"
+		"OnPressed" "stage_3_core_counter,Add,1,,1"
+		"OnPressed" "Global_Give_30_points,ApplyScore,,,1"
+	}
+}
+
 filter:
 {
 	"classname" "filter_activator_team"
@@ -1980,15 +2472,14 @@ modify:
 	insert:
 	{
 		"OnPressed" "stage_x_end_nuke_door_*,Open,,,1"
-		"OnPressed" "Global_GameText_AnnouncementRunScriptCodesetMessage(3);1"
 		"OnPressed" "stage_x_nuke_train,Open,,,1"
 		"OnPressed" "Glocal_Message_Selector,InValue,stage4_end,,1"
 		"OnPressed" "stage_4_nuke_works,Trigger,,80,1"
 		"OnPressed" "stage_x_end_bridge_1,Open,,43,1"
 		"OnPressed" "Global_GameText_Announcement,FireUser4,,,1"
-		"OnPressed" "stage_4_part_5_trigger,FireUser1,,,1"
+		"OnPressed" "Global_GameText_AnnouncementRunScriptCodesetMessage(3);1"
 		"OnPressed" "Global_GameText_Objective,FireUser2,,,1"
-		"OnPressed" "stage_target_helper_2,AddOutput,origin 0 0 0,,1"
+		"OnPressed" "stage_target_helper_2,SetLocalOrigin,0 0 0,,1"
 		"OnPressed" "stage_x_ultralistk_model,FireUser2,,60,1"
 		"OnPressed" "stage_positioner_teleport,InValue,44,,1"
 	}
@@ -2017,11 +2508,50 @@ modify:
 	}
 	insert:
 	{
-		"OnPressed" "Global_GameText_AnnouncementRunScriptCodesetMessage(6);1"
 		"OnPressed" "stage_x_end_nuke_protection_door,Close,,,1"
 		"OnPressed" "Global_GameText_Announcement,FireUser4,,,1"
+		"OnPressed" "Global_GameText_AnnouncementRunScriptCodesetMessage(6);1"
 		"OnPressed" "Global_Give_30_points,ApplyScore,,,1"
 		"OnPressed" "fallback_fade,Fade,,,-1"
+	}
+}
+
+filter:
+{
+	"classname" "filter_activator_team"
+	"targetname" "stage_5_button_filter"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "stage_5_lower_door_button_LIFT"
+	}
+	replace:
+	{
+		"wait" "-1"
+	}
+	delete:
+	{
+		"OnPressed" "stage_5_button_filterTestActivator0-1"
+	}
+	insert:
+	{
+		"OnPressed" "stage_5_lower_timer*,Kill,,,1"
+		"OnPressed" "stage_5_lower_door_case,Kill,,,1"
+		"OnPressed" "stage_5_to_top_teleport,FireUser1,,15,1"
+		"OnPressed" "stage_x_main_lift,Open,,5,1"
+		"OnPressed" "stage_0_alarm_sound_emergency,StopSound,,,1"
+		"OnPressed" "stage_target_helper,SetLocalOrigin,4616 2120 12248,,1"
+		"OnPressed" "Global_GameText_Objective,FireUser3,,,1"
+		"OnPressed" "Global_GameText_Announcement,FireUser4,,,1"
+		"OnPressed" "Global_GameText_Announcement,SetText,** LIFT TO TOP IN 5 SECONDS **,,1"
+		"OnPressed" "stage_x_lower_bridges_tracktrain*,Close,,,1"
+		"OnPressed" "stage_5_end_hint,SetText,,,1"
+		"OnPressed" "stage_0_alarm_sound_emergency,StopSound,,,1"
+		"OnPressed" "stage_5_tank_kill,Enable,,5,1"
 	}
 }
 
@@ -2100,6 +2630,120 @@ modify:
 	}
 }
 
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "stage_x_helicopter_can_leave"
+	}
+	delete:
+	{
+		"OnTrigger" "stage_x_helicopterSetAnimationidle0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "stage_x_end_button_blue"
+	}
+	delete:
+	{
+		"OnUser1" "stage_x_core_column_button_modelSetAnimationclose0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_door"
+		"targetname" "stage_x_core_column_mv_btns"
+	}
+	delete:
+	{
+		"OnFullyOpen" "stage_x_core_column_button_modelSetAnimationopen0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic"
+		"targetname" "Weapons_Turret_Model_Deployed"
+	}
+	delete:
+	{
+		"OnAnimationDone" "Weapon_Turret_Deployed_DevBrushSetParentAttachmentMaintainOffsetturret0-1"
+	}
+}
+
+; Remove missing sounds.
+modify:
+{
+	match:
+	{
+		"noise1" "E3_C17_02.GateGrindsDown1"
+	}
+	delete:
+	{
+		"noise1" "E3_C17_02.GateGrindsDown1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"unlocked_sound" "7"
+	}
+	replace:
+	{
+		"unlocked_sound" "0"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"soundopenoverride" "Doors.CombineGate_citizen_stop2"
+	}
+	delete:
+	{
+		"soundopenoverride" "Doors.CombineGate_citizen_stop2"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"soundcloseoverride" "Doors.CombineGate_citizen_stop2"
+	}
+	delete:
+	{
+		"soundcloseoverride" "Doors.CombineGate_citizen_stop2"
+	}
+}
+
+; Remove invalid keyvalue.
+modify:
+{
+	match:
+	{
+		"Negated" "Allow entities that match criteria"
+	}
+	replace:
+	{
+		"Negated" "0"
+	}
+}
+
 ; Shorten some button delays.
 modify:
 {
@@ -2114,8 +2758,15 @@ modify:
 	}
 }
 
+; Remove extra model.
+filter:
+{
+	"classname" "prop_dynamic"
+	"targetname" "Weapon_ZeroGravity_Model"
+	"origin" "-1298.06 12522 -8552.82"
+}
+
 ; Make stage 2 lobby door non-solid.
-; Optional: Prevent the stage 2 lobby door killing humans.
 modify:
 {
 	match:
@@ -2127,34 +2778,33 @@ modify:
 	{
 		"spawnflags" "808"
 		"forceclosed" "1"
-;		"dmg" "0"
 		"dmg" "9999"
 	}
 	insert:
 	{
 		"effects" "32"
-;		"OnBlockedClosing" "!activatorRunScriptCodeif (self.GetTeam() == 3) self.SetAbsOrigin(Vector(self.GetOrigin().x, 605, self.GetOrigin().z)); else EntFireByHandle(self, _.SetHealth, (0).tostring(), 0, null, null);-1"
-;		"OnBlockedClosing" "!self,Open,,,-1"
-;		"OnBlockedClosing" "!self,Close,,.01,-1"
-		"OnBlockedClosing" "!activatorRunScriptCodeif (self.GetTeam() == 3) EntFireByHandle(caller, _.FireUser1, __, 0, null, null);-1"
-		"OnUser1" "console,Command,say A human has died to the door!,,-1"
 	}
 }
 
-; Prevent blocking bridge lowering in stage 4.
-modify:
-{
-	match:
-	{
-		"classname" "func_door"
-		"targetname" "stage_x_end_bridge_1"
-	}
-	replace:
-	{
-		"spawnflags" "512"
-		"dmg" "9999"
-	}
-}
+; Optional: Prevent the stage 2 lobby door killing humans.
+;modify:
+;{
+;	match:
+;	{
+;		"classname" "func_door"
+;		"targetname" "stage_x_second_door"
+;	}
+;	replace:
+;	{
+;		"dmg" "0"
+;	}
+;	insert:
+;	{
+;		"OnBlockedClosing" "!activatorRunScriptCodeif (self.GetTeam() == 3) self.SetOrigin(Vector(self.GetOrigin().x, 605, self.GetOrigin().z)); else EntFireByHandle(self, _.SetHealth, (0).tostring(), -1, null, null);-1"
+;		"OnBlockedClosing" "!self,Open,,,-1"
+;		"OnBlockedClosing" "!self,Close,,.01,-1"
+;	}
+;}
 
 ; Fix extreme stage 3 elevators being blockable.
 modify:
@@ -2221,17 +2871,85 @@ modify:
 	}
 }
 
-; Fix early triggering nuke on stage 4.
+; Fix broken message on stage 4.
 modify:
 {
 	match:
 	{
-		"classname" "logic_case"
-		"targetname" "stage_4_part_5_case_controller"
+		"classname" "func_tracktrain"
+		"targetname" "stage_x_part_4_plane_tracktrain"
+	}
+	delete:
+	{
+		"OnUser1" "Global_GameText_AnnouncementRunScriptCodeRunScriptCode(19)01"
 	}
 	insert:
 	{
-		"OnCase03" "stage_4_part_5_trigger,Enable,,20,1"
+		"OnUser1" "Global_GameText_Announcement,FireUser3,,,1"
+		"OnUser1" "Global_GameText_AnnouncementRunScriptCodesetMessage(19);1"
+	}
+}
+
+; Fix some funky stuff in stage 4 big gate.
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "stage_4_part_3_button"
+	}
+	insert:
+	{
+		"OnPressed" "fallback_fade,Fade,,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox_multiplayer"
+		"targetname" "stage_4_door_phys"
+	}
+	replace:
+	{
+		"spawnflags" "15003648"
+	}
+	insert:
+	{
+		"OnBreak" "stage_4_part_3_button,Kill,,,1"
+		"OnBreak" "stage_4_teleport,Kill,,,1"
+	}
+}
+
+; Fix some camera stuff in warmup and stage 3.
+filter:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_0_end_camera_disable"
+}
+
+filter:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_0_end_camera_disable"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "stage_0_trigger_detect_zombification"
+	}
+	delete:
+	{
+		"OnStartTouch" "!activatorAddOutputorigin 1592 3912 2110.20-1"
+		"OnStartTouch" "Global_Weapon_StripStripWeaponsAndSuit0-1"
+	}
+	insert:
+	{
+		"OnTrigger" "!activator,SetLocalOrigin,1592 3912 2110,,1"
 	}
 }
 
@@ -2240,7 +2958,1764 @@ modify:
 	match:
 	{
 		"classname" "trigger_once"
-		"targetname" "stage_4_part_5_trigger"
+		"targetname" "stage_0_zombie_boss_trigger"
+	}
+	insert:
+	{
+		"OnTrigger" "Global_Weapon_Strip,Strip,,,1"
+		"OnTrigger" "stage_0_trigger_detect_zombification,Kill,,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Supreme_Trigger"
+	}
+	delete:
+	{
+		"OnTrigger" "stage_0_end_cameraEnable12-1"
+		"OnTrigger" "stage_0_end_cameraDisable13-1"
+		"OnTrigger" "stage_0_end_camera_disableEnable41-1"
+		"OnTrigger" "stage_0_end_camera_disableDisable42-1"
+	}
+	insert:
+	{
+		"OnTrigger" "Map_End_Camera,Enable,,12,1"
+		"OnTrigger" "Map_End_Camera,Disable,,41,1"
+	}
+}
+
+filter:
+{
+	"classname" "trigger_once"
+	"targetname" "stage_3_camera"
+}
+
+filter:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_3_camera_deactivator"
+}
+
+filter:
+{
+	"classname" "filter_activator_team"
+	"targetname" "Global_Team_Set_No_Damage_Z"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_viewcontrol_multiplayer"
+		"targetname" "stage_cinematic_cam"
+	}
+	delete:
+	{
+		"OnUser1" "playerFireUser40.03-1"
+		"OnUser1" "playerAddOutputOnUser4 stage_3_cinematic_cam:Enable::0:10.02-1"
+		"OnUser1" "playerFireUser40.01-1"
+		"OnUser1" "playerAddOutputOnUser4 Global_Team_Set_No_Damage_Z:TestActivator::0:10-1"
+		"OnUser1" "playerSetDamageFilterteam_filter_humans0-1"
+		"OnUser1" "stage_3_cameraEnable0-1"
+		"OnUser1" "stage_3_camera_deactivatorEnable20-1"
+		"OnUser1" "stage_3_camera_deactivatorDisable22-1"
+		"OnUser1" "stage_3_cameraDisable1-1"
+	}
+	insert:
+	{
+		"OnUser1" "!self,Enable,,,-1"
+		"OnUser1" "consolaCliall,FireUser4,,,-1"
+		"OnUser1" "!self,Disable,,20,-1"
+		"OnUser1" "consolaCliall,FireUser1,,20,-1"
+	}
+}
+
+; Optional: Disable HUD during warmup cutscene.
+;modify:
+;{
+;	match:
+;	{
+;		"classname" "logic_relay"
+;		"targetname" "Supreme_Trigger"
+;	}
+;	insert:
+;	{
+;		"OnTrigger" "player,SetHUDVisibility,0,12,1"
+;		"OnTrigger" "player,SetHUDVisibility,1,41,1"
+;	}
+;}
+
+; Optional: Disable HUD during stage 3 cutscene.
+;modify:
+;{
+;	match:
+;	{
+;		"classname" "point_viewcontrol_multiplayer"
+;		"targetname" "stage_cinematic_cam"
+;	}
+;	insert:
+;	{
+;		"OnUser1" "player,SetHUDVisibility,0,,-1"
+;		"OnUser1" "player,SetHUDVisibility,1,20,-1"
+;	}
+;}
+
+; Optional: Kill the humans on stage 3 who weren't on boss room when it starts.
+;modify:
+;{
+;	match:
+;	{
+;		"classname" "trigger_multiple"
+;		"targetname" "stage_3_boss_teleport"
+;	}
+;	insert:
+;	{
+;		"OnStartTouch" "!activatorRunScriptCodeif (self.GetTeam() == 3) EntFireByHandle(self, _.SetHealth, (0).tostring(), -1, null, null);20-1"
+;	}
+;}
+
+; Remove missing script.
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"vscripts" "filter.nut"
+	}
+	delete:
+	{
+		"vscripts" "filter.nut"
+		"OnPressed" "!selfRunScriptCodeFilterHolder();0-1"
+	}
+}
+
+; Remove missing lighting origin.
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic"
+		"lightingorigin" "stage_2_bridge"
+	}
+	delete:
+	{
+		"lightingorigin" "stage_2_bridge"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic"
+		"lightingorigin" "stage_2_lightinf"
+	}
+	delete:
+	{
+		"lightingorigin" "stage_2_lightinf"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic"
+		"lightingorigin" "stage_3_info_lighting"
+	}
+	delete:
+	{
+		"lightingorigin" "stage_3_info_lighting"
+	}
+}
+
+; Don't try to pick more cases.
+modify:
+{
+	match:
+	{
+		"classname" "logic_timer"
+		"targetname" "stage_5_lower_timer_bridges"
+	}
+	delete:
+	{
+		"OnTimer" "stage_5_lower_timer_bridges_casePickRandomShuffle0-1"
+	}
+	insert:
+	{
+		"OnTimer" "stage_5_lower_timer_bridges_case,PickRandom,,,4"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_timer"
+		"targetname" "stage_5_lower_timer"
+	}
+	delete:
+	{
+		"OnTimer" "stage_5_lower_door_casePickRandomShuffle0-1"
+	}
+	insert:
+	{
+		"OnTimer" "stage_5_lower_door_case,PickRandom,,,3"
+	}
+}
+
+; Kill stage 5 door relays when pressed.
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "/stage_5_((we|ea)st|south)_survivors_tr/"
+	}
+	replace:
+	{
+		"spawnflags" "1"
+	}
+	delete:
+	{
+		"OnTrigger" "!selfKill0.5-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "stage_x_reward_vehicle_with_weapons_relay"
+	}
+	replace:
+	{
+		"spawnflags" "1"
+	}
+	delete:
+	{
+		"OnTrigger" "!selfEnable0-1"
+	}
+}
+
+; Make sure "NPC" items spawn in correct order.
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "stage_5_west_survivors_tr"
+	}
+	delete:
+	{
+		"OnTrigger" "Weapon_NPC_TemplateAddOutputorigin 968 -4288 98640-1"
+		"OnTrigger" "Weapon_NPC_TemplateAddOutputorigin 944 -4520 98640.1-1"
+		"OnTrigger" "Weapon_NPC_TemplateAddOutputorigin 968 -4688 98640.2-1"
+		"OnTrigger" "Weapon_NPC_TemplateAddOutputorigin 952 -4832 98640.3-1"
+		"OnTrigger" "Weapon_NPC_TemplateForceSpawn0.31-1"
+		"OnTrigger" "Weapon_NPC_TemplateForceSpawn0.21-1"
+		"OnTrigger" "Weapon_NPC_TemplateForceSpawn0.11-1"
+		"OnTrigger" "Weapon_NPC_TemplateForceSpawn0.01-1"
+	}
+	insert:
+	{
+		"OnTrigger" "Weapon_NPC_Template,ForceSpawn,,,1"
+		"OnTrigger" "Weapon_NPC_Template,SetLocalOrigin,968 -4288 9864,,1"
+		"OnTrigger" "Weapon_NPC_Template,ForceSpawn,,,1"
+		"OnTrigger" "Weapon_NPC_Template,SetLocalOrigin,944 -4520 9864,,1"
+		"OnTrigger" "Weapon_NPC_Template,ForceSpawn,,,1"
+		"OnTrigger" "Weapon_NPC_Template,SetLocalOrigin,968 -4688 9864,,1"
+		"OnTrigger" "Weapon_NPC_Template,ForceSpawn,,,1"
+		"OnTrigger" "Weapon_NPC_Template,SetLocalOrigin,952 -4832 9864,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "stage_5_south_survivors_tr"
+	}
+	delete:
+	{
+		"OnTrigger" "Weapon_NPC_TemplateAddOutputorigin 4872 -8264 98640-1"
+		"OnTrigger" "Weapon_NPC_TemplateAddOutputorigin 4320 -8256 98640.1-1"
+		"OnTrigger" "Weapon_NPC_TemplateAddOutputorigin 4184 -8296 98640.2-1"
+		"OnTrigger" "Weapon_NPC_TemplateForceSpawn0.21-1"
+		"OnTrigger" "Weapon_NPC_TemplateForceSpawn0.11-1"
+		"OnTrigger" "Weapon_NPC_TemplateForceSpawn0.01-1"
+	}
+	insert:
+	{
+		"OnTrigger" "Weapon_NPC_Template,ForceSpawn,,,1"
+		"OnTrigger" "Weapon_NPC_Template,SetLocalOrigin,4872 -8264 9864,,1"
+		"OnTrigger" "Weapon_NPC_Template,ForceSpawn,,,1"
+		"OnTrigger" "Weapon_NPC_Template,SetLocalOrigin,4320 -8256 9864,,1"
+		"OnTrigger" "Weapon_NPC_Template,ForceSpawn,,,1"
+		"OnTrigger" "Weapon_NPC_Template,SetLocalOrigin,4184 -8296 9864,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "stage_5_east_survivors_tr"
+	}
+	delete:
+	{
+		"OnTrigger" "Weapon_NPC_TemplateAddOutputorigin 8248 -4368 98640-1"
+		"OnTrigger" "Weapon_NPC_TemplateAddOutputorigin 8296 -4576 98640.1-1"
+		"OnTrigger" "Weapon_NPC_TemplateAddOutputorigin 8248 -4736 98640.2-1"
+		"OnTrigger" "Weapon_NPC_TemplateAddOutputorigin 8288 -4872 98640.3-1"
+		"OnTrigger" "Weapon_NPC_TemplateForceSpawn0.31-1"
+		"OnTrigger" "Weapon_NPC_TemplateForceSpawn0.21-1"
+		"OnTrigger" "Weapon_NPC_TemplateForceSpawn0.11-1"
+		"OnTrigger" "Weapon_NPC_TemplateForceSpawn0.01-1"
+	}
+	insert:
+	{
+		"OnTrigger" "Weapon_NPC_Template,ForceSpawn,,,1"
+		"OnTrigger" "Weapon_NPC_Template,SetLocalOrigin,8248 -4368 9864,,1"
+		"OnTrigger" "Weapon_NPC_Template,ForceSpawn,,,1"
+		"OnTrigger" "Weapon_NPC_Template,SetLocalOrigin,8296 -4576 9864,,1"
+		"OnTrigger" "Weapon_NPC_Template,ForceSpawn,,,1"
+		"OnTrigger" "Weapon_NPC_Template,SetLocalOrigin,8248 -4736 9864,,1"
+		"OnTrigger" "Weapon_NPC_Template,ForceSpawn,,,1"
+		"OnTrigger" "Weapon_NPC_Template,SetLocalOrigin,8288 -4872 9864,,1"
+	}
+}
+
+; "NPC" item fixes.
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox_multiplayer"
+		"targetname" "Weapon_NPC_Body"
+	}
+	replace:
+	{
+		"spawnflags" "15003648"
+	}
+	delete:
+	{
+		"OnBreak" "Weapon_NPC_ModelClearParent0-1"
+	}
+	insert:
+	{
+		"OnBreak" "Weapon_NPC_Model,ClearParent,,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox_multiplayer"
+		"targetname" "NPC_Soldier_Body"
+	}
+	replace:
+	{
+		"spawnflags" "15003648"
+	}
+	delete:
+	{
+		"OnBreak" "NPC_Soldier_Anim_Die_CaseFireUser10-1"
+		"OnUser1" "!selfKill0-1"
+		"OnUser1" "NPC_Soldier_ModelKill0-1"
+		"OnUser1" "NPC_Soldier_Anim_Die_CaseKill0-1"
+		"OnUser1" "NPC_Soldier_Anim_CaseKill0-1"
+		"OnUser1" "NPC_Soldier_Sound_FireKill0.1-1"
+		"OnUser1" "NPC_Soldier_Sound_FireVolume00-1"
+	}
+	insert:
+	{
+		"OnBreak" "NPC_Soldier_Model,SetAnimation,deathpose_lowviolence,,1"
+		"OnBreak" "NPC_Soldier_Model,SetDefaultAnimation,,,1"
+		"OnBreak" "item1human1soldier1model1,Kill,,,1"
+		"OnBreak" "NPC_Soldier_Fire,Kill,,,1"
+		"OnBreak" "NPC_Soldier_Grenade_Maker,Kill,,,1"
+		"OnBreak" "NPC_Soldier_Area_Grenade,Kill,,,1"
+		"OnBreak" "NPC_Soldier_Area_Gun,Kill,,,1"
+		"OnBreak" "NPC_Soldier_Sound_Fire,Kill,,,1"
+		"OnBreak" "NPC_Soldier_Sound_Fire,StopSound,,,1"
+		"OnUser1" "NPC_Soldier_Model,KillHierarchy,,,1"
+		"OnUser1" "NPC_Soldier_Sound_Fire,Kill,,,1"
+		"OnUser1" "NPC_Soldier_Sound_Fire,StopSound,,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "NPC_Soldier_Area_Gun"
+	}
+	delete:
+	{
+		"OnStartTouch" "NPC_Soldier_ModelFireUser20-1"
+	}
+	insert:
+	{
+		"OnStartTouchAll" "NPC_Soldier_Model,FireUser2,,,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic"
+		"targetname" "NPC_Soldier_Model"
+		"origin" "-254.87 10754.9 -8566"
+	}
+	replace:
+	{
+		"DefaultAnim" "rom"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "NPC_Soldier_Fire"
+	}
+	delete:
+	{
+		"OnUser2" "NPC_Soldier_Anim_CasePickRandom0-1"
+	}
+	insert:
+	{
+		"OnUser2" "NPC_Soldier_Model,SetAnimation,rom,,-1"
+		"OnUser2" "NPC_Soldier_Model,SetDefaultAnimation,rom,,-1"
+	}
+}
+
+filter:
+{
+	"classname" "logic_case"
+	"targetname" "/NPC_Soldier_Anim_(Die_|)Case/"
+}
+
+; Attach weapon to "NPC" item correctly.
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "NPC_Soldier_Template"
+	}
+	delete:
+	{
+		"Template04" "NPC_Soldier_Anim_Case"
+	}
+	replace:
+	{
+		"Template03" "item1human1soldier1model1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic"
+		"targetname" "NPC_Soldier_Model"
+		"origin" "-245 10744 -8510.54"
+	}
+	replace:
+	{
+		"classname" "prop_dynamic_ornament"
+		"targetname" "item1human1soldier1model1"
+	}
+	insert:
+	{
+		"InitialOwner" "NPC_Soldier_Model"
+	}
+}
+
+; Fix some semi-transparent item models.
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic"
+		"targetname" "Weapon_Inmunizer_Model"
+	}
+	replace:
+	{
+		"rendermode" "0"
+		"renderamt" "255"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_deagle"
+		"targetname" "Weapon_Inmunizer_Weapon"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "Weapon_Inmunizer_Model,AddOutput,rendermode 2,,1"
+		"OnPlayerPickup" "Weapon_Inmunizer_Model,Alpha,254,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic"
+		"targetname" "Weapon_Turbo_Device_Model"
+	}
+	replace:
+	{
+		"rendermode" "0"
+		"renderamt" "255"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic"
+		"targetname" "Zombie_Item_Predator_Model"
+	}
+	replace:
+	{
+		"rendermode" "0"
+		"renderamt" "255"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Zombie_Item_Predator_Knife"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "Zombie_Item_Predator_Model,AddOutput,rendermode 2,,1"
+		"OnPlayerPickup" "Zombie_Item_Predator_Model,Alpha,254,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic"
+		"targetname" "Weapon_NPC_Model"
+	}
+	replace:
+	{
+		"rendermode" "0"
+		"renderamt" "255"
+		"DefaultAnim" "knife_aim_idle"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_deagle"
+		"targetname" "Weapon_NPC_Weapon"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "Weapon_NPC_Model,AddOutput,rendermode 2,,1"
+		"OnPlayerPickup" "Weapon_NPC_Model,Alpha,254,,1"
+	}
+}
+
+; Better knife strip system.
+filter:
+{
+	"classname" "trigger_multiple"
+	"targetname" "Zombie_Item_Predator_Knife_Trigger"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "Zombie_Item_Predator_Template"
+	}
+	replace:
+	{
+		"Template10" "Zombie_Item_Predator_Knife"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Zombie_Item_Predator_Knife"
+	}
+	delete:
+	{
+		"OnPlayerPickup" "Zombie_Item_Predator_Knife_TriggerKill0-1"
+	}
+	insert:
+	{
+		"OnCacheInteraction" "map1manager1,CallScriptFunction,CheckKnifeStrip,,-1"
+	}
+}
+
+filter:
+{
+	"classname" "trigger_once"
+	"targetname" "Zombie_Item_Antlion_Trigger"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "Zombie_Item_Antlion_Template"
+	}
+	delete:
+	{
+		"Template07" "Zombie_Item_Antlion_Trigger"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Zombie_Item_Antlion_Knife"
+	}
+	delete:
+	{
+		"OnPlayerPickup" "Zombie_Item_Antlion_TriggerKill0-1"
+	}
+	insert:
+	{
+		"OnCacheInteraction" "map1manager1,CallScriptFunction,CheckKnifeStrip,,-1"
+	}
+}
+
+filter:
+{
+	"classname" "trigger_multiple"
+	"targetname" "Zombie_Item_Tank_Disarmer"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "Zombie_Item_Tank_Spawn"
+	}
+	delete:
+	{
+		"Template02" "Zombie_Item_Tank_Disarmer"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Zombie_Item_Tank_Knife"
+	}
+	delete:
+	{
+		"OnPlayerPickup" "Zombie_Item_Tank_DisarmerKill0-1"
+	}
+	insert:
+	{
+		"OnCacheInteraction" "map1manager1,CallScriptFunction,CheckKnifeStrip,,-1"
+	}
+}
+
+filter:
+{
+	"classname" "trigger_multiple"
+	"targetname" "Zombie_Item_Vortigaunt_Trigger"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "Zombie_Item_Vortigaunt_Template"
+	}
+	delete:
+	{
+		"Template04" "Zombie_Item_Vortigaunt_Trigger"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Zombie_Item_Vortigaunt_Knife"
+	}
+	delete:
+	{
+		"OnPlayerPickup" "Zombie_Item_Vortigaunt_TriggerKill0-1"
+	}
+	insert:
+	{
+		"OnCacheInteraction" "map1manager1,CallScriptFunction,CheckKnifeStrip,,-1"
+	}
+}
+
+filter:
+{
+	"classname" "trigger_multiple"
+	"targetname" "Zombie_Item_Alma_Trigger"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "Zombie_Item_Alma_Template"
+	}
+	delete:
+	{
+		"Template06" "Zombie_Item_Alma_Trigger"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Zombie_Item_Alma_Knife"
+	}
+	delete:
+	{
+		"OnPlayerPickup" "Zombie_Item_Alma_TriggerKill0-1"
+	}
+	insert:
+	{
+		"OnCacheInteraction" "map1manager1,CallScriptFunction,CheckKnifeStrip,,-1"
+	}
+}
+
+filter:
+{
+	"classname" "trigger_multiple"
+	"targetname" "Zombie_Item_Summoner_Trigger"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "Zombie_Item_Summoner_Template"
+	}
+	delete:
+	{
+		"Template05" "Zombie_Item_Summoner_Trigger"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Zombie_Item_Summoner_Knife"
+	}
+	delete:
+	{
+		"OnPlayerPickup" "Zombie_Item_Summoner_TriggerKill0-1"
+	}
+	insert:
+	{
+		"OnCacheInteraction" "map1manager1,CallScriptFunction,CheckKnifeStrip,,-1"
+	}
+}
+
+filter:
+{
+	"classname" "trigger_multiple"
+	"targetname" "Zombie_Item_Jumper_Trigger"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "Zombie_Item_Jumper_Template"
+	}
+	delete:
+	{
+		"Template08" "Zombie_Item_Jumper_Trigger"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Zombie_Item_Jumper_Knife"
+	}
+	delete:
+	{
+		"OnPlayerPickup" "Zombie_Item_Jumper_TriggerKill0-1"
+	}
+	insert:
+	{
+		"OnCacheInteraction" "map1manager1,CallScriptFunction,CheckKnifeStrip,,-1"
+	}
+}
+
+filter:
+{
+	"classname" "trigger_multiple"
+	"targetname" "Zombie_Item_Shockwave_Trigger"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "Zombie_Item_Shockwave_Template"
+	}
+	delete:
+	{
+		"Template08" "Zombie_Item_Shockwave_Trigger"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Zombie_Item_Shockwave_Knife"
+	}
+	delete:
+	{
+		"OnPlayerPickup" "Zombie_Item_Shockwave_TriggerKill0-1"
+	}
+	insert:
+	{
+		"OnCacheInteraction" "map1manager1,CallScriptFunction,CheckKnifeStrip,,-1"
+	}
+}
+
+filter:
+{
+	"classname" "trigger_multiple"
+	"targetname" "Zombie_Item_Freezer_Trigger"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "Zombie_Item_Freezer_Template"
+	}
+	delete:
+	{
+		"Template03" "Zombie_Item_Freezer_Trigger"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Zombie_Item_Freezer_Knife"
+	}
+	delete:
+	{
+		"OnPlayerPickup" "Zombie_Item_Freezer_TriggerKill0-1"
+	}
+	insert:
+	{
+		"OnCacheInteraction" "map1manager1,CallScriptFunction,CheckKnifeStrip,,-1"
+	}
+}
+
+filter:
+{
+	"classname" "trigger_multiple"
+	"targetname" "wpn_jugger_strip"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "temp_jugger"
+	}
+	delete:
+	{
+		"Template12" "wpn_jugger_strip"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "wpn_jugger"
+	}
+	delete:
+	{
+		"OnPlayerPickup" "wpn_jugger_stripKill01"
+	}
+	insert:
+	{
+		"OnCacheInteraction" "map1manager1RunScriptCodeCheckKnifeStrip(1);-1"
+	}
+}
+
+filter:
+{
+	"classname" "trigger_multiple"
+	"targetname" "Human_Item_Mech_Trigger"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Human_Item_Mech_Knife"
+	}
+	delete:
+	{
+		"OnPlayerPickup" "Human_Item_Mech_TriggerKill0-1"
+	}
+	insert:
+	{
+		"OnCacheInteraction" "map1manager1RunScriptCodeCheckKnifeStrip(2);-1"
+	}
+}
+
+; Make stage 1 vehicles move to their position in extreme earlier.
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Extreme_Stage_1"
+	}
+	delete:
+	{
+		"OnTrigger" "Stage_x_Spawn_Tank_Teleport_2Teleport4-1"
+		"OnTrigger" "v_model1EnableMotion2.1-1"
+		"OnTrigger" "v_model1DisableMotion4-1"
+	}
+	insert:
+	{
+		"OnTrigger" "Stage_x_Spawn_Tank_Teleport_2,Teleport,,,1"
+		"OnTrigger" "v_model1,EnableMotion,,,1"
+		"OnTrigger" "v_model1,DisableMotion,,2,1"
+	}
+}
+
+; Make stage 5 truck entity non-solid.
+modify:
+{
+	match:
+	{
+		"classname" "func_tracktrain"
+		"targetname" "stage_x_reward_vehicle_with_weapons"
+	}
+	insert:
+	{
+		"effects" "32"
+	}
+	replace:
+	{
+		"spawnflags" "779"
+	}
+}
+
+; Make sure stage 5 door can only be selected to open if its event is unlocked, fix buttons and make "Tank" vehicle only spawn when button is pressed and make it human only for the first 10 seconds.
+modify:
+{
+	match:
+	{
+		"classname" "logic_case"
+		"targetname" "stage_5_lower_door_case"
+	}
+	delete:
+	{
+		"OnCase01" "stage_5_lower_door_relay_reinforcements_1Trigger0-1"
+		"OnCase02" "stage_5_lower_door_relay_reinforcements_5Trigger0-1"
+		"OnCase03" "stage_5_lower_door_relay_reinforcements_7Trigger0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "/stage_5_lower_door_relay_reinforcements_(1|5|7)/"
+	}
+	replace:
+	{
+		"StartDisabled" "0"
+	}
+}
+
+; Kill stage 5 door relays when pressed.
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "stage_5_west_survivors_tr"
+	}
+	replace:
+	{
+		"spawnflags" "1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_case"
+		"targetname" "Case_Events_Stage_5"
+		"origin" "-4256 11256 -8552"
+	}
+	delete:
+	{
+		"OnCase13" "stage_5_lower_door_relay_reinforcements_1Enable21"
+	}
+	insert:
+	{
+		"OnCase13" "stage_5_lower_door_case,AddOutput,OnCase01 stage_5_lower_door_relay_reinforcements_1:Trigger:::1,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "/stage_5_lower_door_button_(1|5)/"
+	}
+	replace:
+	{
+		"spawnflags" "3073"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_case"
+		"targetname" "Case_Events_Stage_5"
+		"origin" "-4272 11224 -8552"
+	}
+	delete:
+	{
+		"OnCase01" "stage_x_lower_door_5AddOutputOnFullyOpen Spawn_Tank_Teleport_stage_5:Teleport::0:121"
+		"OnCase01" "stage_x_lower_door_5AddOutputOnFullyOpen v_model1:EnableMotion::0.1:121"
+		"OnCase01" "stage_x_lower_door_5AddOutputOnFullyOpen v_model1:DisableMotion::2:121"
+		"OnCase04" "stage_5_lower_door_relay_reinforcements_5Enable21"
+		"OnCase07" "stage_5_lower_door_relay_reinforcements_7Enable21"
+	}
+	insert:
+	{
+		"OnCase01" "stage_5_lower_door_button_5,AddOutput,OnPressed Spawn_Tank_Teleport_stage_5:Teleport:::1,,1"
+		"OnCase01" "stage_5_lower_door_button_5,AddOutput,OnPressed v_button1:RunScriptCode:function InputUse() { return false; }::1,,1"
+		"OnCase01" "stage_5_lower_door_button_5,AddOutput,OnPressed v_model1:EnableMotion:::1,,1"
+		"OnCase01" "stage_5_lower_door_button_5,AddOutput,OnPressed v_model1:DisableMotion::2:1,,1"
+		"OnCase01" "stage_5_lower_door_button_5,AddOutput,OnPressed v_button1:RunScriptCode:function InputUse() { return activator.GetTeam() == 3; }:2:1,,1"
+		"OnCase01" "stage_5_lower_door_button_5,AddOutput,OnPressed v_button1:RunScriptCode:delete InputUse;:10:1,,1"
+		"OnCase04" "stage_5_lower_door_case,AddOutput,OnCase02 stage_5_lower_door_relay_reinforcements_5:Trigger:::1,,1"
+		"OnCase07" "stage_5_lower_door_case,AddOutput,OnCase03 stage_5_lower_door_relay_reinforcements_7:Trigger:::1,,1"
+	}
+}
+
+; Fix input of "All Events Unlocked" text.
+modify:
+{
+	match:
+	{
+		"classname" "logic_compare"
+		"targetname" "Mode_Supreme_Compare"
+	}
+	delete:
+	{
+		"OnGreaterThan" "Global_GameText_AnnouncementFireUser451"
+	}
+	insert:
+	{
+		"OnGreaterThan" "Global_GameText_Announcement,FireUser4, ,5,1"
+	}
+}
+
+; Fix broken music in stage 5 "Solo Ending".
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "stage_5_extreme_relay"
+	}
+	replace:
+	{
+		"spawnflags" "1"
+	}
+	delete:
+	{
+		"OnTrigger" "music_master_ambient_exAddOutputmusic/extreme_new_new/e_stage_5_end_good_2_extra.mp30.11"
+	}
+	insert:
+	{
+		"OnTrigger" "music_master_ambient_ex,AddOutput,message music/extreme_new_new/e_stage_5_end_good_2_extra.mp3,.01,1"
+	}
+}
+
+; Fix "Antlion" item user being able to exploit on stage 5.
+add:
+{
+	"classname" "trigger_multiple"
+	"targetname" "stage_5_liftteleport1"
+	"origin" "4592 -4600 10904"
+	"spawnflags" "1"
+	"model" "*33"
+	"filtername" "team_filter_zombies"
+	"wait" "1e30"
+	"OnStartTouch" "!activator,SetLocalOrigin,4688 -2032 11184,,-1"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "filter_activator_team"
+		"targetname" "stage_5_core_column_end_button_blue"
+	}
+	insert:
+	{
+		"OnUser1" "stage_5_liftteleport1,Kill,,3,1"
+	}
+}
+
+; Fix stage 5 hint entity getting killed early and not showing rest of the texts.
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "stage_5_core_hit_relay"
+	}
+	delete:
+	{
+		"OnUser4" "stage_5_end_hintKill01"
+	}
+}
+
+; The manager entity.
+; This change requires having the "lms1main1.nut" file placed inside "scripts/vscripts/gfl" folder.
+add:
+{
+	"classname" "info_target"
+	"targetname" "map1manager1"
+	"vscripts" "gfl/lms1main1"
+	"thinkfunction" "Think"
+	"OnUser1" "BigNet,Kill,,,1"
+	"OnUser1" "commentary_semaphore,Kill,,,1"
+}
+
+; Add bias towards events and stage 5 damage for selecting the last man in stage 5 and prevent same person being selected twice.
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "stage_5_top_relay_core_working"
+	}
+	insert:
+	{
+		"OnTrigger" "map1manager1,CallScriptFunction,StopTrackingZombieDamage,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Stage_End_Stage_5"
+	}
+	insert:
+	{
+		"OnTrigger" "map1manager1,CallScriptFunction,Stage5Ended,,1"
+	}
+}
+
+; Events.
+modify:
+{
+	match:
+	{
+		"classname" "weapon_deagle"
+		"targetname" "/Weapon_(M(utator|60|ine)|T(hundergun|urret)|Inmunizer|PortalGun|Gauss|ZeroGravity|Extra_(Inmunizer|Unlimmited))_Weapon|Spawn_Fuel_Gun/"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "map1manager1,CallScriptFunction,PlayerCompletedEvent,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_glock"
+		"targetname" "/(Weapon_Turbo|NPC_Train_Driver)_Weapon/"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "map1manager1,CallScriptFunction,PlayerCompletedEvent,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "/Human_Item_Mech_Knife|wpn_jugger/"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "map1manager1,CallScriptFunction,PlayerCompletedEvent,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "/stage_(x_(btn_end|part_4_explosion_button)|1_(b(utton_tower_top|ridge_button)|road_button_alternative_path)|2_(minifier_button|b(tn_main|utton_(weapon_door|factory_control|core_(factory|generator)))|escape_trigger))/"
+	}
+	insert:
+	{
+		"OnPressed" "map1manager1,CallScriptFunction,PlayerCompletedEvent,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "/stage_(3_(button_lock(_[2-6]|)|corridor_button_3x|core_button)|4_(part_3_button|end_button_protection)|5_lower_door_button_(1|5|7|LIFT))/"
+	}
+	insert:
+	{
+		"OnPressed" "map1manager1,CallScriptFunction,PlayerCompletedEvent,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "stage_1_extratrigger1"
+	}
+	insert:
+	{
+		"OnTrigger" "stage_1_base_button_4,AddOutput,OnPressed map1manager1:CallScriptFunction:PlayerCompletedEvent::1,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox"
+		"targetname" "stage_x_end_door_breakable"
+	}
+	replace:
+	{
+		"classname" "func_physbox_multiplayer"
+		"spawnflags" "15003648"
+	}
+	insert:
+	{
+		"OnBreak" "map1manager1RunScriptCodePlayerCompletedEvent(_.driver1);1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "stage_1_cargo_heli_trigger"
+	}
+	insert:
+	{
+		"OnTrigger" "map1manager1RunScriptCodePlayerCompletedEvent(_.driver1);1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "/stage_3_tests_relay_([1-2]|[5-6])/"
+	}
+	insert:
+	{
+		"OnTrigger" "map1manager1,CallScriptFunction,PlayerCompletedEvent,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Human_Item_Mech_Teleportation"
+	}
+	insert:
+	{
+		"OnTrigger" "map1manager1,CallScriptFunction,PlayerCompletedEvent,,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "/stage_4_mech_(rocket(_flame|)|minigun)/"
+	}
+	insert:
+	{
+		"OnTrigger" "map1manager1,CallScriptFunction,PlayerCompletedEvent,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "/stage_nuke_inmuzer[1-3]/"
+	}
+	insert:
+	{
+		"OnStartTouch" "map1manager1,CallScriptFunction,PlayerCompletedEvent,,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "filter_activator_team"
+		"targetname" "/tank_who_entered|stage_(3_buton_filter|5_top_sync_button_((nor|sou)th|(ea|we)st)_filter)/"
+	}
+	insert:
+	{
+		"OnPass" "map1manager1,CallScriptFunction,PlayerCompletedEvent,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "filter_activator_team"
+		"targetname" "Vehicle_Car1_Test"
+	}
+	insert:
+	{
+		"OnFail" "map1manager1,CallScriptFunction,PlayerCompletedEvent,,1"
+	}
+}
+
+; Add text for showing your stats on events.
+add:
+{
+	"classname" "game_text"
+	"targetname" "map1statstext1"
+	"y" ".2"
+	"x" "-1"
+	"channel" "5"
+	"color" "255 255 0"
+	"color2" "128 128 0"
+	"effect" "2"
+	"fadein" ".05"
+	"fadeout" "1"
+	"fxtime" ".5"
+	"holdtime" "2"
+}
+
+add:
+{
+	"classname" "info_game_event_proxy"
+	"targetname" "map1eventgenerator1"
+	"event_name" "player_info"
+}
+
+add:
+{
+	"classname" "logic_eventlistener"
+	"targetname" "map1eventlistener1"
+	"EventName" "player_connect"
+	"FetchEventData" "1"
+	"IsEnabled" "1"
+	"TeamNum" "-1"
+}
+
+add:
+{
+	"classname" "logic_eventlistener"
+	"targetname" "map1eventlistener2"
+	"EventName" "player_activate"
+	"FetchEventData" "1"
+	"IsEnabled" "1"
+	"TeamNum" "-1"
+}
+
+add:
+{
+	"classname" "logic_eventlistener"
+	"targetname" "map1eventlistener3"
+	"EventName" "player_say"
+	"FetchEventData" "1"
+	"IsEnabled" "1"
+	"TeamNum" "-1"
+}
+
+add:
+{
+	"classname" "logic_eventlistener"
+	"targetname" "map1eventlistener4"
+	"EventName" "player_info"
+	"FetchEventData" "1"
+	"IsEnabled" "1"
+	"TeamNum" "-1"
+}
+
+add:
+{
+	"classname" "logic_eventlistener"
+	"targetname" "map1eventlistener5"
+	"EventName" "player_disconnect"
+	"FetchEventData" "1"
+	"IsEnabled" "1"
+	"TeamNum" "-1"
+}
+
+add:
+{
+	"classname" "logic_eventlistener"
+	"targetname" "map1eventlistener6"
+	"EventName" "player_hurt"
+	"FetchEventData" "1"
+	"IsEnabled" "1"
+	"TeamNum" "2"
+}
+
+; Add kill credit and kill icons.
+add:
+{
+	"classname" "point_hurt"
+	"targetname" "map1takedamage1"
+	"DamageTarget" "map1takedamagevictim1"
+	"DamageRadius" ".01"
+	"Damage" ".01"
+	"DamageDelay" ".01"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Weapon_Turret_Deployed_DevBrush"
+	}
+	replace:
+	{
+		"damagecap" "0"
+		"damage" "0"
+	}
+	delete:
+	{
+		"OnStartTouch" "Weapon_Turret_Deployed_FireSoundVolume00-1"
+		"OnStartTouch" "Weapon_Turret_Deployed_FireSoundVolume100.01-1"
+		"OnStartTouch" "Weapons_Turret_Model_ParticleStart0-1"
+		"OnStartTouch" "Weapons_Turret_Model_ParticleStop0.1-1"
+	}
+	insert:
+	{
+		"OnHurtPlayer" "map1manager1RunScriptCodeTakeDamage(3000, 0, _.dronegun, _.player_turret_carrier);-1"
+		"OnHurtPlayer" "Weapon_Turret_Deployed_FireSound,PlaySound,,,-1"
+		"OnHurtPlayer" "Weapons_Turret_Model_Particle,Start,,,-1"
+		"OnHurtPlayer" "Weapons_Turret_Model_Particle,Stop,,,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Weapon_Mine_HasAmmo"
+	}
+	insert:
+	{
+		"OnTrigger" "!activatorRunScriptCodeEntities.FindByName(null, _.Weapon_Mine_Projectile_Model + strTemplateWildcard).SetOwner(self);.01-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "prop_dynamic"
+		"targetname" "Weapon_Mine_Projectile_Model"
+	}
+	insert:
+	{
+		"OnUser4" "Spawn_Explosion_Small_Damage&*,AddOutput,OnStartTouch !self:FireUser1::-1,.03,1"
+		"OnUser4" "!selfRunScriptCodeEntities.FindByName(null, _.Spawn_Explosion_Small_Damage + strTemplateWildcard).SetOwner(self.GetOwner());.031"
+		"OnUser4" "Spawn_Explosion_Small_Damage&*,AddOutput,damage 0,.03,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Weapon_Gauss_Hurt"
+	}
+	replace:
+	{
+		"classname" "trigger_multiple"
+	}
+	delete:
+	{
+		"nodmgforce" "0"
+		"damagetype" "512"
+		"damagemodel" "0"
+		"damagecap" "20"
+		"damage" "20000"
+	}
+	insert:
+	{
+		"wait" "1e30"
+		"OnStartTouch" "map1manager1RunScriptCodeTakeDamage(activator.GetHealth(), 512, _.zone_repulsor);-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "weapon_deagle"
+		"targetname" "Weapon_M60_Weapon"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "!activatorRunScriptCodeEntities.FindByName(null, _.Weapon_Mounted_Gun_Hurt + strTemplateWildcard).SetOwner(self);-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Weapon_Mounted_Gun_Hurt"
+	}
+	replace:
+	{
+		"classname" "trigger_multiple"
+	}
+	delete:
+	{
+		"nodmgforce" "0"
+		"damagetype" "512"
+		"damagemodel" "0"
+		"damagecap" "20"
+		"damage" "100"
+	}
+	insert:
+	{
+		"wait" "1e30"
+		"OnStartTouch" "map1manager1RunScriptCodeTakeDamage(100, 512, _.m249, caller.GetOwner());-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Zombie_Item_Predator_Plasma_Relay"
+	}
+	replace:
+	{
+		"spawnflags" "1"
+		"StartDisabled" "1"
+	}
+	delete:
+	{
+		"OnSpawn" "Zombie_Item_Predator_Plasma_PhyFireUser12-1"
+	}
+	insert:
+	{
+		"OnSpawn" "Zombie_Item_Predator_Plasma_Phy,KillHierarchy,,2,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Zombie_Item_Predator_Plasma_Hurt"
+	}
+	replace:
+	{
+		"classname" "trigger_once"
+	}
+	delete:
+	{
+		"nodmgforce" "0"
+		"Damagetype" "0"
+		"damagemodel" "0"
+		"damagecap" "20"
+		"damage" "50"
+		"OnHurt" "Zombie_Item_Predator_Plasma_PhyFireUser10-1"
+	}
+	insert:
+	{
+		"parentname" "Zombie_Item_Predator_Plasma_Phy"
+		"OnTrigger" "map1manager1RunScriptCodeTakeDamage(25, 0, _.zone_repulsor, _.zombie_predator);1"
+		"OnTrigger" "Zombie_Item_Predator_Plasma_Phy,KillHierarchy,,,1"
+		"OnTrigger" "Zombie_Item_Predator_Thruster,Kill,,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox_multiplayer"
+		"targetname" "Zombie_Item_Predator_Plasma_Phy"
+	}
+	replace:
+	{
+		"spawnflags" "14966784"
+		"health" "9999"
+		"minhealthdmg" "9999"
+		"nodamageforces" "1"
+	}
+	delete:
+	{
+		"OnUser1" "Zombie_Item_Predator_Plasma_ThrusterKill0-1"
+		"OnUser1" "Zombie_Item_Predator_Plasma_RelayKill0-1"
+		"OnUser1" "Zombie_Item_Predator_Plasma_MeasureKill0-1"
+	}
+	insert:
+	{
+		"effects" "32"
+		"OnDamaged" "!self,KillHierarchy,,,1"
+		"OnDamaged" "Zombie_Item_Predator_Thruster,Kill,,,1"
+	}
+}
+
+filter:
+{
+	"classname" "logic_measure_movement"
+	"targetname" "Zombie_Item_Predator_Plasma_Measure"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_template"
+		"targetname" "Zombie_Item_Predator_Plasma_Template"
+	}
+	delete:
+	{
+		"Template06" "Zombie_Item_Predator_Plasma_Measure"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_compare"
+		"targetname" "Zombie_Item_Predator_Suicide_2"
+	}
+	insert:
+	{
+		"OnLessThan" "!activatorRunScriptCodeif (self.GetTeam() == 2) EntFireByHandle(caller, _.FireUser1, __, -1, self, null);1"
+		"OnUser1" "Spawn_Nuke_Hurt&*,AddOutput,OnStartTouch !self:FireUser1:::-1,7.01,1"
+		"OnUser1" "!activatorRunScriptCodeEntities.FindByName(null, _.Spawn_Nuke_Hurt + strTemplateWildcard).SetOwner(self);7.011"
+		"OnUser1" "!activatorRunScriptCodeEntities.FindByName(Entities.FindByName(null, _.Spawn_Nuke_Hurt + strTemplateWildcard), _.Spawn_Nuke_Hurt + strTemplateWildcard).SetOwner(self);7.011"
+		"OnUser1" "Spawn_Nuke_Hurt&*,AddOutput,damage 0,7.01,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Spawn_Nuke_Hurt"
 	}
 	replace:
 	{
@@ -2248,51 +4723,7 @@ modify:
 	}
 	insert:
 	{
-		"OnTrigger" "stage_4_trigger_end,Enable,,20,1"
-	}
-}
-
-;Not necessary since the trigger was remade
-;modify:
-;{
-;	match:
-;	{
-;		"classname" "trigger_once"
-;		"targetname" "stage_4_trigger_end"
-;	}
-;	replace:
-;	{
-;		"StartDisabled" "1"
-;	}
-;	insert:
-;	{
-;		"OnTrigger" "stage_4_end_button*,Unlock,,,1"
-;		"OnTrigger" "stage_4_end_button_protection,AddOutput,OnDamaged !self:FireUser1:::1,,1"
-;	}
-;}
-
-; Fix a huge skip in stage 4 involving jumping from plane's wing.
-add:
-{
-	"classname" "func_reflective_glass"
-	"targetname" "stage_4_custombrush1"
-	"spawnflags" "2"
-	"origin" "-2944 -4416 5344"
-	"Solidity" "2"
-	"solidbsp" "1"
-}
-
-; Fix stage 4 train early trigger.
-modify:
-{
-	match:
-	{
-		"classname" "weapon_glock"
-		"targetname" "NPC_Train_Driver_Weapon"
-	}
-	delete:
-	{
-		"OnPlayerPickup" "NPC_Train_Driver_AreaFireUser101"
+		"OnUser1" "map1manager1RunScriptCodeTakeDamage(activator.GetHealth(), 0, _.prop_exploding_barrel, caller.GetOwner());-1"
 	}
 }
 
@@ -2300,59 +4731,512 @@ modify:
 {
 	match:
 	{
-		"classname" "path_track"
-		"targetname" "Vehicle_Fake_Truck_Path_Track_5"
+		"classname" "logic_relay"
+		"targetname" "Spawn_Nuke_Trigger"
 	}
 	insert:
 	{
-		"OnPass" "NPC_Train_Driver_Area,FireUser1,,,1"
+		"OnSpawn" "Spawn_Nuke_Hurt,Enable,,.01,1"
 	}
 }
 
-; Try a better system for "Train Driver" item holder slowdown on stage 4.
 modify:
 {
 	match:
 	{
-		"classname" "trigger_multiple"
-		"targetname" "NPC_Train_Driver_Weapon_Slower"
+		"classname" "trigger_hurt"
+		"targetname" "Zombie_Item_Tank_Hurt_Trigger"
 	}
 	replace:
 	{
-		"wait" ".01"
+		"classname" "trigger_multiple"
 	}
 	delete:
 	{
-		"OnTrigger" "Global_SpeedModifySpeed10.95-1"
-		"OnTrigger" "Global_SpeedModifySpeed0.80-1"
+		"nodmgforce" "0"
+		"damagetype" "4"
+		"damagemodel" "0"
+		"damagecap" "20"
+		"damage" "199"
 	}
 	insert:
 	{
-		"OnStartTouch" "Global_Speed,ModifySpeed,.8,,-1"
-		"OnEndTouch" "Global_Speed,ModifySpeed,1,,-1"
+		"wait" "1e30"
+		"OnStartTouch" "map1manager1RunScriptCodeTakeDamage(99, 4, _.fists);-1"
 	}
 }
 
-; Part of the above fix, but wanted to take a second here and admire the beautiful targetname.
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Zombie_Item_Alma_Attack_Hurt_Relay"
+	}
+	delete:
+	{
+		"OnTrigger" "!activatorSetHealth-15-1"
+	}
+	insert:
+	{
+		"OnTrigger" "map1manager1RunScriptCodeTakeDamage(activator.GetHealth(), 0, _.Default, _.zombie_alma);5-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "/Spawn_Phy_Car_(2_|)Hurt/"
+	}
+	replace:
+	{
+		"classname" "trigger_multiple"
+	}
+	delete:
+	{
+		"nodmgforce" "0"
+		"damagetype" "0"
+		"damagemodel" "0"
+		"damagecap" "20"
+		"damage" "2000"
+	}
+	insert:
+	{
+		"OnStartTouch" "map1manager1RunScriptCodeTakeDamage(activator.GetHealth(), 1, _.Default, _.zombie_tank);-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "wpn_jugger_trigger"
+	}
+	replace:
+	{
+		"Damagetype" "0"
+		"damagecap" "0"
+		"damage" "0"
+	}
+	insert:
+	{
+		"OnHurt" "map1manager1RunScriptCodeTakeDamage(1000, 512, _.fists);-1"
+		"OnHurtPlayer" "map1manager1RunScriptCodeTakeDamage(1000, 512, _.fists);-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "gatlingbullettimer"
+	}
+	insert:
+	{
+		"OnTrigger" "Spawn_Projectile_Physic&*,AddOutput,OnUser4 !self:FireUser1:::1,.01,-1"
+		"OnTrigger" "!activatorRunScriptCodeEntities.FindByName(null, _.Spawn_Projectile_Physic + strTemplateWildcard).SetOwner(self);.01-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Human_Item_Mech_Hurt_Punch"
+	}
+	replace:
+	{
+		"classname" "trigger_multiple"
+	}
+	delete:
+	{
+		"nodmgforce" "0"
+		"damagetype" "512"
+		"damagemodel" "0"
+		"damagecap" "20"
+		"damage" "2000"
+	}
+	insert:
+	{
+		"wait" "1e30"
+		"OnStartTouch" "map1manager1RunScriptCodeTakeDamage(1000, 512, _.fists, caller.GetMoveParent().GetMoveParent().GetOwner());-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Human_Item_Mech_Hurt_Fire"
+	}
+	replace:
+	{
+		"Damagetype" "0"
+		"damagecap" "0"
+		"damage" "0"
+	}
+	insert:
+	{
+		"OnHurt" "map1manager1RunScriptCodeTakeDamage(275, 512, _.inferno, caller.GetMoveParent().GetMoveParent().GetMoveParent().GetOwner());-1"
+		"OnHurtPlayer" "map1manager1RunScriptCodeTakeDamage(275, 512, _.inferno, caller.GetMoveParent().GetMoveParent().GetMoveParent().GetOwner());-1"
+		"OnHurtPlayer" "!activator,IgniteLifetime,3,,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Human_Item_Mech_Hurt_Minigun"
+	}
+	replace:
+	{
+		"Damagetype" "0"
+		"damagecap" "0"
+		"damage" "0"
+	}
+	insert:
+	{
+		"OnHurt" "map1manager1RunScriptCodeTakeDamage(150, 512, _.m249, caller.GetMoveParent().GetMoveParent().GetMoveParent().GetOwner());-1"
+		"OnHurtPlayer" "map1manager1RunScriptCodeTakeDamage(150, 512, _.m249, caller.GetMoveParent().GetMoveParent().GetMoveParent().GetOwner());-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_compare"
+		"targetname" "Human_Item_Mech_Attack_Rocketlauncher"
+	}
+	insert:
+	{
+		"OnEqualTo" "Spawn_Projectile_Physic&*,AddOutput,OnUser4 !self:FireUser2:::1,1.21,-1"
+		"OnEqualTo" "!activatorRunScriptCodeEntities.FindByName(null, _.Spawn_Projectile_Physic + strTemplateWildcard).SetOwner(self);1.21-1"
+	}
+}
+
 modify:
 {
 	match:
 	{
 		"classname" "func_physbox_multiplayer"
-		"targetname" "CSGOFUCKFIX"
-	}
-	delete:
-	{
-		"OnUser3" "NPC_Train_Driver_Weapon_SlowerKill0-1"
+		"targetname" "Spawn_Projectile_Physic"
 	}
 	insert:
 	{
-		"OnUser3" "NPC_Train_Driver_Weapon_Slower,Disable,,,1"
-		"OnUser3" "NPC_Train_Driver_Weapon_Slower,Kill,,1,1"
+		"OnUser1" "Spawn_Explosion_Small_Damage&*,AddOutput,OnStartTouch !self:FireUser1:::-1,.03,1"
+		"OnUser1" "!selfRunScriptCodeEntities.FindByName(null, _.Spawn_Explosion_Small_Damage + strTemplateWildcard).SetOwner(self.GetOwner());.031"
+		"OnUser1" "Spawn_Explosion_Small_Damage&*,AddOutput,damage 0,.03,1"
+		"OnUser1" "Spawn_Explosion_Small_Damage_H&*,AddOutput,OnStartTouch !self:FireUser1:::-1,.03,1"
+		"OnUser1" "!selfRunScriptCodeEntities.FindByName(null, _.Spawn_Explosion_Small_Damage_H + strTemplateWildcard).SetOwner(self.GetOwner());.031"
+		"OnUser1" "Spawn_Explosion_Small_Damage_H&*,AddOutput,damage 0,.03,1"
+		"OnUser2" "Spawn_Explosion_Small_Damage&*,AddOutput,OnStartTouch !self:FireUser1:::-1,.03,1"
+		"OnUser2" "!selfRunScriptCodeEntities.FindByName(null, _.Spawn_Explosion_Small_Damage + strTemplateWildcard).SetOwner(self.GetOwner());.031"
+		"OnUser2" "Spawn_Explosion_Small_Damage&*,AddOutput,damage 0,.03,1"
 	}
 }
 
-; Replace "AddOutput basevelocity" inputs with "SetVelocity".
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Spawn_Explosion_Small_Damage"
+	}
+	insert:
+	{
+		"OnUser1" "map1manager1RunScriptCodeTakeDamage(activator.GetHealth(), 0, _.prop_exploding_barrel, caller.GetOwner());-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Spawn_Explosion_Small_Damage_H"
+	}
+	insert:
+	{
+		"OnUser1" "map1manager1RunScriptCodeTakeDamage(activator.GetHealth(), 0, _.prop_exploding_barrel, caller.GetOwner());-1"
+	}
+}
+
+add:
+{
+	"classname" "filter_activator_name"
+	"targetname" "map1nobossfilter1"
+	"filtername" "zombie_boss"
+	"Negated" "1"
+}
+
+add:
+{
+	"classname" "filter_multi"
+	"targetname" "map1nononbosszombie1"
+	"Filter01" "map1nobossfilter1"
+	"Filter02" "team_filter_zombies"
+	"Negated" "1"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "point_viewcontrol_multiplayer"
+		"targetname" "stage_cinematic_cam"
+	}
+	delete:
+	{
+		"OnUser2" "playerSetDamageFilterfilter_no_zombies0-1"
+	}
+	insert:
+	{
+		"OnUser2" "playerRunScriptCodeif (self.GetTeam() == 3 && self.GetHealth()) EntFireByHandle(self, _.SetDamageFilter, _.filter_no_zombies, -1, null, null);-1"
+		"OnUser2" "map1manager1RunScriptCodebIsStage3Boss = true;-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Zombie_Item_Boss_Trigger_Hurt_Claws"
+	}
+	insert:
+	{
+		"OnUser1" "playerRunScriptCodeif (bIsStage3Boss  && self.GetTeam() == 3 && self.GetHealth()) EntFireByHandle(self, _.SetDamageFilter, _.map1nononbosszombie1, -1, null, null);.2-1"
+		"OnUser1" "playerRunScriptCodeif (bIsStage3Boss  && self.GetTeam() == 3 && self.GetHealth()) EntFireByHandle(self, _.SetDamageFilter, _.filter_no_zombies, -1, null, null);.8-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Zombie_Item_Boss_Trigger_Hurt_Claws_Crouch"
+	}
+	insert:
+	{
+		"OnUser1" "playerRunScriptCodeif (bIsStage3Boss  && self.GetTeam() == 3 && self.GetHealth()) EntFireByHandle(self, _.SetDamageFilter, _.map1nononbosszombie1, -1, null, null);.6-1"
+		"OnUser1" "playerRunScriptCodeif (bIsStage3Boss  && self.GetTeam() == 3 && self.GetHealth()) EntFireByHandle(self, _.SetDamageFilter, _.filter_no_zombies, -1, null, null);3-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "info_particle_system"
+		"targetname" "Zombie_Item_Boss_Stomp_Particle"
+	}
+	insert:
+	{
+		"OnUser1" "playerRunScriptCodeif (bIsStage3Boss  && self.GetTeam() == 3 && self.GetHealth()) EntFireByHandle(self, _.SetDamageFilter, _.map1nononbosszombie1, -1, null, null);-1"
+		"OnUser1" "playerRunScriptCodeif (bIsStage3Boss  && self.GetTeam() == 3 && self.GetHealth()) EntFireByHandle(self, _.SetDamageFilter, _.filter_no_zombies, -1, null, null);.3-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Zombie_Item_Boss_Trigger_Hurt_Claws_2"
+	}
+	insert:
+	{
+		"OnUser1" "playerRunScriptCodeif (bIsStage3Boss  && self.GetTeam() == 3 && self.GetHealth()) EntFireByHandle(self, _.SetDamageFilter, _.map1nononbosszombie1, -1, null, null);.6-1"
+		"OnUser1" "playerRunScriptCodeif (bIsStage3Boss  && self.GetTeam() == 3 && self.GetHealth()) EntFireByHandle(self, _.SetDamageFilter, _.filter_no_zombies, -1, null, null);1-1"
+		"OnUser2" "playerRunScriptCodeif (bIsStage3Boss  && self.GetTeam() == 3 && self.GetHealth()) EntFireByHandle(self, _.SetDamageFilter, _.map1nononbosszombie1, -1, null, null);-1"
+		"OnUser2" "playerRunScriptCodeif (bIsStage3Boss  && self.GetTeam() == 3 && self.GetHealth()) EntFireByHandle(self, _.SetDamageFilter, _.filter_no_zombies, -1, null, null);1.5-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Zombie_Item_Boss_Attach_Hurt_Explosion"
+	}
+	insert:
+	{
+		"OnUser1" "playerRunScriptCodeif (bIsStage3Boss  && self.GetTeam() == 3 && self.GetHealth()) EntFireByHandle(self, _.SetDamageFilter, _.map1nononbosszombie1, -1, null, null);1.2-1"
+		"OnUser1" "playerRunScriptCodeif (bIsStage3Boss  && self.GetTeam() == 3 && self.GetHealth()) EntFireByHandle(self, _.SetDamageFilter, _.filter_no_zombies, -1, null, null);1.4-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Zombie_Item_Boss_Trigger_Hurt_Claws"
+	}
+	replace:
+	{
+		"classname" "trigger_multiple"
+	}
+	delete:
+	{
+		"nodmgforce" "0"
+		"damagetype" "128"
+		"damagemodel" "0"
+		"damagecap" "20"
+		"damage" "250"
+	}
+	insert:
+	{
+		"wait" "1e30"
+		"filtername" "filter_no_zombies"
+		"OnStartTouch" "map1manager1RunScriptCodeTakeDamage(125, 128);-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "/Zombie_Item_Boss_Trigger_Hurt_Claws_(Crouch|2)/"
+	}
+	replace:
+	{
+		"classname" "trigger_multiple"
+	}
+	delete:
+	{
+		"nodmgforce" "0"
+		"damagetype" "128"
+		"damagemodel" "0"
+		"damagecap" "20"
+		"damage" "3000"
+	}
+	insert:
+	{
+		"wait" "1e30"
+		"OnStartTouch" "map1manager1RunScriptCodeTakeDamage(activator.GetHealth(), 128);-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_case"
+		"targetname" "Zombie_Item_Boss_Attack_Case"
+	}
+	insert:
+	{
+		"OnCase03" "!activatorRunScriptCodeEntities.FindByName(null, _.SPawn_Mercer_Spikes_Hurt).SetOwner(self);1.01-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "SPawn_Mercer_Spikes_Relay"
+	}
+	insert:
+	{
+		"OnSpawn" "SPawn_Mercer_Spikes_Hurt,Enable,,.01,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "SPawn_Mercer_Spikes_Hurt"
+	}
+	replace:
+	{
+		"classname" "trigger_multiple"
+		"StartDisabled" "1"
+	}
+	delete:
+	{
+		"nodmgforce" "0"
+		"damagetype" "128"
+		"damagemodel" "0"
+		"damagecap" "20"
+		"damage" "1000"
+	}
+	insert:
+	{
+		"wait" "1e30"
+		"OnStartTouch" "map1manager1RunScriptCodeTakeDamage(activator.GetHealth(), 128, _.Default, caller.GetOwner());-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Zombie_Item_Boss_Attach_Hurt_Explosion"
+	}
+	replace:
+	{
+		"classname" "trigger_multiple"
+	}
+	delete:
+	{
+		"nodmgforce" "0"
+		"damagetype" "128"
+		"damagemodel" "0"
+		"damagecap" "20"
+		"damage" "170"
+	}
+	insert:
+	{
+		"wait" "1e30"
+		"OnStartTouch" "map1manager1RunScriptCodeTakeDamage(85, 128, _.prop_exploding_barrel, caller.GetMoveParent().GetMoveParent().GetOwner());-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox_multiplayer"
+		"targetname" "stage_x_boss_end_support_breakable_1"
+	}
+	insert:
+	{
+		"OnBreak" "Spawn_Explosion_Damage&*,AddOutput,OnStartTouch !self:FireUser1:::-1,.01,1"
+		"OnBreak" "!activatorRunScriptCodeEntities.FindByName(null, _.Spawn_Explosion_Damage + strTemplateWildcard).SetOwner(self);.011"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_hurt"
+		"targetname" "Spawn_Explosion_Damage"
+	}
+	insert:
+	{
+		"OnUser1" "map1manager1RunScriptCodeTakeDamage(50000, 0, _.prop_exploding_barrel, caller.GetOwner());-1"
+	}
+}
+
+; Replace "AddOutput basevelocity" inputs with "RunScriptCode SetVelocity".
 modify:
 {
 	match:
@@ -2451,6 +5335,8 @@ modify:
 	}
 }
 
+; Nerf "Predator" item jump ability height a little.
+
 modify:
 {
 	match:
@@ -2464,7 +5350,7 @@ modify:
 	}
 	insert:
 	{
-		"OnLessThan" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x, self.GetVelocity().y, 500));-1"
+		"OnLessThan" "!activatorRunScriptCodeself.SetVelocity(Vector(self.GetVelocity().x, self.GetVelocity().y, 400));-1"
 	}
 }
 
@@ -2538,13 +5424,62 @@ modify:
 	}
 }
 
-; Fix broken music in stage 5 "Solo Ending".
+; Make stage 5 zombie teleports cover everywhere.
+filter:
+{
+	"classname" "trigger_teleport"
+	"targetname" "lms_fuckoffzombies"
+}
+
+; Optimize stage 5 "Last Man Standing" triggers and fix it killing the "Mech" user.
+filter:
+{
+	"classname" "func_rotating"
+	"targetname" "stage_5_last_man_rotating"
+}
+
+filter:
+{
+	"classname" "trigger_once"
+	"targetname" "stage_5_last_man_detect"
+}
+
+filter:
+{
+	"classname" "filter_activator_name"
+	"targetname" "filter_last_man_name_allow"
+}
+
+filter:
+{
+	"classname" "trigger_teleport"
+	"targetname" "teleport_lastmanstanding"
+}
+
+filter:
+{
+	"classname" "filter_activator_name"
+	"targetname" "filter_last_man_name"
+}
+
+filter:
+{
+	"classname" "filter_multi"
+	"targetname" "filter_last_man"
+}
+
+filter:
+{
+	"classname" "trigger_hurt"
+	"targetname" "stage_5_last_man_trigger"
+}
+
 modify:
 {
 	match:
 	{
 		"classname" "logic_relay"
-		"targetname" "stage_5_extreme_relay"
+		"targetname" "stage_5_core_destroyed"
 	}
 	replace:
 	{
@@ -2552,55 +5487,284 @@ modify:
 	}
 	delete:
 	{
-		"OnTrigger" "music_master_ambient_exAddOutputmusic/extreme_new_new/e_stage_5_end_good_2_extra.mp30.11"
+		"vscripts" "hichatu/actual_random_solo.nut"
+		"OnTrigger" "stage_5_last_man_detectEnable0-1"
 	}
 	insert:
 	{
-		"OnTrigger" "music_master_ambient_ex,AddOutput,message music/extreme_new_new/e_stage_5_end_good_2_extra.mp3,.01,1"
+		"OnTrigger" "map1manager1,CallScriptFunction,PickLastManStanding,,1"
+		"OnTrigger" "Human_Item_Mech_Model,KillHierarchy,,,1"
+		"OnTrigger" "Human_Item_Mech_UI,Kill,,,1"
+		"OnTrigger" "Human_Item_Mech_Attack_*,Kill,,,1"
+		"OnTrigger" "Human_Item_Mech_Logic,Kill,,,1"
+		"OnTrigger" "Human_Item_Mech_Timer,Kill,,,1"
+		"OnTrigger" "Human_Item_Mech_Selector,Kill,,,1"
+		"OnTrigger" "Human_Item_Mech_Walk,Kill,,,1"
+		"OnTrigger" "Human_Item_Mech_Sound_*,Kill,,,1"
+		"OnTrigger" "Human_Item_Mech_Explosion,Kill,,,1"
+		"OnTrigger" "Mech_Particle_Teleportation,Kill,,,1"
+		"OnTrigger" "Human_Item_Mech_Teleportation,Kill,,,1"
+		"OnTrigger" "Human_Item_Mech_Hint,Kill,,,1"
+		"OnTrigger" "stage_4_Human_Item_Mech_Hint_Telp,Kill,,,1"
+		"OnTrigger" "human_item_mech_hurt_punch,Kill,,,1"
+		"OnTrigger" "Human_Item_Mech_Cam,Kill,,,1"
+		"OnTrigger" "Human_Item_Mech_Cam,Disable,,,1"
+		"OnTrigger" "stage_x_juggernaut_*,Kill,,,1"
+		"OnTrigger" "stage_4_juggernaut_escape_trigger,Kill,,,1"
+		"OnTrigger" "Human_Item_Mech_Show_Model,Kill,,,1"
+		"OnTrigger" "stage_4_mech_*,Kill,,,1"
+		"OnTrigger" "filter_mech,Kill,,,1"
+		"OnTrigger" "Human_Item_Mech_KnifeRunScriptCodeif (!self.GetOwner()) self.Destroy();1"
+		"OnTrigger" "human_mech,AddOutput,targetname ,,1"
+		"OnTrigger" "human_mechRunScriptCodeEntFireByHandle(Entities.FindByName(null, _.Global_Speed), _.ModifySpeed, (1).tostring(), -1, self, null);1"
+		"OnTrigger" "human_mech,AddOutput,gravity 1,,1"
+		"OnTrigger" "human_mech,AddOutput,health 100,,1"
+		"OnTrigger" "human_mech,AddOutput,rendermode 0,,1"
+		"OnTrigger" "human_mech,AddOutput,renderfx 0,,1"
+		"OnTrigger" "human_mech,SetDamageFilter,,,1"
+		"OnTrigger" "wpn_jugger_branch,Kill,,,1"
+		"OnTrigger" "wpn_jugger_fx,Kill,,,1"
+		"OnTrigger" "wpn_jugger_mdl,Kill,,,1"
+		"OnTrigger" "wpn_jugger_phys,Kill,,,1"
+		"OnTrigger" "wpn_jugger_relay_*,Kill,,,1"
+		"OnTrigger" "wpn_jugger_hurt,Kill,,,1"
+		"OnTrigger" "wpn_jugger_snd_*,Kill,,,1"
+		"OnTrigger" "wpn_jugger_trigger,Kill,,,1"
+		"OnTrigger" "wpn_jugger_ui,Kill,,,1"
+		"OnTrigger" "item1human1juggernaut1multiple1,Kill,,,1"
+		"OnTrigger" "item1human1juggernaut1multipledisabled1,Kill,,,1"
+		"OnTrigger" "stage_5_dog_spawner,Kill,,,1"
+		"OnTrigger" "wpn_juggerRunScriptCodeif (!self.GetOwner()) self.Destroy();1"
+		"OnTrigger" "monsterRunScriptCodeEntFireByHandle(Entities.FindByName(null, _.Global_Speed), _.ModifySpeed, (1).tostring(), -1, self, null);1"
+		"OnTrigger" "monster,SetDamageFilter,,,1"
+		"OnTrigger" "monster,AddOutput,rendermode 0,,1"
+		"OnTrigger" "monster,AddOutput,renderfx 0,,1"
+		"OnTrigger" "monster,AddOutput,renderamt 255,,1"
+		"OnTrigger" "monster,AddOutput,health 100,,1"
+		"OnTrigger" "last_man_standingRunScriptCodeEntFireByHandle(Entities.FindByName(null, _.Global_Speed), _.ModifySpeed, (1).tostring(), -1, self, null);11"
+		"OnTrigger" "last_man_standing,SetDamageFilter,,1,1"
+		"OnTrigger" "last_man_standing,AddOutput,rendermode 0,1,1"
+		"OnTrigger" "last_man_standing,AddOutput,renderfx 0,1,1"
+		"OnTrigger" "last_man_standing,AddOutput,renderamt 255,1,1"
+		"OnTrigger" "monster,AddOutput,targetname ,1,1"
+		"OnTrigger" "monsterRunScriptCodeEntFireByHandle(Entities.FindByName(null, _.Global_Speed), _.ModifySpeed, (1).tostring(), -1, self, null);11"
+		"OnTrigger" "monster,SetDamageFilter,,1,1"
+		"OnTrigger" "monster,AddOutput,rendermode 0,1,1"
+		"OnTrigger" "monster,AddOutput,renderfx 0,1,1"
+		"OnTrigger" "monster,AddOutput,renderamt 255,1,1"
+		"OnTrigger" "last_man_standingRunScriptCodeEntFireByHandle(Entities.FindByName(null, _.Global_Speed), _.ModifySpeed, (1).tostring(), -1, self, null);2.31"
+		"OnTrigger" "human_mechRunScriptCodeEntFireByHandle(Entities.FindByName(null, _.Global_Speed), _.ModifySpeed, (1).tostring(), -1, self, null);2.31"
+		"OnTrigger" "last_man_standingRunScriptCodeEntFireByHandle(Entities.FindByName(null, _.Global_Speed), _.ModifySpeed, (1).tostring(), -1, self, null);31"
+		"OnTrigger" "human_mechRunScriptCodeEntFireByHandle(Entities.FindByName(null, _.Global_Speed), _.ModifySpeed, (1).tostring(), -1, self, null);31"
 	}
 }
 
-; Fix "Antlion" item user being able to exploit on stage 5.
-add:
-{
-	"classname" "trigger_multiple"
-	"targetname" "stage_5_liftteleport1"
-	"origin" "4592 -4600 10904"
-	"spawnflags" "1"
-	"model" "*33"
-	"filtername" "team_filter_zombies"
-	"wait" ".01"
-	"OnStartTouch" "!activator,SetLocalOrigin,4688 -2032 11184,,-1"
-}
-
-modify:
-{
-	match:
-	{
-		"classname" "filter_activator_team"
-		"targetname" "stage_5_core_column_end_button_blue"
-	}
-	insert:
-	{
-		"OnUser1" "stage_5_liftteleport1,Kill,,3,1"
-	}
-}
-
-; Fix stage 5 hint entity getting killed early and not showing rest of the texts.
+; Reset "Mech" item user's gravity when "Team Win Ending" is triggered.
 modify:
 {
 	match:
 	{
 		"classname" "logic_relay"
-		"targetname" "stage_5_core_hit_relay"
+		"targetname" "stage_5_top_relay_core_working"
 	}
-	delete:
+	insert:
 	{
-		"OnUser4" "stage_5_end_hintKill01"
+		"OnTrigger" "human_mech,AddOutput,gravity 1,,1"
 	}
 }
 
-; Fix weapon item buttons not rotating properly
+; Fix "Mech" item setting speed of user to normal after doing attacks.
+modify:
+{
+	match:
+	{
+		"classname" "logic_compare"
+		"targetname" "Human_Item_Mech_Attack_Punch"
+	}
+	delete:
+	{
+		"OnEqualTo" "Global_SpeedModifySpeed12.3-1"
+	}
+	insert:
+	{
+		"OnEqualTo" "Global_Speed,ModifySpeed,.8,2.3,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_compare"
+		"targetname" "Human_Item_Mech_Attack_Rocketlauncher"
+	}
+	delete:
+	{
+		"OnEqualTo" "Global_SpeedModifySpeed13-1"
+	}
+	insert:
+	{
+		"OnEqualTo" "Global_Speed,ModifySpeed,.8,3,-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "env_hudhint"
+		"targetname" "Human_Item_Mech_Hint"
+	}
+	delete:
+	{
+		"OnUser1" "Human_Item_Mech_HintFireUser10.5-1"
+	}
+	insert:
+	{
+		"OnUser1" "Human_Item_Mech_Hint,FireUser1,,.01,-1"
+	}
+}
+
+; Useless entity.
+filter:
+{
+	"classname" "info_target"
+	"targetname" "driver1"
+}
+
+; Make "270" angles to "90" cause why not.
+modify:
+{
+	match:
+	{
+		"angles" "0 270 0"
+	}
+	replace:
+	{
+		"angles" "0 -90 0"
+	}
+}
+
+; Turn "info_teleport_destination"s with no parent to "logic_relay", bless "Moltard".
+modify:
+{
+	match:
+	{
+		"classname" "info_teleport_destination"
+	}
+	insert:
+	{
+		"hasparent" "0"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "info_teleport_destination"
+		"parentname" "/.*/"
+	}
+	replace:
+	{
+		"hasparent" "1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"hasparent" "0"
+	}
+	replace:
+	{
+		"classname" "logic_relay"
+		"StartDisabled" "1"
+	}
+	delete:
+	{
+		"hasparent" "0"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"hasparent" "1"
+	}
+	delete:
+	{
+		"hasparent" "1"
+	}
+}
+
+; Fix "ModifySpeed" outputs.
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox_multiplayer"
+		"targetname" "Zombie_Item_Predator_Health"
+	}
+	delete:
+	{
+		"OnBreak" "zombie_predatorAddOutputOnUser4 Global_Speed:ModifySpeed:0:0:10-1"
+		"OnBreak" "zombie_predatorFireUser40.01-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "env_entity_maker"
+		"targetname" "Zombie_Item_Predator_Suicide_Maker"
+	}
+	delete:
+	{
+		"OnEntitySpawned" "zombie_predatorFireUser40.01-1"
+		"OnEntitySpawned" "zombie_predatorAddOutputOnUser4 Global_Speed:ModifySpeed:0:0:10-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox_multiplayer"
+		"targetname" "Human_Item_Mech_Body"
+	}
+	delete:
+	{
+		"OnBreak" "human_mechAddOutputOnUser1 Global_Speed:ModifySpeed:0:0:10-1"
+		"OnBreak" "human_mechAddOutputOnUser1 Global_Speed:ModifySpeed:1:1.7:10-1"
+	}
+	insert:
+	{
+		"OnBreak" "human_mechRunScriptCodeEntFireByHandle(Entities.FindByName(null, _.Global_Speed), _.ModifySpeed, (1).tostring(), -1, self, null);1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "/stage_5_Trap_Gravity_Trigger([3-4]|)/"
+	}
+	delete:
+	{
+		"OnStartTouch" "Global_SpeedModifySpeed1.1510-1"
+	}
+	insert:
+	{
+		"OnStartTouch" "Global_Speed,ModifySpeed,1,10,-1"
+	}
+}
+
+; Fix weapon item buttons not rotating.
 modify:
 {
 	match:
@@ -2629,72 +5793,21 @@ modify:
 	}
 }
 
-
-; OLD CHANGES THAT WERE FORGOTTON ABOUT LIKE THE COINS YOU HAVE DOWN THE SIDE OF THE SOFA
-; WORKS FINE OFFLINE I THINK
-
-; Reduce stage 2 car generator movelinear speed slightly.
+; Fix "Alma" item being able to be triggered when no human is inside her zone.
 modify:
 {
 	match:
 	{
-		"classname" "func_movelinear"
-		"targetname" "Spawn_Phy_Car_Generator_Movelinear"
-	}
-	replace:
-	{
-		"speed" "1900"
-	}
-}
-
-; Remove missing sounds to prevent le linux server lag
-modify:
-{
-	match:
-	{
-		"unlocked_sound" "7"
-	}
-	replace:
-	{
-		"unlocked_sound" "0"
-	}
-}
-modify:
-{
-	match:
-	{
-		"soundopenoverride" "Doors.CombineGate_citizen_stop2"
+		"classname" "trigger_multiple"
+		"targetname" "Zombie_Item_Alma_Detector"
 	}
 	delete:
 	{
-		"soundopenoverride" "Doors.CombineGate_citizen_stop2"
+		"OnStartTouch" "Zombie_Item_Alma_RelayEnable0-1"
 	}
-}
-modify:
-{
-	match:
+	insert:
 	{
-		"soundcloseoverride" "Doors.CombineGate_citizen_stop2"
-	}
-	delete:
-	{
-		"soundcloseoverride" "Doors.CombineGate_citizen_stop2"
-	}
-}
-
-; Make sure stage 5 door can only be selected to open if its event is unlocked, fix buttons and make "Tank" vehicle only spawn when button is pressed and make it human only for the first 10 seconds.
-modify:
-{
-	match:
-	{
-		"classname" "logic_case"
-		"targetname" "stage_5_lower_door_case"
-	}
-	delete:
-	{
-		"OnCase01" "stage_5_lower_door_relay_reinforcements_1Trigger0-1"
-		"OnCase02" "stage_5_lower_door_relay_reinforcements_5Trigger0-1"
-		"OnCase03" "stage_5_lower_door_relay_reinforcements_7Trigger0-1"
+		"OnStartTouchAll" "Zombie_Item_Alma_Relay,Enable,,,-1"
 	}
 }
 
@@ -2703,43 +5816,274 @@ modify:
 	match:
 	{
 		"classname" "logic_relay"
-		"targetname" "/stage_5_lower_door_relay_reinforcements_(1|5|7)/"
+		"targetname" "Zombie_Item_Alma_Relay"
 	}
-	replace:
+	delete:
 	{
-		"StartDisabled" "0"
+		"OnTrigger" "!selfDisable0-1"
+		"OnTrigger" "!selfEnable15-1"
 	}
 }
 
-; Kill stage 5 door relays when pressed.
+; Fix "Alma" item reverting humans back to wrong speed if they didn't die.
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "Zombie_Item_Alma_Attack_Hurt"
+	}
+	delete:
+	{
+		"OnStartTouch" "Global_SpeedModifySpeed1.155-1"
+	}
+	insert:
+	{
+		"OnStartTouch" "Global_Speed,ModifySpeed,1,5,-1"
+	}
+}
+
+; Fix stage 3 boss not being able to attack after being defeated, replace "movetype" inputs with speedmod, adjust some timings, fix "Boss" item animations, carry some outputs from "path_track" to here and don't lose the round if "Boss" item user disconnects.
+modify:
+{
+	match:
+	{
+		"classname" "weapon_knife"
+		"targetname" "Zombie_Item_Boss_Knife"
+	}
+	delete:
+	{
+		"OnPlayerPickup" "!activatorSetDamageFilter0-1"
+	}
+	insert:
+	{
+		"OnPlayerPickup" "!activator,SetDamageFilter,filter_no_humans,,1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "Zombie_Item_Boss_Trigger_Attack"
+	}
+	replace:
+	{
+		"wait" "1e30"
+	}
+}
+
 modify:
 {
 	match:
 	{
 		"classname" "logic_relay"
-		"targetname" "stage_5_west_survivors_tr"
+		"targetname" "Zombie_Item_Boss_Normal_Transformation"
+	}
+	delete:
+	{
+		"OnTrigger" "!activatorAddOutputgravity 0.43-1"
+		"OnTrigger" "Global_SpeedModifySpeed2.55-1"
+		"OnTrigger" "Global_SpeedModifySpeed00-1"
+		"OnTrigger" "Zombie_Item_Boss_Attack_SelectorDisable39-1"
+		"OnTrigger" "Zombie_Item_Boss_Attack_CaseFireUser438-1"
+		"OnTrigger" "!activatorAddOutputmovetype 00-1"
+		"OnTrigger" "!activatorAddOutputmovetype 25-1"
+	}
+	insert:
+	{
+		"OnTrigger" "zombie_boss,AddOutput,gravity .4,5,1"
+		"OnTrigger" "Global_Speed,ModifySpeed,0,,1"
+		"OnTrigger" "Global_Speed,ModifySpeed,2.5,5,1"
+		"OnTrigger" "Zombie_Item_Boss_Normal_UI,Kill,,40,1"
+		"OnTrigger" "Zombie_Item_Boss_Attack_Selector,Kill,,40,1"
+		"OnTrigger" "Zombie_Item_Boss_Attack_Case,Kill,,40,1"
+		"OnTrigger" "Zombie_Item_Boss_Attack_Selected,Kill,,40,1"
+		"OnTrigger" "Zombie_Item_Boss_Attack_Selected,HideHudHint,,40,1"
+		"OnTrigger" "Zombie_Item_Boss_Trigger_Attack,Kill,,40,1"
+		"OnTrigger" "Zombie_Item_Boss_CanDieRunScriptCodeif (!Entities.FindByName(null, _.zombie_boss)) EntFireByHandle(self, _.Enable, __, -1, null, null);42.981"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Zombie_Item_Boss_CanDie"
+	}
+	replace:
+	{
+		"spawnflags" "0"
+	}
+	delete:
+	{
+		"OnTrigger" "Global_GameText_AnnouncementRunScriptCodesetMessage(21)0-1"
+		"OnTrigger" "Global_SpeedModifySpeed00-1"
+		"OnTrigger" "Global_SpeedModifySpeed214-1"
+		"OnTrigger" "Zombie_Item_Boss_Morphed_ModelSetDefaultAnimationrun9-1"
+		"OnTrigger" "Zombie_Item_Boss_Morphed_ModelFireUser17-1"
+		"OnTrigger" "zombie_bossAddOutputmovetype 00-1"
+		"OnTrigger" "zombie_bossAddOutputmovetype 214-1"
+		"OnTrigger" "zombie_bossRunScriptCodeforeach(k,_ in {Global_Speed_suppress=1}){foreach(v,__ in {ModifySpeed=1}){EntFire(k, v, '0'.tochar(), 0.0, self);}}0.11"
+		"OnTrigger" "zombie_bossRunScriptCodeforeach(k,_ in {Global_Speed_suppress=1}){foreach(v,__ in {ModifySpeed=1}){EntFire(k, v, '0'.tochar(), 0.0, self);}}13.91"
+	}
+	insert:
+	{
+		"OnTrigger" "Global_Speed_suppress,ModifySpeed,0,,1"
+		"OnTrigger" "!self,Kill,,,1"
+		"OnTrigger" "!selfRunScriptCodeEntFireByHandle(self, _.FireUser + (Entities.FindByName(null, _.zombie_boss) ? 1 : 2), __, -1, null, null);1"
+		"OnUser1" "Global_GameText_AnnouncementRunScriptCodesetMessage(21);1"
+		"OnUser2" "Global_GameText_Announcement,SetText,** HE HAS LEFT! GO GO ESCAPE FROM THE LAB! **,,1"
+		"OnTrigger" "Zombie_Item_Boss_Morphed_Model,SetDefaultAnimation,run,13,1"
+		"OnTrigger" "Zombie_Item_Boss_Morphed_Model,FireUser1,,13,1"
+		"OnTrigger" "zombie_boss,AddOutput,movetype 2,15,1"
+		"OnTrigger" "Global_Speed,ModifySpeed,2,15,1"
+		"OnTrigger" "Global_Speed_suppress,ModifySpeed,1,15,1"
+	}
+}
+
+filter:
+{
+	"classname" "trigger_once"
+	"targetname" "stage_3_end_teleport"
+}
+
+filter:
+{
+	"classname" "filter_multi"
+	"targetname" "filter_no_boss_all_humans"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stage_x_end_vehicle_escape_track_1"
+	}
+	delete:
+	{
+		"OnPass" "zombie_bossFireUser40.1-1"
+		"OnPass" "Global_GameText_AnnouncementRunScriptCodesetMessage(21)0-1"
+		"OnPass" "zombie_bossAddOutputOnUser4 Global_Speed:ModifySpeed:0::10-1"
+		"OnPass" "zombie_bossAddOutputOnUser4 Global_Speed:ModifySpeed:1.7:14:10-1"
+		"OnPass" "Global_GameText_AnnouncementFireUser40-1"
+		"OnPass" "Zombie_Item_Boss_Morphed_ModelSetPlaybackRate00.1-1"
+		"OnPass" "Zombie_Item_Boss_Morphed_ModelSetPlaybackRate112.1-1"
+		"OnPass" "Zombie_Item_Boss_Attack_CaseAddOutputtargetname Zombie_Item_Boss_Attack_Deactivated0-1"
+		"OnPass" "Zombie_Item_Boss_Attack_DeactivatedAddOutputtargetname Zombie_Item_Boss_Attack_Case13-1"
+		"OnPass" "zombie_bossAddOutputmovetype 00-1"
+		"OnPass" "zombie_bossAddOutputmovetype 214-1"
+		"OnPass" "playerSetDamageFilter0.11"
+	}
+	insert:
+	{
+		"OnPass" "zombie_boss,AddOutput,movetype 0,,1"
+		"OnPass" "playerRunScriptCodeif (self.GetTeam() == 3 && self.GetHealth()) EntFireByHandle(self, _.SetDamageFilter, __, -1, null, null);1"
+		"OnPass" "map1manager1RunScriptCodebIsStage3Boss = false;1"
+		"OnPass" "playerRunScriptCodeif (self.GetTeam() == 2 && self.GetName() != _.zombie_boss && self.GetHealth()) self.SetAbsOrigin(Vector(716, 1908, 1443));1"
+	}
+}
+
+; Make "Boss" item breakable type "None", humans aren't metal.
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox_multiplayer"
+		"targetname" "Zombie_Item_Boss_Super_Health"
+	}
+	replace:
+	{
+		"material" "10"
+	}
+}
+
+; Show them how a real nothing filter is done.
+modify:
+{
+	match:
+	{
+		"classname" "filter_activator_name"
+		"targetname" "filter_nothing"
+	}
+	replace:
+	{
+		"classname" "filter_base"
+		"Negated" "1"
+	}
+	delete:
+	{
+		"filtername" "nothing_etc"
+		"OnFail" "!activatorSetHealth-10-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "stage5_zmratio"
 	}
 	replace:
 	{
 		"spawnflags" "1"
 	}
+	delete:
+	{
+		"vscripts" "hichatu/alternatezratio.nut"
+		"OnTrigger" "consoleCommandzr_infect_mzombie_ratio 221"
+		"OnTrigger" "!selfRunScriptCode//AlternateRatioSystem() - Stripper if needed21"
+		"OnTrigger" "stage5_zmhpsetterEnable201"
+	}
+	insert:
+	{
+		"OnTrigger" "console,Command,zr_infect_mzombie_ratio 2,,1"
+	}
 }
 
+filter:
+{
+	"classname" "logic_relay"
+	"targetname" "stage5_zmhpsetter"
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Stage_Start_Stage_5"
+	}
+	insert:
+	{
+		"OnTrigger" "map1manager1RunScriptCodebDidZombiesSpawnOnStage5 = true;201"
+		"OnTrigger" "game_playerdie,AddOutput,OnUse map1manager1:CallScriptFunction:DiedOnStage5::-1,20,1"
+	}
+}
+
+; Handle it in a think function.
+filter:
+{
+	"classname" "logic_timer"
+	"targetname" "stage5_zmhpsetter"
+}
+
+; Fix early triggering nuke on stage 4.
 modify:
 {
 	match:
 	{
 		"classname" "logic_case"
-		"targetname" "Case_Events_Stage_5"
-		"origin" "-4256 11256 -8552"
-	}
-	delete:
-	{
-		"OnCase13" "stage_5_lower_door_relay_reinforcements_1Enable21"
+		"targetname" "stage_4_part_5_case_controller"
 	}
 	insert:
 	{
-		"OnCase13" "stage_5_lower_door_case,AddOutput,OnCase01 stage_5_lower_door_relay_reinforcements_1:Trigger:::1,,1"
+		"OnCase03" "stage_4_part_5_trigger,Enable,,20,1"
+		"OnCase03" "stage_4_end_buttonRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1201"
 	}
 }
 
@@ -2747,12 +6091,111 @@ modify:
 {
 	match:
 	{
-		"classname" "func_button"
-		"targetname" "/stage_5_lower_door_button_(1|5)/"
+		"classname" "trigger_once"
+		"targetname" "stage_4_part_5_trigger"
 	}
 	replace:
 	{
-		"spawnflags" "3073"
+		"StartDisabled" "1"
+	}
+	insert:
+	{
+		"OnTrigger" "stage_4_trigger_end,Enable,,10,1"
+		"OnTrigger" "stage_4_end_buttonRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }601"
+	}
+}
+
+; Move stage 4 end trigger back some units so it no longer sticks out of the wall.
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "stage_4_trigger_end"
+	}
+	replace:
+	{
+		"origin" "11408 -9200 3504"
+		"StartDisabled" "1"
+	}
+	insert:
+	{
+		"OnTrigger" "stage_4_end_button*,Unlock,,,1"
+		"OnTrigger" "stage_4_end_button_protection,AddOutput,OnDamaged !self:FireUser1:::1,,1"
+		"OnTrigger" "stage_4_end_buttonRunScriptCodefunction InputUse() { local iTeam = activator.GetTeam(); if (iTeam == 2) EntFire(_.ZOMBIESTRIGGERED, _.Trigger); return iTeam == 3; }1"
+	}
+}
+
+; Fix skipping over the oil tank in stage 4.
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "stage_4_teleport"
+	}
+	replace:
+	{
+		"origin" "4260 -707.5 5184"
+		"wait" "1e30"
+	}
+	delete:
+	{
+		"model" "*715"
+	}
+}
+
+; Kill the door on stage 4 when "Ultralisk" passes.
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "stage_x_ultralistk_path_5"
+	}
+	insert:
+	{
+		"OnPass" "stage_4_part_6_door_1,Kill,,5,1"
+	}
+}
+
+; Fix a huge skip in stage 4 involving jumping from plane's wing.
+add:
+{
+	"classname" "func_reflective_glass"
+	"targetname" "stage_4_custombrush1"
+	"spawnflags" "2"
+	"origin" "-2944 -4416 5344"
+	"Solidity" "2"
+	"solidbsp" "1"
+}
+
+; Make this door open to the other side.
+modify:
+{
+	match:
+	{
+		"classname" "prop_door_rotating"
+		"targetname" "stage_4_part_5_door_2"
+	}
+	replace:
+	{
+		"spawnflags" "2048"
+	}
+}
+
+; Make stage 1 barrels not break the incorrect walls.
+modify:
+{
+	match:
+	{
+		"classname" "prop_physics"
+		"targetname" "stage_1_end_explosion_barrel_2"
+	}
+	delete:
+	{
+		"OnBreak" "stage_4_part_4_doorBreak0-1"
+		"OnPlayerUse" "stage_1_wall_way2Break0-1"
 	}
 }
 
@@ -2760,28 +6203,86 @@ modify:
 {
 	match:
 	{
-		"classname" "logic_case"
-		"targetname" "Case_Events_Stage_5"
-		"origin" "-4272 11224 -8552"
+		"classname" "prop_physics"
+		"targetname" "stage_1_end_explosion_barrel"
 	}
 	delete:
 	{
-		"OnCase01" "stage_x_lower_door_5AddOutputOnFullyOpen Spawn_Tank_Teleport_stage_5:Teleport::0:121"
-		"OnCase01" "stage_x_lower_door_5AddOutputOnFullyOpen v_model1:EnableMotion::0.1:121"
-		"OnCase01" "stage_x_lower_door_5AddOutputOnFullyOpen v_model1:DisableMotion::2:121"
-		"OnCase04" "stage_5_lower_door_relay_reinforcements_5Enable21"
-		"OnCase07" "stage_5_lower_door_relay_reinforcements_7Enable21"
+		"OnPlayerUse" "stage_x_end_door_breakableBreak0-1"
+		"OnBreak" "stage_4_part_4_doorBreak0-1"
 	}
 	insert:
 	{
-		"OnCase01" "stage_5_lower_door_button_5AddOutputOnPressed Spawn_Tank_Teleport_stage_5:Teleport::0:11"
-		"OnCase01" "stage_5_lower_door_button_5AddOutputOnPressed v_button1:RunScriptCode:function InputUse() { return false; }:0:11"
-		"OnCase01" "stage_5_lower_door_button_5AddOutputOnPressed v_model1:EnableMotion::0.1:11"
-		"OnCase01" "stage_5_lower_door_button_5AddOutputOnPressed v_model1:DisableMotion::2:11"
-		"OnCase01" "stage_5_lower_door_button_5AddOutputOnPressed v_button1:RunScriptCode:function InputUse() { return activator.GetTeam() == 3; }:2:11"
-		"OnCase01" "stage_5_lower_door_button_5AddOutputOnPressed v_button1:RunScriptCode:delete InputUse;:10:11"
-		"OnCase04" "stage_5_lower_door_caseAddOutputOnCase02 stage_5_lower_door_relay_reinforcements_5:Trigger::0:11"
-		"OnCase07" "stage_5_lower_door_caseAddOutputOnCase03 stage_5_lower_door_relay_reinforcements_7:Trigger::0:11"
+		"OnBreak" "stage_x_end_door_breakable,Break,,,1"
 	}
 }
 
+; Fix stage 4 train early trigger.
+modify:
+{
+	match:
+	{
+		"classname" "weapon_glock"
+		"targetname" "NPC_Train_Driver_Weapon"
+	}
+	delete:
+	{
+		"OnPlayerPickup" "NPC_Train_Driver_AreaFireUser101"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "path_track"
+		"targetname" "Vehicle_Fake_Truck_Path_Track_5"
+	}
+	insert:
+	{
+		"OnPass" "NPC_Train_Driver_Area,FireUser1,,,1"
+	}
+}
+
+; Try a better system for "Train Driver" item holder slowdown on stage 4.
+modify:
+{
+	match:
+	{
+		"classname" "trigger_multiple"
+		"targetname" "NPC_Train_Driver_Weapon_Slower"
+	}
+	replace:
+	{
+		"wait" "1e30"
+	}
+	delete:
+	{
+		"OnTrigger" "Global_SpeedModifySpeed10.95-1"
+		"OnTrigger" "Global_SpeedModifySpeed0.80-1"
+	}
+	insert:
+	{
+		"OnStartTouch" "Global_Speed,ModifySpeed,.8,,-1"
+		"OnEndTouch" "Global_Speed,ModifySpeed,1,,-1"
+	}
+}
+
+; Part of the above fix, but wanted to take a second here and admire the beautiful targetname.
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox_multiplayer"
+		"targetname" "CSGOFUCKFIX"
+	}
+	delete:
+	{
+		"OnUser3" "NPC_Train_Driver_Weapon_SlowerKill0-1"
+	}
+	insert:
+	{
+		"OnUser3" "NPC_Train_Driver_Weapon_Slower,Disable,,,1"
+		"OnUser3" "NPC_Train_Driver_Weapon_Slower,Kill,,1,1"
+	}
+}

--- a/stripper/ze_last_man_standing_p3.cfg
+++ b/stripper/ze_last_man_standing_p3.cfg
@@ -573,7 +573,7 @@ modify:
 	{
 		"OnTrigger" "Zombie_Item_Vortigaunt_Template,SetLocalOrigin,7886 3108 -13662,,-1"
 	}
-}	
+}
 
 ; Fix boost on stage 5 with core.
 modify:

--- a/vscripts/lms1main1.nut
+++ b/vscripts/lms1main1.nut
@@ -1,0 +1,687 @@
+// By Berke "STEAM_0:0:95142811"
+
+::strTemplateWildcard <- "&*",
+::hManagerScriptScope <- this, hMapEntities <- array(3), UserIDQueuePlayers <- array(0), hPlayers <- array(0), SavedPlayerInfos <- array(0), ::bIsStage3Boss <- false, bDidZombiesSpawnOnStage5 <- false, bShouldTrackZombieDamage <- true,
+CurrentPlayerInfos <-
+{
+	hPlayer = null,
+	iUserID = 0
+},
+::__ <- " ",
+::_ <- delegate
+{
+	function _get(strKey)
+	{
+		return strKey;
+	}
+}
+: {};
+
+local hEventListener;
+
+while (hEventListener = Entities.FindByName(hEventListener, "map1eventlistener*"))
+{
+	hEventListener.__KeyValueFromString("classname", "info_ladder");
+
+	local strEventName = "Player";
+
+	switch (hEventListener.GetName().slice(17).tointeger())
+	{
+		case 1:
+		{
+			strEventName += "Connect";
+
+			break;
+		}
+
+		case 2:
+		{
+			strEventName += "Activate";
+
+			break;
+		}
+
+		case 3:
+		{
+			strEventName += "Say";
+
+			break;
+		}
+
+		case 4:
+		{
+			strEventName += "Info";
+
+			break;
+		}
+
+		case 5:
+		{
+			strEventName += "Disconnect";
+
+			break;
+		}
+
+		case 6:
+			strEventName += "ZombieHurt";
+	}
+
+	hEventListener.__KeyValueFromString("targetname", "");
+
+	hEventListener.ValidateScriptScope();
+
+	local hScriptScope = hEventListener.GetScriptScope();
+
+	hScriptScope.strEventName <- strEventName;
+
+	delegate
+	{
+		function _newslot(strKey, Values)
+		{
+			hManagerScriptScope[strEventName](Values);
+		}
+	}
+	: hScriptScope;
+}
+
+EntFireByHandle(self, "FireUser1", "", -1, null, null);
+
+function RoundSpawn()
+{
+	hMapEntities = array(3), bIsStage3Boss = false, bDidZombiesSpawnOnStage5 = false, bShouldTrackZombieDamage = true, CurrentPlayerInfos.hPlayer = null, CurrentPlayerInfos.iUserID = 0;
+
+	UserIDQueuePlayers.clear();
+
+	local hEventListener;
+
+	while (hEventListener = Entities.FindByName(hEventListener, "map1eventlistener*"))
+		hEventListener.Destroy();
+
+	foreach (SavedPlayerInfo in SavedPlayerInfos)
+		SavedPlayerInfo.iStage5Damage = 0;
+}
+
+function Think()
+{
+	if (UserIDQueuePlayers.len())
+	{
+		local UserIDQueuePlayerFirst = UserIDQueuePlayers.remove(0), hUserIDQueuePlayerFirst = UserIDQueuePlayerFirst.hPlayer;
+
+		CurrentPlayerInfos.hPlayer = hUserIDQueuePlayerFirst, CurrentPlayerInfos.iUserID = UserIDQueuePlayerFirst.iUserID;
+
+		EntFireByHandle(GetUserIDEventGenerator(), "GenerateGameEvent", "", -1, hUserIDQueuePlayerFirst, null);
+	}
+
+	if (bDidZombiesSpawnOnStage5)
+		foreach (hPlayer in hPlayers)
+			if (hPlayer.GetTeam() == 2 && hPlayer.GetHealth() > 900  && hPlayer.GetName().find("zombie_") != 0)
+				hPlayer.SetHealth(900);
+
+	return -1;
+}
+
+function PlayerConnect(EventData)
+{
+	local strSteamID = EventData.networkid;
+
+	if (strSteamID == "BOT")
+		SavedPlayerInfos.push(
+		{
+			hPlayer = null,
+			strName = EventData.name,
+			iUserID = EventData.userid,
+			strSteamID = "",
+			iCompletedEvents = 0,
+			iStage5Damage = 0,
+			bIsSoloBanned = false
+		});
+
+	else
+	{
+		strSteamID = strSteamID.slice(8);
+
+		local bIsPlayerInfoUnsaved = true;
+
+		foreach (SavedPlayerInfo in SavedPlayerInfos)
+			if (SavedPlayerInfo.strSteamID == strSteamID)
+			{
+				SavedPlayerInfo.strName = EventData.name, SavedPlayerInfo.iUserID = EventData.userid, bIsPlayerInfoUnsaved = false;
+
+				break;
+			}
+
+		if (bIsPlayerInfoUnsaved)
+			SavedPlayerInfos.push(
+			{
+				hPlayer = null,
+				strName = EventData.name,
+				iUserID = EventData.userid,
+				strSteamID = strSteamID,
+				iCompletedEvents = 0,
+				iStage5Damage = 0,
+				bIsSoloBanned = false
+			});
+	 }
+}
+
+function PlayerActivate(EventData)
+{
+	local hPlayer, bIsPlayerUnsaved = false;
+
+	while (hPlayer = Entities.FindByClassname(hPlayer, "player"))
+	{
+		bIsPlayerUnsaved = true;
+
+		foreach (hStoredPlayer in hPlayers)
+			if (hPlayer == hStoredPlayer)
+			{
+				bIsPlayerUnsaved = false;
+
+				break;
+			}
+
+		if (bIsPlayerUnsaved)
+		{
+			hPlayers.push(hPlayer);
+
+			break;
+		}
+	}
+
+	if (!bIsPlayerUnsaved)
+	{
+		hPlayer = null;
+
+		while (hPlayer = Entities.FindByClassname(hPlayer, "cs_bot"))
+		{
+			bIsPlayerUnsaved = true;
+
+			foreach (hStoredPlayer in hPlayers)
+				if (hPlayer == hStoredPlayer)
+				{
+					bIsPlayerUnsaved = false;
+
+					break;
+				}
+
+			if (bIsPlayerUnsaved)
+			{
+				hPlayers.push(hPlayer);
+
+				break;
+			}
+		}
+	}
+
+	local iUserID = EventData.userid, bIsPlayerUnregistered = true;
+
+	foreach (SavedPlayerInfo in SavedPlayerInfos)
+		if (SavedPlayerInfo.iUserID == iUserID)
+		{
+			bIsPlayerUnregistered = false;
+
+			break;
+		}
+
+	if (bIsPlayerUnregistered)
+		SavedPlayerInfos.push(
+		{
+			hPlayer = null,
+			strName = "",
+			iUserID = EventData.userid,
+			strSteamID = "",
+			iCompletedEvents = 0,
+			iStage5Damage = 0,
+			bIsSoloBanned = false
+		});
+
+	bIsPlayerUnregistered = true;
+
+	foreach (hPlayer in hPlayers)
+	{
+		bIsPlayerUnregistered = true;
+
+		foreach (SavedPlayerInfo in SavedPlayerInfos)
+			if (SavedPlayerInfo.hPlayer == hPlayer)
+			{
+				bIsPlayerUnregistered = false;
+
+				break;
+			}
+
+		if (bIsPlayerUnregistered)
+		{
+			UserIDQueuePlayers.push(
+			{
+				hPlayer = hPlayer,
+				iUserID = EventData.userid
+			});
+
+			break;
+		}
+	}
+}
+
+function PlayerSay(EventData)
+{
+	if (rstrip(EventData.text).tolower() == "!showmapstats")
+	{
+		local iUserID = EventData.userid;
+
+		foreach (SavedPlayerInfo in SavedPlayerInfos)
+			if (SavedPlayerInfo.iUserID == iUserID)
+			{
+				local hPlayer = SavedPlayerInfo.hPlayer;
+				
+				if (hPlayer)
+				{
+					local strText = "Completed events: " + SavedPlayerInfo.iCompletedEvents;
+
+					if (bDidZombiesSpawnOnStage5 && bShouldTrackZombieDamage && hPlayer.GetTeam() == 3 && hPlayer.GetHealth())
+						strText += "\\nStage 5 damage: " + SavedPlayerInfo.iStage5Damage;
+
+					PrintStatsText(hPlayer, strText);
+				}
+
+				break;
+			}
+	}
+}
+
+function PlayerInfo(EventData)
+{
+	if (CurrentPlayerInfos.iUserID)
+	{
+		foreach (SavedPlayerInfo in SavedPlayerInfos)
+			if (SavedPlayerInfo.iUserID == CurrentPlayerInfos.iUserID)
+			{
+				SavedPlayerInfo.hPlayer = CurrentPlayerInfos.hPlayer;
+
+				break;
+			}
+
+		if (!UserIDQueuePlayers.len())
+			CurrentPlayerInfos.hPlayer = null, CurrentPlayerInfos.iUserID = 0;
+	}
+}
+
+function PlayerDisconnect(EventData)
+{
+	EntFireByHandle(self, "CallScriptFunction", "RemoveDisconnectPlayer", -1, null, null);
+
+	local iUserID = EventData.userid;
+
+	foreach (iOrder, UserIDQueuePlayer in UserIDQueuePlayers)
+		if (UserIDQueuePlayer.iUserID == iUserID)
+		{
+			UserIDQueuePlayers.remove(iOrder);
+
+			break;
+		}
+
+	foreach (iOrder, SavedPlayerInfo in SavedPlayerInfos)
+		if (SavedPlayerInfo.iUserID == iUserID)
+		{
+			if (SavedPlayerInfo.strSteamID == "")
+				SavedPlayerInfos.remove(iOrder);
+
+			else
+				SavedPlayerInfo.strName = "", SavedPlayerInfo.iUserID = 0, SavedPlayerInfo.hPlayer = null;
+
+			break;
+		}
+}
+
+function RemoveDisconnectPlayer()
+{
+	foreach (iOrder, hPlayer in hPlayers)
+		if (!hPlayer.IsValid())
+		{
+			hPlayers.remove(iOrder);
+
+			break;
+		}
+}
+
+function PlayerZombieHurt(EventData)
+{
+	if (bDidZombiesSpawnOnStage5 && bShouldTrackZombieDamage)
+	{
+		local iAttackerUserID = EventData.attacker;
+
+		if (iAttackerUserID)
+			foreach (SavedPlayerInfo in SavedPlayerInfos)
+				if (SavedPlayerInfo.iUserID == iAttackerUserID)
+				{
+					local hPlayer = SavedPlayerInfo.hPlayer;
+
+					if (hPlayer && hPlayer.GetTeam() == 3)
+					{
+						local flOrigin = hPlayer.GetOrigin(), flOriginX = flOrigin.x, flOriginY = flOrigin.y;
+
+						if (flOriginX >= -1024 && flOriginX <= 10240 && flOriginY >= -10240 && flOriginY <= 1024)
+						{
+							local strName = hPlayer.GetName();
+
+							SavedPlayerInfo.iStage5Damage += strName == "human_mech" || strName == "driver1" ? EventData.dmg_health / 25 : EventData.dmg_health;
+						}
+					}
+
+					break;
+				}
+	}
+}
+
+function PlayerCompletedEvent(Player = "")
+{
+	Player = (activator ? activator.GetClassname() == "player" : false) ? activator : Entities.FindByName(null, Player);
+
+	if (Player && Player.GetTeam() == 3)
+		foreach (SavedPlayerInfo in SavedPlayerInfos)
+			if (SavedPlayerInfo.hPlayer == Player)
+			{
+				SavedPlayerInfo.iCompletedEvents++;
+
+				PrintStatsText(Player, "You have completed an event!\\nCompleted events: " + SavedPlayerInfo.iCompletedEvents);
+
+				break;
+			}
+}
+
+function DiedOnStage5()
+{
+	if (activator.IsValid() && activator.GetTeam() == 3)
+		foreach (SavedPlayerInfo in SavedPlayerInfos)
+			if (SavedPlayerInfo.hPlayer == activator)
+			{
+				if (bShouldTrackZombieDamage)
+					SavedPlayerInfo.iStage5Damage = 0;
+
+				break;
+			}
+}
+
+function StopTrackingZombieDamage()
+{
+	bShouldTrackZombieDamage = false;
+
+	foreach (SavedPlayerInfo in SavedPlayerInfos)
+		SavedPlayerInfo.iStage5Damage = 0;
+}
+
+function Stage5Ended()
+{
+	foreach (SavedPlayerInfo in SavedPlayerInfos)
+		SavedPlayerInfo.iCompletedEvents = 0, SavedPlayerInfo.bIsSoloBanned = false;
+}
+
+function PrintStatsText(hPlayer, strText)
+{
+	local hStatsText = GetStatsText();
+
+	EntFireByHandle(hStatsText, "AddOutput", "spawnflags " + (hPlayer ? 0 : 1), -1, null, null);
+
+	EntFireByHandle(hStatsText, "RunScriptCode", "self.__KeyValueFromString(\"message\", \"" + strText + "\");", -1, null, null);
+
+	EntFireByHandle(hStatsText, "Display", "", -1, hPlayer, null);
+}
+
+function CheckKnifeStrip(iItemType = 0)
+{
+	if (iItemType == 2 ? true : (iItemType ? (activator.GetTeam() == 3 ? true : false) : (activator.GetTeam() == 2 && activator.GetName().find("zombie_") != 0 ? true : false)))
+		for (local hKnife = activator.FirstMoveChild(); hKnife; hKnife = hKnife.NextMovePeer())
+			if (hKnife.GetClassname() == "weapon_knife")
+			{
+				if (!hKnife.FirstMoveChild())
+					hKnife.Destroy();
+
+				break;
+			}
+}
+
+function TakeDamage(iDamage, iDamageType, strKillIcon = "Default", Killer = "Owner")
+{
+	if (typeof Killer == "string")
+		Killer = Killer == "Owner" ? caller.GetMoveParent().GetOwner() : Entities.FindByName(null, Killer);
+
+	if (!Killer || activator.GetTeam() == Killer.GetTeam())
+	{
+		local iNewHealth = activator.GetHealth() - iDamage;
+
+		EntFireByHandle(activator, "SetHealth", iNewHealth < 0 ? "0" : iNewHealth.tostring(), -1, null, null);
+	}
+
+	else
+	{
+		local hTakeDamageEntity = GetTakeDamageEntity();
+
+		EntFireByHandle(hTakeDamageEntity, "AddOutput", "Damage " + iDamage, -1, null, null);
+
+		EntFireByHandle(hTakeDamageEntity, "AddOutput", "DamageType " + iDamageType, -1, null, null);
+
+		if (strKillIcon == "Default")
+			strKillIcon = "point_hurt";
+
+		EntFireByHandle(hTakeDamageEntity, "AddOutput", "classname " + strKillIcon, -1, null, null);
+
+		local strOldTargetName = activator.GetName();
+
+		EntFireByHandle(activator, "AddOutput", "targetname map1takedamagevictim1", -1, null, null);
+
+		EntFireByHandle(hTakeDamageEntity, "Hurt", "", -1, Killer, null);
+
+		EntFireByHandle(activator, "RunScriptCode", "if (self.IsValid() && self.GetName() == \"map1takedamagevictim1\") self.__KeyValueFromString(\"targetname\", \"" + strOldTargetName + "\");", -1, null, null);
+	}
+}
+
+function PickLastManStanding()
+{
+	local PotentialSoloers = array(0), iPotentialSoloersLength = 0;
+
+	for (local iLoopCount = 0; !iPotentialSoloersLength && iLoopCount < 2; iLoopCount++)
+	{
+		iPotentialSoloersLength = 0;
+
+		PotentialSoloers.clear();
+
+		foreach (SavedPlayerInfo in SavedPlayerInfos)
+		{
+			local hPlayer = SavedPlayerInfo.hPlayer;
+
+			if (hPlayer.GetTeam() == 3 && hPlayer.GetHealth() > 0 && (!SavedPlayerInfo.bIsSoloBanned || iLoopCount))
+			{
+				local flOrigin = hPlayer.GetOrigin(), flOriginX = flOrigin.x, flOriginY = flOrigin.y;
+
+				if (flOriginX >= -1024 && flOriginX <= 10240 && flOriginY >= -10240 && flOriginY <= 1024 && flOrigin.z >= 12288)
+				{
+					local iStage5Damage = SavedPlayerInfo.iStage5Damage, iCompletedEvents = SavedPlayerInfo.iCompletedEvents;
+
+					PotentialSoloers.push(
+					{
+						hPlayer = SavedPlayerInfo.hPlayer,
+						strName = SavedPlayerInfo.strName,
+						iCompletedEvents = iCompletedEvents,
+						iStage5Damage = iStage5Damage,
+						iTotalPoints = iStage5Damage + 150 * iCompletedEvents,
+						iPlacement = 1
+					});
+
+					iPotentialSoloersLength++;
+				}
+			}
+		}
+	}
+
+	StopTrackingZombieDamage();
+
+	if (iPotentialSoloersLength)
+	{
+		local SoloPlayerInfo = {};
+
+		if (iPotentialSoloersLength == 1)
+			SoloPlayerInfo = PotentialSoloers[0];
+
+		else
+		{
+			PotentialSoloers.sort(SortSoloByTotalPoints);
+
+			local iLuckBox = array(0);
+
+			foreach (iOrder, PotentialSoloer in PotentialSoloers)
+			{
+				PotentialSoloer.iPlacement = iOrder + 1;
+
+				local iRepeatAmount = 1;
+
+				if (iOrder <= 14)
+					switch (iOrder)
+					{
+						case 0:
+						{
+							iRepeatAmount = 5;
+
+							break;
+						}
+
+						case 1:
+						case 2:
+						{
+							iRepeatAmount = 4;
+
+							break;
+						}
+
+						case 3:
+						case 4:
+						{
+							iRepeatAmount = 3;
+
+							break;
+						}
+
+						default:
+							iRepeatAmount = 2;
+					}
+
+				for (local iSecondOrder = 0; iSecondOrder < iRepeatAmount; iSecondOrder++)
+					iLuckBox.push(iOrder);
+			}
+
+			SoloPlayerInfo = PotentialSoloers[iLuckBox[RandomInt(0, iLuckBox.len() - 1)]];
+		}
+
+		local strName = SoloPlayerInfo.strName, iPlacement = SoloPlayerInfo.iPlacement;
+
+		PrintStatsText(null, (strName == "" ? "A human" : "Human " + strName) + " has been chosen for the solo ending!\\nCompleted " + SoloPlayerInfo.iCompletedEvents + " events and did " + SoloPlayerInfo.iStage5Damage + " damage on stage 5.\\nResulting in " + SoloPlayerInfo.iTotalPoints + " points." + (iPotentialSoloersLength == 1 ? "" : "\\nPlaced " + iPlacement + GetOrdinalNumberSuffix(iPlacement) + " out of " + PotentialSoloers.len() + "."));
+
+		local hSoloPlayer = SoloPlayerInfo.hPlayer;
+
+		foreach (SavedPlayerInfo in SavedPlayerInfos)
+			if (SavedPlayerInfo.hPlayer == hSoloPlayer)
+			{
+				SavedPlayerInfo.bIsSoloBanned = true;
+
+				break;
+			}
+
+		local hExit = Entities.FindByName(null, "fuckedoffzombies");
+
+		foreach (hPlayer in hPlayers)
+			if (hPlayer.GetHealth())
+			{
+				if (hPlayer.GetTeam() == 3)
+				{
+					if (hPlayer != hSoloPlayer)
+						EntFireByHandle(hPlayer, "SetHealth", "0", -1, null, null);
+				}
+
+				else
+				{
+					hPlayer.SetOrigin(hExit.GetOrigin());
+					hPlayer.SetAngles(0, hExit.GetAngles().y, 0);
+					hPlayer.SetVelocity(Vector());
+				}
+			}
+
+		local hExits = array(0);
+
+		while (hExit = Entities.FindByName(hExit, "last_man_standing_tpdest"))
+			hExits.push(hExit);
+
+		hExit = hExits[RandomInt(0, hExits.len() - 1)];
+
+		hSoloPlayer.SetOrigin(hExit.GetOrigin());
+		hSoloPlayer.SetAngles(0, hExit.GetAngles().y, 0);
+		hSoloPlayer.SetVelocity(Vector());
+	}
+
+	else
+	{
+		PrintStatsText(null, "No valid players were found, no one gets the solo!");
+
+		foreach (hPlayer in hPlayers)
+			if (hPlayer.GetTeam() == 3 && hPlayer.GetHealth())
+				EntFireByHandle(hPlayer, "SetHealth", "0", -1, null, null);
+	}
+}
+
+function SortSoloByTotalPoints(First, Second)
+{
+	local flFirstTotalPoint = First.iTotalPoints, flSecondTotalPoint = Second.iTotalPoints, iReturn = 0;
+
+	if (flFirstTotalPoint > flSecondTotalPoint)
+		iReturn = -1;
+
+	else if (flFirstTotalPoint < flSecondTotalPoint)
+		iReturn = 1;
+
+	return iReturn;
+}
+
+function GetOrdinalNumberSuffix(iNumber)
+{
+	local strSuffix = "th";
+
+	if (iNumber <= 3 || iNumber > 20)
+		switch (iNumber % 10)
+		{
+			case 1:
+			{
+				strSuffix = "st";
+
+				break;
+			}
+
+			case 2:
+			{
+				strSuffix = "nd";
+
+				break;
+			}
+
+			case 3:
+				strSuffix = "rd";
+		}
+
+	return strSuffix;
+}
+
+function GetTakeDamageEntity()
+{
+	return GetEntity(0, "takedamage1");
+}
+
+function GetStatsText()
+{
+	return GetEntity(1, "statstext1");
+}
+
+function GetUserIDEventGenerator()
+{
+	return GetEntity(2, "eventgenerator1");
+}
+
+function GetEntity(iOrder, strName)
+{
+	return hMapEntities[iOrder] ? hMapEntities[iOrder] : hMapEntities[iOrder] = Entities.FindByName(null, "map1" + strName);
+}

--- a/vscripts/lms1main1.nut
+++ b/vscripts/lms1main1.nut
@@ -523,6 +523,8 @@ function PickLastManStanding()
 
 	StopTrackingZombieDamage();
 
+	local hExit = Entities.FindByName(null, "fuckedoffzombies");
+
 	if (iPotentialSoloersLength)
 	{
 		local SoloPlayerInfo = {};
@@ -593,8 +595,6 @@ function PickLastManStanding()
 				break;
 			}
 
-		local hExit = Entities.FindByName(null, "fuckedoffzombies");
-
 		foreach (hPlayer in hPlayers)
 			if (hPlayer.GetHealth())
 			{
@@ -629,8 +629,20 @@ function PickLastManStanding()
 		PrintStatsText(null, "No valid players were found, no one gets the solo!");
 
 		foreach (hPlayer in hPlayers)
-			if (hPlayer.GetTeam() == 3 && hPlayer.GetHealth())
-				EntFireByHandle(hPlayer, "SetHealth", "0", -1, null, null);
+		{
+			if (hPlayer.GetHealth())
+			{
+				if (hPlayer.GetTeam() == 3)
+					EntFireByHandle(hPlayer, "SetHealth", "0", -1, null, null);
+
+				else
+				{
+					hPlayer.SetOrigin(hExit.GetOrigin());
+					hPlayer.SetAngles(0, hExit.GetAngles().y, 0);
+					hPlayer.SetVelocity(Vector());
+				}
+			}
+		}
 	}
 }
 

--- a/vscripts/lms1main1.nut
+++ b/vscripts/lms1main1.nut
@@ -316,6 +316,8 @@ function PlayerInfo(EventData)
 
 function PlayerDisconnect(EventData)
 {
+	RemoveDisconnectPlayer();
+
 	EntFireByHandle(self, "CallScriptFunction", "RemoveDisconnectPlayer", -1, null, null);
 
 	local iUserID = EventData.userid;

--- a/vscripts/lms1main1.nut
+++ b/vscripts/lms1main1.nut
@@ -629,7 +629,6 @@ function PickLastManStanding()
 		PrintStatsText(null, "No valid players were found, no one gets the solo!");
 
 		foreach (hPlayer in hPlayers)
-		{
 			if (hPlayer.GetHealth())
 			{
 				if (hPlayer.GetTeam() == 3)
@@ -642,7 +641,6 @@ function PickLastManStanding()
 					hPlayer.SetVelocity(Vector());
 				}
 			}
-		}
 	}
 }
 

--- a/vscripts/lms1main1.nut
+++ b/vscripts/lms1main1.nut
@@ -114,8 +114,17 @@ function Think()
 
 	if (bDidZombiesSpawnOnStage5)
 		foreach (hPlayer in hPlayers)
-			if (hPlayer.GetTeam() == 2 && hPlayer.GetHealth() > 900  && hPlayer.GetName().find("zombie_") != 0)
-				hPlayer.SetHealth(900);
+			if (hPlayer.GetTeam() == 2)
+			{
+				if (hPlayer.GetName().find("zombie_") == 0)
+				{
+					if (hPlayer.GetHealth() > 1200)
+						hPlayer.SetHealth(1200);
+				}
+
+				else if (hPlayer.GetHealth() > 900)
+					hPlayer.SetHealth(900);
+			}
 
 	return -1;
 }


### PR DESCRIPTION
-Make "Team Win" ending not count zombie events.
-Make stage 2 trigger buttons only unlock when that room is selected to prevent trolling with boost.
-Readd the solo picker, hopefully should work now, has been optimized and the point calculation has been changed to "stage 5 damage" + 150 * "completed events".
-Readd kill credits.
-Remove more missing sounds.
-Don't reduce health of zombie item users in stage 5.
-Fix stage 1 exploding barrels targeting wrong entity.
-Fix exploding the big door on stage 4 not disabling the trigger.
-Kill the sliding door on stage 4 end when "Ultralisk" passes through it.

Solo picker still might not work so map test please