### PR TITLE
Fix item pushes on tenkinoko

### DIFF
--- a/stripper/ze_tenkinoko_welkin_v1_7f.cfg
+++ b/stripper/ze_tenkinoko_welkin_v1_7f.cfg
@@ -1,3 +1,30 @@
+;fix trigger_push spawnflag boosting zombies
+modify:
+{
+	match:
+	{
+		"classname" "trigger_push"
+		"targetname" "item_SunnyDoll_trigger_push"
+	}
+	replace:
+	{
+		"spawnflags" "1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "trigger_push"
+		"targetname" "item_arashi_push"
+	}
+	replace:
+	{
+		"spawnflags" "1"
+	}
+}
+
 ;on laser stage,early disable the push, prevent the zombies to be able to go ahead of the humans
 modify:
 {


### PR DESCRIPTION
Spawnflag bug made items boosting zombies a common occurence on tenkinoko. What was thought to be a "GFL-only" issue turns out to just be dumb source engine jank.