### PR TITLE
Update several configs

### DIFF
--- a/entwatch/ze_slackerino_mapperino_v4.cfg
+++ b/entwatch/ze_slackerino_mapperino_v4.cfg
@@ -21,7 +21,7 @@
     }
     "1"
     {
-        "name"              "Heal"
+        "name"              "Heal Magick"
         "shortname"         "Heal"
         "color"             "{default}"
         "buttonclass"       "func_button"
@@ -40,7 +40,7 @@
     }
     "2"
     {
-        "name"              "Fire"
+        "name"              "Fire Magick"
         "shortname"         "Fire"
         "color"             "{orange}"
         "buttonclass"       "func_button"
@@ -54,12 +54,12 @@
         "hammerid"          "29491"
         "mode"              "2"
         "maxuses"           "0"
-        "cooldown"          "65"
+        "cooldown"          "60"
         "maxamount"         "1"
     }
     "3"
     {
-        "name"              "Electro"
+        "name"              "Electro Magick"
         "shortname"         "Electro"
         "color"             "{olive}"
         "buttonclass"       "func_button"
@@ -73,12 +73,12 @@
         "hammerid"          "29734"
         "mode"              "2"
         "maxuses"           "0"
-        "cooldown"          "65"
+        "cooldown"          "60"
         "maxamount"         "1"
     }
     "4"
     {
-        "name"              "Blizzard"
+        "name"              "Blizzard Magick"
         "shortname"         "Blizzard"
         "color"             "{blue}"
         "buttonclass"       "func_button"
@@ -97,7 +97,7 @@
     }
     "5"
     {
-        "name"              "Gravity"
+        "name"              "Gravity Magick"
         "shortname"         "Gravity"
         "color"             "{purple}"
         "buttonclass"       "func_button"
@@ -116,7 +116,7 @@
     }
     "6"
     {
-        "name"              "Wind"
+        "name"              "Wind Magick"
         "shortname"         "Wind"
         "color"             "{green}"
         "buttonclass"       "func_button"
@@ -154,7 +154,7 @@
     }
     "8"
     {
-        "name"              "Zombie Heal"
+        "name"              "Zombie Heal Magick"
         "shortname"         "ZM Heal"
         "color"             "{default}"
         "buttonclass"       "func_button"
@@ -174,7 +174,7 @@
     }
     "9"
     {
-        "name"              "Zombie Fire"
+        "name"              "Zombie Fire Magick"
         "shortname"         "ZM Fire"
         "color"             "{red}"
         "buttonclass"       "func_button"
@@ -194,7 +194,7 @@
     }
     "10"
     {
-        "name"              "Zombie Gravity"
+        "name"              "Zombie Gravity Magick"
         "shortname"         "ZM Gravity"
         "color"             "{purple}"
         "buttonclass"       "func_button"
@@ -214,7 +214,7 @@
     }
     "11"
     {
-        "name"              "Zombie Warp"
+        "name"              "Zombie Warp Magick"
         "shortname"         "ZM Warp"
         "color"             "{darkred}"
         "buttonclass"       "func_button"

--- a/stripper/ze_2049_v1_1.cfg
+++ b/stripper/ze_2049_v1_1.cfg
@@ -1,8 +1,34 @@
-;block off stage 2 pixel surf
+;-----------------------------
+;Block off stage 2 pixel surf
+;-----------------------------
 add:
 {
 	"classname" "func_brush"
 	"model" "*160"
 	"origin" "6343 -3777.5 -7408"
 	"rendermode" "10"
+}
+
+;-------------------
+;Delay stage 1 nuke
+;-------------------
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "s1_nuke_trigger"
+	}
+	delete:
+	{
+		"OnTrigger" "x_nuke_fadeFade4.81"
+		"OnTrigger" "x_nuke_zm01Enable4.81"
+		"OnTrigger" "global_nuke_sPlaySound4.81"
+	}
+	insert:
+	{
+		"OnTrigger" "x_nuke_fadeFade9.81"
+		"OnTrigger" "x_nuke_zm01Enable9.81"
+		"OnTrigger" "global_nuke_sPlaySound9.81"
+	}
 }

--- a/stripper/ze_offliner_v2_csgo1.cfg
+++ b/stripper/ze_offliner_v2_csgo1.cfg
@@ -1,12 +1,42 @@
+;move shockwave button higher
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"targetname" "shockwave_item_button"
+	}
+	replace:
+	{
+		"origin" "-1090 -3843.1 -380.1"
+	}
+}
+
+;move shockwave particle higher
+modify:
+{
+	match:
+	{
+		"classname" "info_particle_system"
+		"targetname" "shockwave_item_particle_start"
+	}
+	replace:
+	{
+		"origin" "-1088 -3836.63 -445"
+	}
+}
+
 ;remove unpacked sounds
 filter:
 {
 	"hammerid" "120996"
 }
+
 filter:
 {
 	"hammerid" "123922"
 }
+
 filter:
 {
 	"hammerid" "121021"
@@ -20,6 +50,7 @@ add:
 	"model" "*90"
 	"rendermode" "10"
 }
+
 add:
 {
 	"classname" "func_brush"
@@ -42,7 +73,7 @@ modify:
 	}
 }
 
-; Fix sphere particle not starting
+;fix sphere particle not starting
 modify:
 {
 	match:
@@ -56,7 +87,7 @@ modify:
 	}
 }
 
-; Fix attack on boss
+;fix attack on boss
 modify:
 {
 	match:
@@ -70,7 +101,7 @@ modify:
 	}
 }
 
-; Fix crouch lasers
+;fix crouch lasers
 modify:
 {
 	match:
@@ -97,7 +128,7 @@ modify:
 	}
 }
 
-; Fix zombie attack on bossfight
+;fix zombie attack on bossfight
 modify:
 {
 	match:
@@ -107,12 +138,14 @@ modify:
 	}
 	delete:
 	{
+		"OnCase03" "boss_zm_attack_trigger_teleDisable0.01-1"
 		"OnCase03" "boss_zm_attack_end_trigger_teleEnable7.99-1"
 		"OnCase03" "boss_zm_attack_end_trigger_teleDisable8-1"
 	}
 	insert:
 	{
-		"OnCase03" "boss_zm_attack_end_trigger_teleEnable7.98-1"
-		"OnCase03" "boss_zm_attack_end_trigger_teleDisable8.02-1"
+		"OnCase03" "boss_zm_attack_trigger_teleDisable0.05-1"
+		"OnCase03" "boss_zm_attack_end_trigger_teleEnable8-1"
+		"OnCase03" "boss_zm_attack_end_trigger_teleDisable8.05-1"
 	}
 }

--- a/stripper/ze_slackerino_mapperino_v4.cfg
+++ b/stripper/ze_slackerino_mapperino_v4.cfg
@@ -1,10 +1,27 @@
-;OPTIONAL: change lyrics to chinese
+;STRIPPER BY KOEN (STEAM_0:1:114921174) & CONSOLE (STEAM_0:1:107271710)
+
+;ADD STRIPPER VERSION TEXT
+;CURRENT VERSION: #5
+modify:
+{
+	match:
+	{
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "cmdCommandsay ** STRIPPER VERSION 5 **10-1"
+	}
+}
+
+;OPTIONAL: TOGGLE CHINESE LYRICS
 ;modify:
 ;{
 ;	match:
 ;	{
 ;		"classname" "logic_case"
 ;		"targetname" "Levels_Case"
+;		"hammerid" "1788136"
 ;	}
 ;	insert:
 ;	{
@@ -13,13 +30,14 @@
 ;	}
 ;}
 
-;OPTIONAL: change lyrics to display via hint text
+;OPTIONAL: DISPLAY LYRICS VIA HINT TEXT
 modify:
 {
 	match:
 	{
 		"classname" "logic_case"
 		"targetname" "Levels_Case"
+		"hammerid" "1788136"
 	}
 	insert:
 	{
@@ -29,76 +47,73 @@ modify:
 	}
 }
 
-;add freezetime to allow players to buy weapons
+;ADD FREEZETIME FOR PURCHASING WEAPONS
 modify:
 {
 	match:
 	{
-		"classname" "point_servercommand"
-		"targetname" "cmd"
+		"classname" "logic_auto"
+	}
+	insert:
+	{
+		"OnMapSpawn" "cmdCommandmp_freezetime 50-1"
+	}
+}
+
+;DECREASE FIRE & ELECTRO CD FOR BALANCING
+;MAKE SURE YOU UPDATE ENTWATCH CONFIG
+modify:
+{
+	match:
+	{
+		"classname" "logic_relay"
+		"targetname" "Item_Relay_Electro"
+		"hammerid" "29732"
 	}
 	delete:
 	{
-		"OnUser1" "!selfCommandmp_freezetime 101"
+		"OnTrigger" "Item_Electro_ButtonUnlock65-1"
+		"OnTrigger" "Weapon_Electro_EffectStart65-1"
 	}
 	insert:
 	{
-		"OnUser1" "!selfCommandmp_freezetime 501"
+		"OnTrigger" "Item_Electro_ButtonUnlock60-1"
+		"OnTrigger" "Weapon_Electro_EffectStart60-1"
 	}
 }
 
-;stage 1 boss room make zm cage not make noise when knifed
 modify:
 {
 	match:
 	{
-		"classname" "func_breakable"
-		"targetname" "Hashmel_ZM_Cage"
+		"classname" "logic_relay"
+		"targetname" "Item_Relay_Fire"
+		"hammerid" "29724"
 	}
-	replace:
+	delete:
 	{
-		"spawnflags" "1"
-	}
-}
-
-;toggle lightning at stage 2 lasers
-modify:
-{
-	match:
-	{
-		"classname" "trigger_once"
-		"targetname" "Stage_4_End_Guard_Trigger"
+		"OnTrigger" "Item_Fire_ButtonUnlock65-1"
+		"OnTrigger" "Weapon_Fire_EffectStart65-1"
 	}
 	insert:
 	{
-		"OnTrigger" "Stage_34_3D_Sky_TimerDisable0-1"
+		"OnTrigger" "Item_Fire_ButtonUnlock60-1"
+		"OnTrigger" "Weapon_Fire_EffectStart60-1"
 	}
 }
 
+;FIX ITEM BUTTONS NOT ROTATING PROPERLY WITH PLAYERS
 modify:
 {
 	match:
 	{
-		"classname" "math_counter"
-		"targetname" "Stage_4_End_Guard_Counter"
-	}
-	insert:
-	{
-		"OnHitMin" "Stage_34_3D_Sky_TimerEnable0-1"
-	}
-}
-
-;fix guardian physboxes with motion enabled
-modify:
-{
-	match:
-	{
-		"classname" "func_physbox"
-		"targetname" "Famfrit_Phys_Body_Holy"
+		"classname" "func_button"
+		"targetname" "/Item_(PotionHP|Heal|Fire|Electro|Blizzard|Darkaga|Wind|Berserk)_Button/"
+		"spawnflags" "17408"
 	}
 	replace:
 	{
-		"spawnflags" "56320"
+		"spawnflags" "1024"
 	}
 }
 
@@ -106,12 +121,13 @@ modify:
 {
 	match:
 	{
-		"classname" "func_physbox"
-		"targetname" "Famfrit_Phys_Body_Fire"
+		"classname" "func_button"
+		"targetname" "/Item_Z_(Heal|Fire|Darkaga|Warp)_Button/"
+		"spawnflags" "17408"
 	}
 	replace:
 	{
-		"spawnflags" "56320"
+		"spawnflags" "1024"
 	}
 }
 
@@ -134,6 +150,7 @@ add:
 	"damage" "200"
 	"nodamageforce" "0"
 }
+
 add:
 {
 	"classname" "trigger_hurt"
@@ -148,6 +165,7 @@ add:
 	"damage" "200"
 	"nodamageforce" "0"
 }
+
 add:
 {
 	"classname" "trigger_hurt"
@@ -162,12 +180,14 @@ add:
 	"damage" "200"
 	"nodamageforce" "0"
 }
+
 modify:
 {
 	match:
 	{
 		"classname" "logic_case"
 		"targetname" "Hashmel_Tower_Case"
+		"hammerid" "3269685"
 	}
 	delete:
 	{
@@ -200,6 +220,7 @@ modify:
 	{
 		"classname" "trigger_multiple"
 		"targetname" "Hashmel_Attacks_HP_Add"
+		"hammerid" "3308075"
 	}
 	delete:
 	{
@@ -224,10 +245,26 @@ modify:
 	{
 		"classname" "logic_timer"
 		"targetname" "Hashmel_Attack_Tower_Timer"
+		"hammerid" "3790057"
 	}
 	replace:
 	{
 		"RefireTime" "45"
+	}
+}
+
+;MAKE BOSS ROOM ZM CAGE NOT MAKE SOUND WHEN KNIFED
+modify:
+{
+	match:
+	{
+		"classname" "func_breakable"
+		"targetname" "Hashmel_ZM_Cage"
+		"hammerid" "28230"
+	}
+	replace:
+	{
+		"spawnflags" "1"
 	}
 }
 
@@ -243,30 +280,35 @@ modify:
 	{
 		"classname" "func_movelinear"
 		"targetname" "Famfrit_Overflow_WaterSurface"
+		"hammerid" "4742233"
 	}
 	delete:
 	{
 		"OnFullyClosed" "cmdCommandsv_airacceleration 120-1"
 	}
 }
+
 modify:
 {
 	match:
 	{
 		"classname" "logic_relay"
 		"targetname" "Famfrit_Overflow_Relay"
+		"hammerid" "4702588"
 	}
 	delete:
 	{
 		"OnSpawn" "cmdCommandsv_airaccelerate 1500-1"
 	}
 }
+
 modify:
 {
 	match:
 	{
 		"classname" "logic_relay"
 		"targetname" "Famfrit_Start_Relay"
+		"hammerid" "31957"
 	}
 	insert:
 	{
@@ -282,6 +324,7 @@ modify:
 	{
 		"classname" "logic_timer"
 		"targetname" "Famfrit_Overflow_Timer"
+		"hammerid" "3233182"
 	}
 	replace:
 	{
@@ -294,18 +337,109 @@ modify:
 	}
 }
 
-;TEMPORARY CHANGE: INCREASE SECRET MUSIC TRIGGER HP FROM 10 TO 150
+;INCREASE SECRET MUSIC TRIGGER HP
 modify:
 {
 	match:
 	{
 		"classname" "func_breakable"
 		"targetname" "Stage_4_Secret_Breakable"
+		"hammerid" "4142064"
 	}
 	replace:
 	{
-		"health" "150"
+		"health" "1500"
 	}
+}
+
+;FIX GUARDIAN PHYSBOXES WITH MOTION ENABLED
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox"
+		"targetname" "Famfrit_Phys_Body_Holy"
+		"hammerid" "34197"
+	}
+	replace:
+	{
+		"spawnflags" "56320"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "func_physbox"
+		"targetname" "Famfrit_Phys_Body_Fire"
+		"hammerid" "34194"
+	}
+	replace:
+	{
+		"spawnflags" "56320"
+	}
+}
+
+;TOGGLE LIGHTNING DURING LASERS
+modify:
+{
+	match:
+	{
+		"classname" "trigger_once"
+		"targetname" "Stage_4_End_Guard_Trigger"
+		"hammerid" "34257"
+	}
+	insert:
+	{
+		"OnTrigger" "Stage_34_3D_Sky_TimerDisable0-1"
+	}
+}
+
+modify:
+{
+	match:
+	{
+		"classname" "math_counter"
+		"targetname" "Stage_4_End_Guard_Counter"
+		"hammerid" "34212"
+	}
+	insert:
+	{
+		"OnHitMin" "Stage_34_3D_Sky_TimerEnable0-1"
+	}
+}
+
+;CLEANUP OLD ENTITIES ON FAMFRIT BOSS FIGHT THAT RESETS ZOMBIE ITEM USER TARGETNAMES
+filter:
+{
+	"targetname" "/boss_spec_filter.*/"
+	"classname" "filter_activator_name"
+}
+
+filter:
+{
+	"classname" "logic_relay"
+	"targetname" "filter_spec_trigger"
+}
+
+filter:
+{
+	"classname" "trigger_multiple"
+	"targetname" "boss_spec_trigger"
+}
+
+;DISABLE CUTSCENE IF ZOMBIES ENTER BOSS ROOM
+add:
+{
+	"classname" "trigger_once"
+	"targetname" "Stage_24_Zombie_Check"
+	"origin" "-5616 9564 3184"
+	"model" "*171"
+	"filtername" "Zombies_Filter"
+	"spawnflags" "1"
+	"OnStartTouch" "Stage_4_Boss_CutsceneDisable01"
+	"OnStartTouch" "cmdCommandsay ** ZOMBIES DETECTED! KILL THEM BEFORE FAMFRIT STARTS ATTACKING! **01"
 }
 
 ;--------------------------------------------
@@ -319,13 +453,14 @@ modify:
 	{
 		"classname" "logic_case"
 		"targetname" "Levels_Case"
+		"hammerid" "1788136"
 	}
 	insert:
 	{
 		"OnCase04" "cmdCommandsv_enablebunnyhopping 11-1"
-		"OnCase04" "cmdCommandsv_airaccelerate 1001.1-1"
 	}
 }
+
 modify:
 {
 	match:
@@ -346,6 +481,7 @@ modify:
 	{
 		"classname" "trigger_hurt"
 		"targetname" "Stage_Race_CP_7_Bonus"
+		"hammerid" "4179319"
 	}
 	delete:
 	{
@@ -353,12 +489,14 @@ modify:
 		"OnStartTouch" "Level_StockerFireUser101"
 	}
 }
+
 modify:
 {
 	match:
 	{
 		"classname" "logic_case"
-		"targetname" "Levels_Case"
+		"targetname" "Levels_case"
+		"hammerid" "1788136"
 	}
 	delete:
 	{
@@ -367,5 +505,20 @@ modify:
 	insert:
 	{
 		"OnCase04" "Level_StockerAddOutputOnUser1 Levels_Counter:SetValue:3:0:10.021"
+	}
+}
+
+;DISABLE BOSS ROOM ZOMBIE CHECK DURING RACE MODE
+modify:
+{
+	match:
+	{
+		"classname" "logic_case"
+		"targetname" "Levels_case"
+		"hammerid" "1788136"
+	}
+	insert:
+	{
+		"OnCase04" "Stage_24_Zombie_CheckKill01"
 	}
 }

--- a/stripper/ze_tenkinoko_welkin_v1_7f.cfg
+++ b/stripper/ze_tenkinoko_welkin_v1_7f.cfg
@@ -1,4 +1,18 @@
-;fix trigger_push spawnflag boosting zombies
+;FIX ITEM BUTTONS NOT ROTATING PROPERLY WITH PLAYER
+modify:
+{
+	match:
+	{
+		"classname" "func_button"
+		"spawnflags" "19457"
+	}
+	replace:
+	{
+		"spawnflags" "3073"
+	}
+}
+
+;FIX TRIGGER_PUSH SPAWNFLAG PUSHING ZOMBIES
 modify:
 {
 	match:
@@ -25,7 +39,7 @@ modify:
 	}
 }
 
-;on laser stage,early disable the push, prevent the zombies to be able to go ahead of the humans
+;DISABLE ENDING PUSH ON WEATHERAGE TO PREVENT ZOMBIES GETTING AHEAD
 modify:
 {
 	match:
@@ -39,7 +53,7 @@ modify:
 	}
 }
 
-;Make Frozen Tomb activation button less frustrating to press
+;MAKE FROZEN TOMB BUTTON EASIER TO PRESS
 modify:
 {
 	match:
@@ -53,7 +67,7 @@ modify:
 	}
 }
 
-;Remove map's own entwatch display, as it shows no new information compared to server's default entwatch (and causes game_text flickering)
+;REMOVE BUILT-IN ENTWATCH DISPLAY
 filter:
 {
 	"classname" "game_text"


### PR DESCRIPTION
Since events on csgo are still occurring regularly, and that some maps are still getting ported to CS2, I figured I should update some existing configs in the repo.

entwatch/slackerino mapperino
-> Updated item names and cooldowns to reflect stripper change

stripper/2049
-> Delayed stage 1 nuke by 5 seconds to give slower players a chance to catch up

stripper/offliner
-> Fixed shockwave item being too low
-> Fixed shockwave item particle being too low in the floor
-> Fixed zombie attack teleport not teleporting all zombies properly

stripper/slackerino
-> Various balancing changes to the map
-> Fix item buttons not rotating properly with players

stripper/tenkinoko
-> Fix item buttons not rotating properly with players